### PR TITLE
Make ReBAC FactSource-backed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@
 ### Added
 
 - Batch authorization APIs for evaluating or filtering caller-owned resource/context pairs while preserving input order and duplicate resources. (#17)
-- `FactKey`, `FactLoadResult`, `FactLoadError`, `FactSource`, `RelationshipQuery`, and `LookupSource` as the new fact-loading layer for ReBAC and future fact-backed policies.
+- `FactKey`, `FactLoadResult`, `FactLoadError`, `FactSource`, and `RelationshipQuery` as the new fact-loading layer for ReBAC and future fact-backed policies.
 - Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
+- `EvaluationSession::builder()` for declaring all request-scoped fact sources in one place.
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
 - PostgreSQL 18 bulk ReBAC example demonstrating an in-memory public-post policy composed with SQL-backed relationship facts, ordered `unnest ... WITH ORDINALITY` loading, and point-vs-bulk behavior.
 - Axum example bulk invoice listing endpoint demonstrating app-state fact sources and request-scoped `EvaluationSession` registration.
+- In-RAM ReBAC example and Criterion benchmarks for shared in-process `FactSource` usage and session overhead.
 
 ### Changed
 
 - `AndPolicy`, `OrPolicy`, `NotPolicy`, boxed `dyn Policy`, and `RebacPolicy` now preserve batching through their batch evaluation paths.
+- `EvaluationSession::register` and `register_arc` now fail fast on duplicate fact-source registration; use `replace` or `replace_arc` when overwriting is intentional.
 - Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy pending/grant/deny counts for batch evaluation.
 - README and rustdocs now frame Gatehouse as an in-process authorization engine with request-scoped fact loading, and document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
 - README and rustdocs now document batch tracing fields and the typed-relation-to-backend-storage boundary for SQL-backed ReBAC sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
 - PostgreSQL 18 bulk ReBAC example demonstrating an in-memory public-post policy composed with SQL-backed relationship facts, ordered `unnest ... WITH ORDINALITY` loading, and point-vs-bulk behavior.
+- Axum example bulk invoice listing endpoint demonstrating app-state fact sources and request-scoped `EvaluationSession` registration.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **FactSource-backed ReBAC**: `RelationshipResolver` has been removed. `RebacPolicy` now extracts subject/resource IDs, builds `RelationshipQuery` keys, and loads relationship facts through a request-scoped `EvaluationSession` registered with a `FactSource`. (#20)
 - **Session-aware policy API**: `Policy::evaluate_access(...)` has been replaced by `Policy::evaluate(&EvalCtx)` and `Policy::evaluate_batch(&BatchEvalCtx)`. `PermissionChecker` evaluation now takes an explicit `EvaluationSession`; RBAC/ABAC-only callers can use `EvaluationSession::empty()`.
 - **Borrowed policy type names**: `Policy::policy_type` now returns `&str` instead of allocating a `String`.
+- **Sync policy inputs**: `Policy` and `PermissionChecker` now require `Subject`, `Resource`, `Action`, and `Context` to be `Sync` so batch contexts can borrow them across async evaluation.
 
 ### Added
 
@@ -14,6 +15,9 @@
 - `FactKey`, `FactLoadResult`, `FactLoadError`, `FactSource`, and `RelationshipQuery` as the new fact-loading layer for ReBAC and future fact-backed policies.
 - Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
 - `EvaluationSession::builder()` for declaring all request-scoped fact sources in one place.
+- `EvaluationSession::shared_empty()` for hot RBAC/ABAC-only paths that should not allocate a fresh empty session per call.
+- `DelegatingPolicy` for cross-domain authorization delegation through a child `PermissionChecker` while preserving child batch evaluation and trace output.
+- `PermissionChecker::evaluate_batch_resources_in_session` and `filter_authorized_resources_in_session` for resource-only batches with unit context.
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
 - PostgreSQL 18 bulk ReBAC example demonstrating an in-memory public-post policy composed with SQL-backed relationship facts, ordered `unnest ... WITH ORDINALITY` loading, and point-vs-bulk behavior.
 - Axum example bulk invoice listing endpoint demonstrating app-state fact sources and request-scoped `EvaluationSession` registration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
 - `FactKey`, `FactLoadResult`, `FactLoadError`, `FactSource`, `RelationshipQuery`, and `LookupSource` as the new fact-loading layer for ReBAC and future fact-backed policies.
 - Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
-- PostgreSQL 18 bulk ReBAC example demonstrating ordered `unnest ... WITH ORDINALITY` loading and point-vs-bulk behavior.
+- PostgreSQL 18 bulk ReBAC example demonstrating an in-memory public-post policy composed with SQL-backed relationship facts, ordered `unnest ... WITH ORDINALITY` loading, and point-vs-bulk behavior.
 
 ### Changed
 
 - `AndPolicy`, `OrPolicy`, `NotPolicy`, boxed `dyn Policy`, and `RebacPolicy` now preserve batching through their batch evaluation paths.
 - Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy pending/grant/deny counts for batch evaluation.
-- README and rustdocs now document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
+- README and rustdocs now frame Gatehouse as an in-process authorization engine with request-scoped fact loading, and document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.3.0] - 2026-05-18
+
+### Breaking
+
+- **FactSource-backed ReBAC**: `RelationshipResolver` has been removed. `RebacPolicy` now extracts subject/resource IDs, builds `RelationshipQuery` keys, and loads relationship facts through a request-scoped `EvaluationSession` registered with a `FactSource`. (#20)
+- **Session-aware policy API**: `Policy::evaluate_access(...)` has been replaced by `Policy::evaluate(&EvalCtx)` and `Policy::evaluate_batch(&BatchEvalCtx)`. `PermissionChecker` evaluation now takes an explicit `EvaluationSession`; RBAC/ABAC-only callers can use `EvaluationSession::empty()`.
+- **Borrowed policy type names**: `Policy::policy_type` now returns `&str` instead of allocating a `String`.
+
+### Added
+
+- Batch authorization APIs for evaluating or filtering caller-owned resource/context pairs while preserving input order and duplicate resources. (#17)
+- `FactKey`, `FactLoadResult`, `FactLoadError`, `FactSource`, `RelationshipQuery`, and `LookupSource` as the new fact-loading layer for ReBAC and future fact-backed policies.
+- Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
+- `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
+- PostgreSQL 18 bulk ReBAC example demonstrating ordered `unnest ... WITH ORDINALITY` loading and point-vs-bulk behavior.
+
+### Changed
+
+- `AndPolicy`, `OrPolicy`, `NotPolicy`, boxed `dyn Policy`, and `RebacPolicy` now preserve batching through their batch evaluation paths.
+- Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy pending/grant/deny counts for batch evaluation.
+- README and rustdocs now document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
+
+### Fixed
+
+- Fact sources that return the wrong number of results now fail closed with `FactLoadError::SourceContractViolation` instead of panicking or producing partial results.
+- Cancelled or panicking leader tasks for in-flight fact loads now wake waiters with `FactLoadError::LoaderCancelled` instead of leaving them pending forever.
+- SQL-backed example fact sources now map backend errors to fail-closed `FactLoadResult::Error` values instead of panicking.
+
 ## [0.2.0] - 2026-02-17
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Request-scoped fact caching, duplicate-key expansion, source-level chunking via `FactSource::max_batch_size`, and in-flight load coalescing.
 - `EvaluationSession::builder()` for declaring all request-scoped fact sources in one place.
 - `EvaluationSession::shared_empty()` for hot RBAC/ABAC-only paths that should not allocate a fresh empty session per call.
+- `EvaluationSession::try_register`, `try_register_arc`, `try_replace`, and `try_replace_arc` for non-panicking fact-source setup.
 - `DelegatingPolicy` for cross-domain authorization delegation through a child `PermissionChecker` while preserving child batch evaluation and trace output.
 - `PermissionChecker::evaluate_batch_resources_in_session` and `filter_authorized_resources_in_session` for resource-only batches with unit context.
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
@@ -26,8 +27,8 @@
 ### Changed
 
 - `AndPolicy`, `OrPolicy`, `NotPolicy`, boxed `dyn Policy`, and `RebacPolicy` now preserve batching through their batch evaluation paths.
-- `EvaluationSession::register` and `register_arc` now fail fast on duplicate fact-source registration; use `replace` or `replace_arc` when overwriting is intentional.
-- Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy pending/grant/deny counts for batch evaluation.
+- `EvaluationSession::register` and `register_arc` now fail fast on duplicate fact-source registration; use `replace` or `replace_arc` when overwriting is intentional, or the `try_*` variants when setup should return errors instead.
+- Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy chunk pending/grant/deny counts for batch evaluation.
 - README and rustdocs now frame Gatehouse as an in-process authorization engine with request-scoped fact loading, and document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
 - README and rustdocs now document batch tracing fields and the typed-relation-to-backend-storage boundary for SQL-backed ReBAC sources.
 
@@ -35,6 +36,7 @@
 
 - Fact sources that return the wrong number of results now fail closed with `FactLoadError::SourceContractViolation` instead of panicking or producing partial results.
 - Cancelled or panicking leader tasks for in-flight fact loads now wake waiters with `FactLoadError::LoaderCancelled` instead of leaving them pending forever.
+- Source replacement now checks in-flight loads, installs the new source, and clears cached facts while holding the same session registry lock, so readers cannot observe old cached facts after a replacement is installed.
 - SQL-backed example fact sources now map backend errors to fail-closed `FactLoadResult::Error` values instead of panicking.
 
 ## [0.2.0] - 2026-02-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - `PermissionChecker::with_max_batch_size` as a defensive cap for policy batch calls.
 - PostgreSQL 18 bulk ReBAC example demonstrating an in-memory public-post policy composed with SQL-backed relationship facts, ordered `unnest ... WITH ORDINALITY` loading, and point-vs-bulk behavior.
 - Axum example bulk invoice listing endpoint demonstrating app-state fact sources and request-scoped `EvaluationSession` registration.
-- In-RAM ReBAC example and Criterion benchmarks for shared in-process `FactSource` usage and session overhead.
+- In-RAM ReBAC example and Criterion benchmarks for shared in-process `FactSource` usage, session overhead, latency-injected batching, and in-flight coalescing.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `AndPolicy`, `OrPolicy`, `NotPolicy`, boxed `dyn Policy`, and `RebacPolicy` now preserve batching through their batch evaluation paths.
 - Evaluation tracing now records single-item outcome fields, batch item/grant/deny counts, and per-policy pending/grant/deny counts for batch evaluation.
 - README and rustdocs now frame Gatehouse as an in-process authorization engine with request-scoped fact loading, and document decision semantics, short-circuit trace behavior, batch authorization, fact-backed ReBAC, and telemetry fields.
+- README and rustdocs now document batch tracing fields and the typed-relation-to-backend-storage boundary for SQL-backed ReBAC sources.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -339,6 +339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +373,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -403,6 +418,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -457,6 +483,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +519,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -571,6 +618,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,8 +673,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -655,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -725,6 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -740,6 +825,7 @@ dependencies = [
  "criterion",
  "hyper",
  "tokio",
+ "tokio-postgres",
  "tokio-test",
  "tower",
  "tracing",
@@ -777,6 +863,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -833,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +983,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1099,9 +1204,18 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "litemap"
@@ -1148,6 +1262,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1301,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1194,6 +1318,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1248,6 +1390,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1452,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]
@@ -1358,7 +1549,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1368,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1379,6 +1581,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1559,8 +1767,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1584,6 +1803,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1622,6 +1847,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "syn"
@@ -1703,6 +1939,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1979,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2 0.6.2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1827,15 +2104,36 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1902,6 +2200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +2224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2006,6 +2322,19 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "futures-channel",
  "hyper",
  "proptest",
+ "serde",
  "tokio",
  "tokio-postgres",
  "tokio-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,12 +817,13 @@ dependencies = [
 
 [[package]]
 name = "gatehouse"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "async-trait",
  "axum",
  "criterion",
+ "futures-channel",
  "hyper",
  "tokio",
  "tokio-postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1218,6 +1219,12 @@ name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1871,6 +1878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2002,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2201,6 +2226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +858,7 @@ dependencies = [
  "async-trait",
  "axum",
  "criterion",
+ "dashmap",
  "futures-channel",
  "hyper",
  "proptest",
@@ -922,6 +937,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1377,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +846,7 @@ dependencies = [
  "criterion",
  "futures-channel",
  "hyper",
+ "proptest",
  "tokio",
  "tokio-postgres",
  "tokio-test",
@@ -1219,6 +1241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1557,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1641,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -1663,10 +1725,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1886,6 +1973,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2110,6 +2210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2289,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hyper = "1"
 actix-web = "4"
 criterion = { version = "0.8" }
 proptest = "1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [[bench]]
 name = "permission_checker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tower = "0.5"
 hyper = "1"
 actix-web = "4"
 criterion = { version = "0.8" }
+dashmap = "6"
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tower = "0.5"
 hyper = "1"
 actix-web = "4"
 criterion = { version = "0.8" }
+proptest = "1"
 
 [[bench]]
 name = "permission_checker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1"
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 tokio-test = "0.4"
+tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
 axum = "0.8"
 tower = "0.5"
 hyper = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehouse"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thepartly/gatehouse"
@@ -10,6 +10,7 @@ description = "A flexible authorization library that combines role-based (RBAC),
 tracing = "0.1"
 uuid = {version="1", features = ["serde", "v4"]}
 async-trait = "0.1"
+futures-channel = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thepartly/gatehouse"
-description = "A flexible authorization library that combines role-based (RBAC), attribute-based (ABAC), and relationship-based (ReBAC) access control policies."
+description = "An in-process authorization engine for Rust with composable policies and request-scoped fact loading."
 
 [dependencies]
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hyper = "1"
 actix-web = "4"
 criterion = { version = "0.8" }
 proptest = "1"
+serde = { version = "1", features = ["derive"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [[bench]]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,182 @@
+# Migrating from 0.2 to 0.3
+
+Gatehouse 0.3 is a breaking release. The main shift is that relationship data is now loaded through request-scoped `EvaluationSession` instances and typed `FactSource`s instead of policy-owned `RelationshipResolver`s.
+
+## Policy Implementations
+
+The `Policy` trait now receives an evaluation context rather than separate arguments, and `policy_type` returns `&str`.
+
+```rust
+// 0.2
+#[async_trait]
+impl Policy<User, Document, Read, RequestContext> for OwnerPolicy {
+    async fn evaluate_access(
+        &self,
+        user: &User,
+        _action: &Read,
+        document: &Document,
+        _context: &RequestContext,
+    ) -> PolicyEvalResult {
+        if user.id == document.owner_id {
+            PolicyEvalResult::Granted {
+                policy_type: "OwnerPolicy".to_string(),
+                reason: Some("owner".to_string()),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: "OwnerPolicy".to_string(),
+                reason: "not owner".to_string(),
+            }
+        }
+    }
+
+    fn policy_type(&self) -> String {
+        "OwnerPolicy".to_string()
+    }
+}
+
+// 0.3
+#[async_trait]
+impl Policy<User, Document, Read, RequestContext> for OwnerPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, User, Document, Read, RequestContext>,
+    ) -> PolicyEvalResult {
+        if ctx.subject.id == ctx.resource.owner_id {
+            PolicyEvalResult::Granted {
+                policy_type: "OwnerPolicy".to_string(),
+                reason: Some("owner".to_string()),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: "OwnerPolicy".to_string(),
+                reason: "not owner".to_string(),
+            }
+        }
+    }
+
+    fn policy_type(&self) -> &str {
+        "OwnerPolicy"
+    }
+}
+```
+
+For dynamic policy names, store the name in the policy and return a borrowed string:
+
+```rust
+struct NamedPolicy {
+    name: Box<str>,
+}
+
+impl NamedPolicy {
+    fn new(name: impl Into<Box<str>>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+#[async_trait]
+impl Policy<User, Document, Read, RequestContext> for NamedPolicy {
+    async fn evaluate(
+        &self,
+        _ctx: &EvalCtx<'_, User, Document, Read, RequestContext>,
+    ) -> PolicyEvalResult {
+        PolicyEvalResult::Denied {
+            policy_type: self.policy_type().to_string(),
+            reason: "not implemented".to_string(),
+        }
+    }
+
+    fn policy_type(&self) -> &str {
+        self.name.as_ref()
+    }
+}
+```
+
+## Checker Calls
+
+All checker evaluation now takes an explicit session. For RBAC/ABAC-only paths, use `EvaluationSession::empty()` or `EvaluationSession::shared_empty()`.
+
+```rust
+// 0.2
+let decision = checker
+    .evaluate_access(&user, &Read, &document, &request_context)
+    .await;
+
+// 0.3
+let session = EvaluationSession::empty();
+let decision = checker
+    .evaluate_in_session(&session, &user, &Read, &document, &request_context)
+    .await;
+```
+
+Use `EvaluationSession::shared_empty()` only when no fact-backed policies are expected. It is a process-wide empty session and rejects source registration.
+
+## ReBAC
+
+`RelationshipResolver` has been removed. Use `RelationshipQuery` as the fact key, implement `FactSource`, and register the source in the request session.
+
+```rust
+// 0.2
+let policy = RebacPolicy::new(
+    resolver,
+    |user: &User| user.id,
+    |document: &Document| document.id,
+    "viewer".to_string(),
+);
+checker.add_policy(policy);
+
+// 0.3
+#[async_trait]
+impl FactSource<RelationshipQuery<Uuid, Uuid, Relation>> for RelationshipStore {
+    async fn load_many(
+        &self,
+        keys: &[RelationshipQuery<Uuid, Uuid, Relation>],
+    ) -> Vec<FactLoadResult<bool>> {
+        // Load all keys in one backend call and return one result per key.
+        todo!()
+    }
+}
+
+let relationships: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, Relation>>> =
+    Arc::new(RelationshipStore::new(pool));
+let session = EvaluationSession::builder()
+    .with_arc::<RelationshipQuery<Uuid, Uuid, Relation>>(Arc::clone(&relationships))
+    .build();
+
+checker.add_policy(RebacPolicy::new(
+    |user: &User| user.id,
+    |document: &Document| document.id,
+    Relation::Viewer,
+));
+
+let decision = checker
+    .evaluate_in_session(&session, &user, &Read, &document, &request_context)
+    .await;
+```
+
+`FactSource::load_many` receives unique keys and must return exactly one result per key in the same order. Missing sources, backend errors, wrong result counts, and cancelled leader loads fail closed.
+
+## Batch List Endpoints
+
+Use the batch helpers for list endpoints instead of looping manually:
+
+```rust
+let visible = checker
+    .filter_authorized_with_context_in_session_by(
+        &session,
+        &user,
+        &Read,
+        documents,
+        &request_context,
+        |document| document,
+    )
+    .await;
+```
+
+`PermissionChecker` still evaluates policies in order with `OR` semantics. Policies such as `RebacPolicy` can collapse backend work inside `Policy::evaluate_batch`.
+
+## Session Setup and Cancellation
+
+Prefer `EvaluationSession::builder()` so all request-scoped fact sources are declared together. `register` and `register_arc` still panic on duplicate source registration; use `try_register` or `try_register_arc` if setup should return an error. Use `replace`, `replace_arc`, `try_replace`, or `try_replace_arc` only when overwriting a source is intentional.
+
+If a leader task for an in-flight fact load is cancelled or panics, the session caches `FactLoadError::LoaderCancelled` for the affected keys. This poisons those keys for the rest of that request-scoped session so authorization fails closed and waiters do not hang. Retry with a fresh session.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ let visible_posts = checker
 
 The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_in_session`.
 
+If the item itself is the resource and the context type is `()`, use `evaluate_batch_resources_in_session` or `filter_authorized_resources_in_session`.
+
 Policies can override `Policy::evaluate_batch` to collapse backend work. `RebacPolicy` builds `RelationshipQuery` fact keys and loads them through the request-scoped `EvaluationSession`, so deduplication, chunking, caching, and fail-closed source errors live in one `FactSource` layer. Combinator policies (`AndPolicy`, `OrPolicy`, and `NotPolicy`) preserve batching for their inner policies.
 
 `PermissionChecker::with_max_batch_size` caps the number of still-pending items passed to each policy batch call. Fact-backed policies can also set `FactSource::max_batch_size`, which caps source-level loads after session deduplication.
@@ -185,6 +187,10 @@ let session = EvaluationSession::builder()
 ```
 
 `register` and `register_arc` fail fast if the same fact key type is registered twice. Use `replace` or `replace_arc` only when overwriting a source is intentional.
+
+For hot RBAC/ABAC-only paths, `EvaluationSession::shared_empty()` returns a process-wide empty session and avoids per-call allocation. Only use it when no fact-backed policies are expected; it rejects source registration.
+
+The source registry is keyed by the exact Rust fact key type. If two backends serve the same logical key shape, define distinct key/newtype wrappers rather than registering both under one `RelationshipQuery<...>` type.
 
 #### Cache Lifetime And Revocation
 
@@ -218,6 +224,7 @@ let custom_policy = PolicyBuilder::<MySubject, MyResource, MyAction, MyContext>:
 - `RbacPolicy`: Role-based access control. Grants when at least one required role for `(resource, action)` is present in the subject's roles.
 - `AbacPolicy`: Attribute-based access control. Grants when its boolean condition closure returns `true`.
 - `RebacPolicy`: Relationship-based access control. Extracts flat subject/resource IDs, builds `RelationshipQuery` keys, and grants when the request-scoped `EvaluationSession` loads `Found(true)` from a registered `FactSource`.
+- `DelegatingPolicy`: Delegates a decision to another `PermissionChecker` after mapping parent-domain inputs into child-domain inputs. Batch delegation preserves the child checker's batch path and trace.
 
 Fact-backed ReBAC failures fail closed: missing sources, missing facts, source errors, and source contract violations produce denied decisions rather than panics or accidental grants.
 
@@ -226,6 +233,7 @@ Fact-backed ReBAC failures fail closed: missing sources, missing facts, source e
 - `AndPolicy`: Grants access only if all inner policies allow access. Must be created with at least one policy.
 - `OrPolicy`: Grants access if any inner policy allows access. Must be created with at least one policy.
 - `NotPolicy`: Inverts the decision of an inner policy.
+- `DelegatingPolicy`: Cross-domain delegation through another checker, useful when one resource's access depends on another authorization domain.
 
 ## Tracing And Telemetry
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ let visible_posts = checker
 
 The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_access`.
 
-Policies can override `Policy::evaluate_access_batch` to collapse backend work. `RebacPolicy` forwards batch checks to `RelationshipResolver::has_relationship_batch`, whose default implementation loops over `has_relationship`; SQL or graph-backed resolvers can override it with one set-oriented lookup.
+Policies can override `Policy::evaluate_access_batch` to collapse backend work. `RebacPolicy` forwards batch checks to `RelationshipResolver::has_relationship_batch`, whose default implementation loops over `has_relationship`; SQL or graph-backed resolvers can override it with one set-oriented lookup. Combinator policies (`AndPolicy`, `OrPolicy`, and `NotPolicy`) preserve batching for their inner policies.
+
+If a backend needs smaller requests, configure a chunk size:
+
+```rust
+use std::num::NonZeroUsize;
+
+let checker = PermissionChecker::new()
+    .with_max_batch_size(NonZeroUsize::new(500).unwrap());
+```
 
 ### PolicyBuilder
 The `PolicyBuilder` provides a fluent API to construct custom policies by chaining predicate functions for 
@@ -120,4 +129,4 @@ DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_t
   cargo run --example pg18_bulk_rebac --release
 ```
 
-On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, 10x faster for 100 resources, and over 150x faster for 10,000 resources.
+On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, 10x faster for 100 resources, and over 200x faster for 10,000 resources.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 [![Crates.io](https://img.shields.io/crates/v/gatehouse)](https://crates.io/crates/gatehouse)
 [![Documentation](https://docs.rs/gatehouse/badge.svg)](https://docs.rs/gatehouse)
 
-A flexible authorization library that combines role-based (RBAC), attribute-based (ABAC), and relationship-based (ReBAC) access control policies.
+An in-process authorization engine for Rust. Compose RBAC, ABAC, and relationship-based policies; load relationship facts through a request-scoped session that batches, deduplicates, and coalesces backend calls. List endpoints stay correct and fast without pushing policy into your data layer.
 
 ![Gatehouse Logo](https://raw.githubusercontent.com/thepartly/gatehouse/main/.github/logo.svg)
 
 ## Features
-- **Multi-paradigm Authorization**: Support for RBAC, ABAC, and ReBAC patterns
+- **In-process authorization**: Keep policy logic in Rust without requiring a separate authorization service
+- **Multi-paradigm policies**: Compose RBAC, ABAC, and ReBAC patterns
+- **Request-scoped fact loading**: Load relationship facts through `EvaluationSession` and `FactSource`
+- **Batch-safe list endpoints**: Authorize many resources with policy-correct batching, deduplication, and caller-order preservation
 - **Policy Composition**: Combine policies with logical operators (`AND`, `OR`, `NOT`)
 - **Detailed Evaluation Tracing**: Decision trace for the policies and branches that were actually evaluated
 - **Fluent Builder API**: Construct custom policies with a PolicyBuilder.
@@ -69,6 +72,14 @@ let outcome: Result<(), String> = evaluation.to_result(|reason| reason.to_string
 assert!(outcome.is_ok());
 # });
 ```
+
+## Why v0.3 Matters
+
+Simple checks still look like normal Rust predicates. The difference shows up when an endpoint has to authorize a page, feed, subscription batch, or search result. Before v0.3, those paths either paid N policy evaluations and N backend round trips, or duplicated policy logic into SQL and risked bypassing later checker policies.
+
+Gatehouse now treats authorization as computation over request-scoped facts. A policy stack can keep in-memory checks, combinators, and relationship checks in one place, while `EvaluationSession` batches and caches the fact loads needed by that request.
+
+You do not need to model every check as a fact. RBAC and ABAC-style predicates stay simple and in-process; fact sources are the production path for data that would otherwise require per-resource I/O, such as relationship checks behind list endpoints.
 
 ## Decision Semantics
 
@@ -163,6 +174,14 @@ let checker = PermissionChecker::new()
     .with_max_batch_size(NonZeroUsize::new(500).unwrap());
 ```
 
+### Fact Sources And Sessions
+
+`EvaluationSession` is request-scoped. Register the fact sources needed for one request, run the checker, then drop the session. Cached facts, cached errors, and in-flight load state do not outlive the request.
+
+`FactSource::load_many` receives unique keys and must return exactly one result per key in the same order. The session handles duplicate expansion and caller-order preservation. Missing sources, backend errors, missing facts, wrong result counts, and cancelled loader tasks all fail closed.
+
+`RebacPolicy` is the first built-in fact-backed policy. It extracts subject/resource IDs, builds `RelationshipQuery<SubjectId, ResourceId, Relation>` keys, and asks the session for those relationship facts. `LookupSource` reserves the complementary "what can this subject see?" shape for backends that can enumerate visible resources directly.
+
 ### PolicyBuilder
 The `PolicyBuilder` provides a fluent API to construct custom policies by chaining predicate functions for 
 subjects, actions, resources, and context. Every configured predicate must pass for the built policy to grant access. Once built, the policy can be added to a `PermissionChecker`.
@@ -222,6 +241,7 @@ See the `examples` directory for complete demonstrations of:
 - Role-based access control (`rbac_policy`)
 - Attribute-style custom policies with `PolicyBuilder` (`policy_builder`)
 - Relationship-based access control (`rebac_policy`)
+- PostgreSQL-backed batched relationship facts (`pg18_bulk_rebac`)
 - Group authorization with trace output (`groups_policy`)
 - Policy combinators (`combinator_policy`)
 - Axum integration with shared policies (`axum`)
@@ -239,11 +259,11 @@ Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChec
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
 
-The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It compares N point queries through per-item sessions with one bulk `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
+The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
 
 ```shell
 DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \
   cargo run --example pg18_bulk_rebac --release
 ```
 
-On a local PostgreSQL 18.3 container, the bulk path was about 6x faster for 10 resources, 41x faster for 100 resources, and 50-90x faster for 1,000+ resources.
+The example prints a CSV so you can compare your own database and machine. A local PostgreSQL 18.3 run of the mixed-policy example produced `x4.5` at 10 resources, `x63.4` at 1,000 resources, `x69.8` at 5,000 resources, and `x71.6` at 10,000 resources. Exact numbers vary; the important property is that the policy stack stays in Gatehouse while relationship fact loading collapses to batched SQL.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ if result.is_granted() {
 }
 ```
 
+### Batch Authorization
+
+List and subscription endpoints often need to answer "which of these resources can this subject access?" Use `evaluate_batch_by` when you need the decision for every input item, or `filter_authorized_by` when you only need the authorized subset.
+
+```rust
+let visible_posts = checker
+    .filter_authorized_with_context_by(&user, &Action::View, posts, &request_context, |post| post)
+    .await;
+```
+
+The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_access`.
+
+Policies can override `Policy::evaluate_access_batch` to collapse backend work. `RebacPolicy` forwards batch checks to `RelationshipResolver::has_relationship_batch`, whose default implementation loops over `has_relationship`; SQL or graph-backed resolvers can override it with one set-oriented lookup.
+
 ### PolicyBuilder
 The `PolicyBuilder` provides a fluent API to construct custom policies by chaining predicate functions for 
 subjects, actions, resources, and context. Once built, the policy can be added to a [`PermissionChecker`].
@@ -98,3 +112,12 @@ cargo run --example rbac_policy
 Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChecker::evaluate_access` across
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
+
+The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC resolver using PostgreSQL 18. It compares N point queries through `evaluate_access` with one bulk `WITH ORDINALITY` query through `filter_authorized_with_context_by`:
+
+```shell
+DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \
+  cargo run --example pg18_bulk_rebac --release
+```
+
+On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, 10x faster for 100 resources, and over 150x faster for 10,000 resources.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Gatehouse now treats authorization as computation over request-scoped facts. A p
 
 You do not need to model every check as a fact. RBAC and ABAC-style predicates stay simple and in-process; fact sources are the production path for data that would otherwise require per-resource I/O, such as relationship checks behind list endpoints.
 
+If you are upgrading from 0.2, see `MIGRATION.md` for the `RelationshipResolver` to `FactSource` migration path and `Policy` trait changes.
+
 ## Decision Semantics
 
 - `PermissionChecker` evaluates policies sequentially with `OR` semantics and short-circuits on the first grant.
@@ -186,7 +188,7 @@ let session = EvaluationSession::builder()
     .build();
 ```
 
-`register` and `register_arc` fail fast if the same fact key type is registered twice. Use `replace` or `replace_arc` only when overwriting a source is intentional.
+`register` and `register_arc` fail fast if the same fact key type is registered twice. Use `replace` or `replace_arc` only when overwriting a source is intentional. Use `try_register`, `try_register_arc`, `try_replace`, or `try_replace_arc` when setup code should handle registration errors without panicking.
 
 For hot RBAC/ABAC-only paths, `EvaluationSession::shared_empty()` returns a process-wide empty session and avoids per-call allocation. Only use it when no fact-backed policies are expected; it rejects source registration.
 
@@ -197,6 +199,8 @@ The source registry is keyed by the exact Rust fact key type. If two backends se
 Cached facts, cached errors, and in-flight load state do not outlive the request-scoped session. This is a correctness boundary as well as a performance detail: if a permission is revoked after one request has loaded it, a new request builds a new session and must load the fact again.
 
 `FactSource::load_many` receives unique keys and must return exactly one result per key in the same order. The session handles duplicate expansion and caller-order preservation. Missing sources, backend errors, missing facts, wrong result counts, and cancelled loader tasks all fail closed.
+
+If the leader task for an in-flight fact load is cancelled or panics, the session caches `FactLoadError::LoaderCancelled` for those keys and wakes waiters. That intentionally poisons those keys for the rest of the request-scoped session so the request fails closed instead of hanging. Build a fresh session for a retry or a new request.
 
 `RebacPolicy` is the first built-in fact-backed policy. It extracts subject/resource IDs, builds `RelationshipQuery<SubjectId, ResourceId, Relation>` keys, and asks the session for those relationship facts.
 
@@ -281,6 +285,8 @@ Nested `gatehouse.batch_policy` span fields:
 
 - `policy.type`
 - `policy.pending_count`
+- `policy.chunk_index`
+- `policy.chunk_count`
 - `policy.granted_count`
 - `policy.denied_count`
 
@@ -322,7 +328,7 @@ Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChec
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
 
-The `in_ram_fact_source` Criterion group isolates Gatehouse's session overhead when the source itself is hot and in-process. The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
+The `in_ram_fact_source` Criterion group isolates Gatehouse's session overhead when the source itself is hot and in-process; it is not a benchmark for network or database latency. The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
 
 ```shell
 DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ let checker = PermissionChecker::new()
 
 `RebacPolicy` is the first built-in fact-backed policy. It extracts subject/resource IDs, builds `RelationshipQuery<SubjectId, ResourceId, Relation>` keys, and asks the session for those relationship facts. `LookupSource` reserves the complementary "what can this subject see?" shape for backends that can enumerate visible resources directly.
 
+Use a typed relation enum when your domain has a fixed relation set, even if the backing store uses strings. The `EvaluationSession` deduplicates and caches by the typed `RelationshipQuery`; the `FactSource` owns the backend boundary and can convert `Relation::Viewer` to `"viewer"` when binding SQL parameters. The `pg18_bulk_rebac` example demonstrates this pattern against a PostgreSQL `text` column.
+
 ### PolicyBuilder
 The `PolicyBuilder` provides a fluent API to construct custom policies by chaining predicate functions for 
 subjects, actions, resources, and context. Every configured predicate must pass for the built policy to grant access. Once built, the policy can be added to a `PermissionChecker`.
@@ -213,9 +215,9 @@ Fact-backed ReBAC failures fail closed: missing sources, missing facts, source e
 
 ## Tracing And Telemetry
 
-When trace-level events are enabled, `PermissionChecker::evaluate_in_session` creates an instrumented span and every evaluated policy records a `trace!` event on the `gatehouse::security` target. Batch evaluation records `item_count`, `granted_count`, `denied_count`, `policy_count`, and nested `gatehouse.batch_policy` spans with per-policy pending/granted/denied counts.
+When trace-level events are enabled, `PermissionChecker::evaluate_in_session` creates an instrumented span and every evaluated policy records a `trace!` event on the `gatehouse::security` target. Batch evaluation records checker-level aggregate fields and nested `gatehouse.batch_policy` spans with per-policy pending/granted/denied counts.
 
-Emitted fields:
+Single-item security event fields:
 
 - `security_rule.name`
 - `security_rule.category`
@@ -228,6 +230,27 @@ Emitted fields:
 - `event.outcome`
 - `policy.type`
 - `policy.result.reason`
+
+Single-item checker span fields:
+
+- `policy_count`
+- `outcome`
+- `policy.type`
+
+Batch checker span fields:
+
+- `item_count`
+- `granted_count`
+- `denied_count`
+- `policy_count`
+- `max_batch_size`
+
+Nested `gatehouse.batch_policy` span fields:
+
+- `policy.type`
+- `policy.pending_count`
+- `policy.granted_count`
+- `policy.denied_count`
 
 Fallback behavior when `security_rule()` is not overridden:
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,27 @@ let checker = PermissionChecker::new()
 
 ### Fact Sources And Sessions
 
-`EvaluationSession` is request-scoped. Register the fact sources needed for one request, run the checker, then drop the session. Cached facts, cached errors, and in-flight load state do not outlive the request.
+`EvaluationSession` is request-scoped. Register the fact sources needed for one request, run the checker, then drop the session. Declare all request sources in one place with `EvaluationSession::builder()`:
+
+```rust,ignore
+let session = EvaluationSession::builder()
+    .with_arc::<RelationshipQuery<Uuid, Uuid, Relation>>(Arc::clone(&relationships))
+    .build();
+```
+
+`register` and `register_arc` fail fast if the same fact key type is registered twice. Use `replace` or `replace_arc` only when overwriting a source is intentional.
+
+#### Cache Lifetime And Revocation
+
+Cached facts, cached errors, and in-flight load state do not outlive the request-scoped session. This is a correctness boundary as well as a performance detail: if a permission is revoked after one request has loaded it, a new request builds a new session and must load the fact again.
 
 `FactSource::load_many` receives unique keys and must return exactly one result per key in the same order. The session handles duplicate expansion and caller-order preservation. Missing sources, backend errors, missing facts, wrong result counts, and cancelled loader tasks all fail closed.
 
-`RebacPolicy` is the first built-in fact-backed policy. It extracts subject/resource IDs, builds `RelationshipQuery<SubjectId, ResourceId, Relation>` keys, and asks the session for those relationship facts. `LookupSource` reserves the complementary "what can this subject see?" shape for backends that can enumerate visible resources directly.
+`RebacPolicy` is the first built-in fact-backed policy. It extracts subject/resource IDs, builds `RelationshipQuery<SubjectId, ResourceId, Relation>` keys, and asks the session for those relationship facts.
 
 Use a typed relation enum when your domain has a fixed relation set, even if the backing store uses strings. The `EvaluationSession` deduplicates and caches by the typed `RelationshipQuery`; the `FactSource` owns the backend boundary and can convert `Relation::Viewer` to `"viewer"` when binding SQL parameters. The `pg18_bulk_rebac` example demonstrates this pattern against a PostgreSQL `text` column.
+
+If several relationship domains all look like `Uuid -> Uuid`, prefer one domain relation enum and dispatch inside the corresponding `FactSource`. If you need separate source registrations, wrap IDs in domain newtypes so each `RelationshipQuery<SubjectId, ResourceId, Relation>` has a distinct Rust type.
 
 ### PolicyBuilder
 The `PolicyBuilder` provides a fluent API to construct custom policies by chaining predicate functions for 
@@ -216,6 +230,16 @@ Fact-backed ReBAC failures fail closed: missing sources, missing facts, source e
 ## Tracing And Telemetry
 
 When trace-level events are enabled, `PermissionChecker::evaluate_in_session` creates an instrumented span and every evaluated policy records a `trace!` event on the `gatehouse::security` target. Batch evaluation records checker-level aggregate fields and nested `gatehouse.batch_policy` spans with per-policy pending/granted/denied counts.
+
+Span, event target, and field names listed here are public observability API. Renaming or removing them is treated as a semver-major change.
+
+Span and event names:
+
+- `evaluate_in_session` span for single-item checker evaluation
+- `evaluate_batch_in_session_by` span for batch checker evaluation
+- `gatehouse.batch_policy` span for each policy batch pass
+- `gatehouse.fact_load` span for each source-level fact load
+- `gatehouse::security` target for per-policy security events
 
 Single-item security event fields:
 
@@ -252,6 +276,13 @@ Nested `gatehouse.batch_policy` span fields:
 - `policy.granted_count`
 - `policy.denied_count`
 
+`gatehouse.fact_load` span fields:
+
+- `fact.name`
+- `fact.load_id`
+- `fact.key_count`
+- `fact.unique_key_count`
+
 Fallback behavior when `security_rule()` is not overridden:
 
 - `security_rule.name` falls back to `policy_type()`
@@ -264,6 +295,7 @@ See the `examples` directory for complete demonstrations of:
 - Role-based access control (`rbac_policy`)
 - Attribute-style custom policies with `PolicyBuilder` (`policy_builder`)
 - Relationship-based access control (`rebac_policy`)
+- In-RAM relationship facts shared across request sessions (`in_ram_rebac`)
 - PostgreSQL-backed batched relationship facts (`pg18_bulk_rebac`)
 - Group authorization with trace output (`groups_policy`)
 - Policy combinators (`combinator_policy`)
@@ -282,7 +314,7 @@ Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChec
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
 
-The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
+The `in_ram_fact_source` Criterion group isolates Gatehouse's session overhead when the source itself is hot and in-process. The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
 
 ```shell
 DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \
@@ -290,3 +322,5 @@ DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_t
 ```
 
 The example prints a CSV so you can compare your own database and machine. Local PostgreSQL 18.3 runs of the mixed-policy example show modest wins for tiny lists and tens-to-low-hundreds improvements once the list is large enough for round trips to dominate. Exact numbers vary; the important property is that the policy stack stays in Gatehouse while relationship fact loading collapses to batched SQL.
+
+The PostgreSQL example uses `tokio-postgres` directly to keep the demonstration small. `sqlx` users should keep the same boundary: implement `FactSource<RelationshipQuery<...>>`, map backend errors to `FactLoadError::backend`, and preserve the one-result-per-input-key contract.

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_t
   cargo run --example pg18_bulk_rebac --release
 ```
 
-On a local PostgreSQL 18.3 container, the bulk path was about 5x faster for 10 resources, 34x faster for 100 resources, and over 100x faster for 1,000+ resources.
+On a local PostgreSQL 18.3 container, the bulk path was about 6x faster for 10 resources, 41x faster for 100 resources, and 50-90x faster for 1,000+ resources.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_t
   cargo run --example pg18_bulk_rebac --release
 ```
 
-On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, 10x faster for 100 resources, and over 200x faster for 10,000 resources.
+On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, around 10x faster for 100 resources, and tens to hundreds of times faster for thousands of resources.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,8 @@ The foundation of the authorization system:
 ```rust
 #[async_trait]
 trait Policy<Subject, Resource, Action, Context> {
-    async fn evaluate_access(
-        &self,
-        subject: &Subject,
-        action: &Action,
-        resource: &Resource,
-        context: &Context,
-    ) -> PolicyEvalResult;
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Subject, Resource, Action, Context>)
+        -> PolicyEvalResult;
 }
 ```
 
@@ -45,7 +40,10 @@ checker.add_policy(rbac_policy);
 checker.add_policy(owner_policy);
 
 // Check if access is granted
-let result = checker.evaluate_access(&user, &action, &resource, &context).await;
+let session = EvaluationSession::empty();
+let result = checker
+    .evaluate_in_session(&session, &user, &action, &resource, &context)
+    .await;
 if result.is_granted() {
     // Access allowed
 } else {
@@ -55,19 +53,27 @@ if result.is_granted() {
 
 ### Batch Authorization
 
-List and subscription endpoints often need to answer "which of these resources can this subject access?" Use `evaluate_batch_by` when you need the decision for every input item, or `filter_authorized_by` when you only need the authorized subset.
+List and subscription endpoints often need to answer "which of these resources can this subject access?" Use `evaluate_batch_in_session_by` when you need the decision for every input item, or `filter_authorized_in_session_by` when you only need the authorized subset.
 
 ```rust
+let session = EvaluationSession::empty();
 let visible_posts = checker
-    .filter_authorized_with_context_by(&user, &Action::View, posts, &request_context, |post| post)
+    .filter_authorized_with_context_in_session_by(
+        &session,
+        &user,
+        &Action::View,
+        posts,
+        &request_context,
+        |post| post,
+    )
     .await;
 ```
 
-The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_access`.
+The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_in_session`.
 
-Policies can override `Policy::evaluate_access_batch` to collapse backend work. `RebacPolicy` forwards batch checks to `RelationshipResolver::has_relationship_batch`, whose default implementation loops over `has_relationship`; SQL or graph-backed resolvers can override it with one set-oriented lookup. Combinator policies (`AndPolicy`, `OrPolicy`, and `NotPolicy`) preserve batching for their inner policies.
+Policies can override `Policy::evaluate_batch` to collapse backend work. `RebacPolicy` builds `RelationshipQuery` fact keys and loads them through the request-scoped `EvaluationSession`, so deduplication, chunking, caching, and fail-closed source errors live in one `FactSource` layer. Combinator policies (`AndPolicy`, `OrPolicy`, and `NotPolicy`) preserve batching for their inner policies.
 
-If a backend needs smaller requests, configure a chunk size:
+`PermissionChecker::with_max_batch_size` caps the number of still-pending items passed to each policy batch call. Fact-backed policies can also set `FactSource::max_batch_size`, which caps source-level loads after session deduplication.
 
 ```rust
 use std::num::NonZeroUsize;
@@ -118,15 +124,15 @@ cargo run --example rbac_policy
 
 ## Performance
 
-Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChecker::evaluate_access` across
+Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChecker::evaluate_in_session` across
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
 
-The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC resolver using PostgreSQL 18. It compares N point queries through `evaluate_access` with one bulk `WITH ORDINALITY` query through `filter_authorized_with_context_by`:
+The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It compares N point queries through per-item sessions with one bulk `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
 
 ```shell
 DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \
   cargo run --example pg18_bulk_rebac --release
 ```
 
-On a local PostgreSQL 18.3 container, the bulk path was roughly break-even for tiny batches, around 10x faster for 100 resources, and tens to hundreds of times faster for thousands of resources.
+On a local PostgreSQL 18.3 container, the bulk path was about 5x faster for 10 resources, 34x faster for 100 resources, and over 100x faster for 1,000+ resources.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ See the `examples` directory for complete demonstrations of:
 - PostgreSQL-backed batched relationship facts (`pg18_bulk_rebac`)
 - Group authorization with trace output (`groups_policy`)
 - Policy combinators (`combinator_policy`)
-- Axum integration with shared policies (`axum`)
+- Axum integration with shared policies, app state, request-scoped sessions, and a bulk invoice listing endpoint (`axum`)
 - Actix Web integration with shared policies (`actix_web`)
 
 Run with:
@@ -266,4 +266,4 @@ DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_t
   cargo run --example pg18_bulk_rebac --release
 ```
 
-The example prints a CSV so you can compare your own database and machine. A local PostgreSQL 18.3 run of the mixed-policy example produced `x4.5` at 10 resources, `x63.4` at 1,000 resources, `x69.8` at 5,000 resources, and `x71.6` at 10,000 resources. Exact numbers vary; the important property is that the policy stack stays in Gatehouse while relationship fact loading collapses to batched SQL.
+The example prints a CSV so you can compare your own database and machine. Local PostgreSQL 18.3 runs of the mixed-policy example show modest wins for tiny lists and tens-to-low-hundreds improvements once the list is large enough for round trips to dominate. Exact numbers vary; the important property is that the policy stack stays in Gatehouse while relationship fact loading collapses to batched SQL.

--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ Criterion benchmarks in `benches/permission_checker.rs` exercise `PermissionChec
 several policy stack sizes. Run them with `cargo bench` to track changes in evaluation latency as you evolve
 your policy definitions.
 
-The `in_ram_fact_source` Criterion group isolates Gatehouse's session overhead when the source itself is hot and in-process; it is not a benchmark for network or database latency. The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
+The `in_ram_fact_source` Criterion group isolates Gatehouse's session overhead when the source itself is hot and in-process; it is not a benchmark for network or database latency. The `latency_fact_source` group injects a fixed async delay per source call so the benchmarks also show the intended shape under backend latency: N per-item sessions versus one batched session, and independent repeated loads versus shared-session in-flight coalescing.
+
+The `pg18_bulk_rebac` example demonstrates a SQL-backed ReBAC `FactSource` using PostgreSQL 18. It models a list endpoint with an in-memory `PublicPost` policy plus a SQL-backed `viewer` relationship policy, then compares N point queries through per-item sessions with one batched `WITH ORDINALITY` query through `filter_authorized_with_context_in_session_by`:
 
 ```shell
 DATABASE_URL="host=localhost port=15432 user=postgres password=test dbname=awa_test" \

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -1,7 +1,13 @@
+use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use gatehouse::{Effect, EvaluationSession, PermissionChecker, PolicyBuilder};
+use gatehouse::{
+    Effect, EvaluationSession, FactLoadResult, FactSource, PermissionChecker, PolicyBuilder,
+    RebacPolicy, RelationshipQuery,
+};
 use std::hint::black_box;
+use std::sync::Arc;
 use tokio::runtime::Runtime;
+use uuid::Uuid;
 
 type Subject = ();
 type Resource = ();
@@ -96,5 +102,129 @@ fn bench_permission_checker(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_permission_checker);
+#[derive(Clone)]
+struct BenchUser {
+    id: Uuid,
+}
+
+#[derive(Clone)]
+struct BenchResource {
+    id: Uuid,
+}
+
+struct BenchAction;
+struct BenchContext;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum BenchRelation {
+    Viewer,
+}
+
+impl std::fmt::Display for BenchRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Viewer => f.write_str("viewer"),
+        }
+    }
+}
+
+type BenchRelationship = RelationshipQuery<Uuid, Uuid, BenchRelation>;
+
+struct AlwaysFoundSource;
+
+#[async_trait]
+impl FactSource<BenchRelationship> for AlwaysFoundSource {
+    async fn load_many(&self, keys: &[BenchRelationship]) -> Vec<FactLoadResult<bool>> {
+        keys.iter().map(|_| FactLoadResult::Found(true)).collect()
+    }
+}
+
+fn build_rebac_checker() -> PermissionChecker<BenchUser, BenchResource, BenchAction, BenchContext> {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(RebacPolicy::new(
+        |user: &BenchUser| user.id,
+        |resource: &BenchResource| resource.id,
+        BenchRelation::Viewer,
+    ));
+    checker
+}
+
+fn bench_in_ram_fact_source(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create Tokio runtime");
+    let subject = BenchUser { id: Uuid::new_v4() };
+    let action = BenchAction;
+    let context = BenchContext;
+    let source: Arc<dyn FactSource<BenchRelationship>> = Arc::new(AlwaysFoundSource);
+    let checker = build_rebac_checker();
+    let mut group = c.benchmark_group("in_ram_fact_source");
+
+    for &item_count in &[1usize, 10, 100, 1_000] {
+        let resources = (0..item_count)
+            .map(|_| BenchResource { id: Uuid::new_v4() })
+            .collect::<Vec<_>>();
+        let keys = resources
+            .iter()
+            .map(|resource| BenchRelationship {
+                subject_id: subject.id,
+                resource_id: resource.id,
+                relation: BenchRelation::Viewer,
+            })
+            .collect::<Vec<_>>();
+
+        group.bench_with_input(
+            BenchmarkId::new("session_get_many_uncached", item_count),
+            &keys,
+            |b, keys| {
+                b.iter(|| {
+                    let session = EvaluationSession::builder()
+                        .with_arc::<BenchRelationship>(Arc::clone(&source))
+                        .build();
+                    let result = runtime.block_on(session.get_many(black_box(keys)));
+                    black_box(result)
+                });
+            },
+        );
+
+        let cached_session = EvaluationSession::builder()
+            .with_arc::<BenchRelationship>(Arc::clone(&source))
+            .build();
+        runtime.block_on(cached_session.get_many(&keys));
+        group.bench_with_input(
+            BenchmarkId::new("session_get_many_cached", item_count),
+            &keys,
+            |b, keys| {
+                b.iter(|| {
+                    let result = runtime.block_on(cached_session.get_many(black_box(keys)));
+                    black_box(result)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("checker_batch_uncached", item_count),
+            &resources,
+            |b, resources| {
+                b.iter(|| {
+                    let session = EvaluationSession::builder()
+                        .with_arc::<BenchRelationship>(Arc::clone(&source))
+                        .build();
+                    let result =
+                        runtime.block_on(checker.filter_authorized_with_context_in_session_by(
+                            &session,
+                            &subject,
+                            &action,
+                            black_box(resources.clone()),
+                            &context,
+                            |resource| resource,
+                        ));
+                    black_box(result)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_permission_checker, bench_in_ram_fact_source);
 criterion_main!(benches);

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use gatehouse::{Effect, PermissionChecker, PolicyBuilder};
+use gatehouse::{Effect, EvaluationSession, PermissionChecker, PolicyBuilder};
 use std::hint::black_box;
 use tokio::runtime::Runtime;
 
@@ -57,7 +57,7 @@ fn bench_permission_checker(c: &mut Criterion) {
     let action: Action = ();
     let resource: Resource = ();
     let context: Context = ();
-    let mut group = c.benchmark_group("permission_checker_evaluate_access");
+    let mut group = c.benchmark_group("permission_checker_evaluate_in_session");
 
     for &policy_count in &[1usize, 4, 16, 64] {
         let allow_checker = build_trailing_allow_checker(policy_count);
@@ -66,8 +66,11 @@ fn bench_permission_checker(c: &mut Criterion) {
             &allow_checker,
             |b, checker| {
                 b.iter(|| {
-                    let result = runtime
-                        .block_on(checker.evaluate_access(&subject, &action, &resource, &context));
+                    let session = EvaluationSession::empty();
+                    let result = runtime.block_on(
+                        checker
+                            .evaluate_in_session(&session, &subject, &action, &resource, &context),
+                    );
                     black_box(result)
                 });
             },
@@ -79,8 +82,11 @@ fn bench_permission_checker(c: &mut Criterion) {
             &deny_checker,
             |b, checker| {
                 b.iter(|| {
-                    let result = runtime
-                        .block_on(checker.evaluate_access(&subject, &action, &resource, &context));
+                    let session = EvaluationSession::empty();
+                    let result = runtime.block_on(
+                        checker
+                            .evaluate_in_session(&session, &subject, &action, &resource, &context),
+                    );
                     black_box(result)
                 });
             },

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -6,7 +6,9 @@ use gatehouse::{
 };
 use std::hint::black_box;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::runtime::Runtime;
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 type Subject = ();
@@ -139,6 +141,45 @@ impl FactSource<BenchRelationship> for AlwaysFoundSource {
     }
 }
 
+#[derive(Clone)]
+struct LatencyFoundSource {
+    delay: Duration,
+    serial_gate: Option<Arc<AsyncMutex<()>>>,
+}
+
+impl LatencyFoundSource {
+    fn concurrent(delay: Duration) -> Self {
+        Self {
+            delay,
+            serial_gate: None,
+        }
+    }
+
+    fn serialized(delay: Duration) -> Self {
+        Self {
+            delay,
+            serial_gate: Some(Arc::new(AsyncMutex::new(()))),
+        }
+    }
+
+    async fn wait(&self) {
+        if let Some(serial_gate) = &self.serial_gate {
+            let _guard = serial_gate.lock().await;
+            tokio::time::sleep(self.delay).await;
+        } else {
+            tokio::time::sleep(self.delay).await;
+        }
+    }
+}
+
+#[async_trait]
+impl FactSource<BenchRelationship> for LatencyFoundSource {
+    async fn load_many(&self, keys: &[BenchRelationship]) -> Vec<FactLoadResult<bool>> {
+        self.wait().await;
+        keys.iter().map(|_| FactLoadResult::Found(true)).collect()
+    }
+}
+
 fn build_rebac_checker() -> PermissionChecker<BenchUser, BenchResource, BenchAction, BenchContext> {
     let mut checker = PermissionChecker::new();
     checker.add_policy(RebacPolicy::new(
@@ -226,5 +267,157 @@ fn bench_in_ram_fact_source(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_permission_checker, bench_in_ram_fact_source);
+fn bench_latency_fact_source(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create Tokio runtime");
+    let subject = BenchUser { id: Uuid::new_v4() };
+    let action = BenchAction;
+    let context = BenchContext;
+    let checker = build_rebac_checker();
+    let delay = Duration::from_millis(1);
+    let batch_source: Arc<dyn FactSource<BenchRelationship>> =
+        Arc::new(LatencyFoundSource::concurrent(delay));
+    let coalescing_source: Arc<dyn FactSource<BenchRelationship>> =
+        Arc::new(LatencyFoundSource::serialized(delay));
+    let mut group = c.benchmark_group("latency_fact_source");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_secs(2));
+
+    for &item_count in &[10usize, 100] {
+        let resources = (0..item_count)
+            .map(|_| BenchResource { id: Uuid::new_v4() })
+            .collect::<Vec<_>>();
+        let keys = resources
+            .iter()
+            .map(|resource| BenchRelationship {
+                subject_id: subject.id,
+                resource_id: resource.id,
+                relation: BenchRelation::Viewer,
+            })
+            .collect::<Vec<_>>();
+
+        group.bench_with_input(
+            BenchmarkId::new("naive_per_item_sessions", item_count),
+            &resources,
+            |b, resources| {
+                b.iter(|| {
+                    let result = runtime.block_on(async {
+                        let mut authorized = Vec::new();
+                        for resource in black_box(resources.clone()) {
+                            let session = EvaluationSession::builder()
+                                .with_arc::<BenchRelationship>(Arc::clone(&batch_source))
+                                .build();
+                            let mut visible = checker
+                                .filter_authorized_with_context_in_session_by(
+                                    &session,
+                                    &subject,
+                                    &action,
+                                    vec![resource],
+                                    &context,
+                                    |resource| resource,
+                                )
+                                .await;
+                            authorized.append(&mut visible);
+                        }
+                        authorized
+                    });
+                    black_box(result)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("checker_batch_one_session", item_count),
+            &resources,
+            |b, resources| {
+                b.iter(|| {
+                    let session = EvaluationSession::builder()
+                        .with_arc::<BenchRelationship>(Arc::clone(&batch_source))
+                        .build();
+                    let result =
+                        runtime.block_on(checker.filter_authorized_with_context_in_session_by(
+                            &session,
+                            &subject,
+                            &action,
+                            black_box(resources.clone()),
+                            &context,
+                            |resource| resource,
+                        ));
+                    black_box(result)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("independent_same_keys_4_tasks", item_count),
+            &keys,
+            |b, keys| {
+                b.iter(|| {
+                    runtime.block_on(async {
+                        let source = Arc::clone(&coalescing_source);
+                        let (a, b, c, d) = tokio::join!(
+                            async {
+                                let session = EvaluationSession::builder()
+                                    .with_arc::<BenchRelationship>(Arc::clone(&source))
+                                    .build();
+                                session.get_many(black_box(keys)).await
+                            },
+                            async {
+                                let session = EvaluationSession::builder()
+                                    .with_arc::<BenchRelationship>(Arc::clone(&source))
+                                    .build();
+                                session.get_many(black_box(keys)).await
+                            },
+                            async {
+                                let session = EvaluationSession::builder()
+                                    .with_arc::<BenchRelationship>(Arc::clone(&source))
+                                    .build();
+                                session.get_many(black_box(keys)).await
+                            },
+                            async {
+                                let session = EvaluationSession::builder()
+                                    .with_arc::<BenchRelationship>(Arc::clone(&source))
+                                    .build();
+                                session.get_many(black_box(keys)).await
+                            },
+                        );
+                        black_box((a, b, c, d))
+                    })
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("coalesced_same_keys_4_tasks", item_count),
+            &keys,
+            |b, keys| {
+                b.iter(|| {
+                    let session = Arc::new(
+                        EvaluationSession::builder()
+                            .with_arc::<BenchRelationship>(Arc::clone(&coalescing_source))
+                            .build(),
+                    );
+                    runtime.block_on(async {
+                        let (a, b, c, d) = tokio::join!(
+                            async { session.get_many(black_box(keys)).await },
+                            async { session.get_many(black_box(keys)).await },
+                            async { session.get_many(black_box(keys)).await },
+                            async { session.get_many(black_box(keys)).await },
+                        );
+                        black_box((a, b, c, d))
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_permission_checker,
+    bench_in_ram_fact_source,
+    bench_latency_fact_source
+);
 criterion_main!(benches);

--- a/examples/actix_web.rs
+++ b/examples/actix_web.rs
@@ -30,7 +30,9 @@
 use actix_web::{
     dev::Payload, web, App, FromRequest, HttpRequest, HttpResponse, HttpServer, Responder,
 };
-use gatehouse::{AccessEvaluation, AndPolicy, PermissionChecker, Policy, PolicyBuilder};
+use gatehouse::{
+    AccessEvaluation, AndPolicy, EvaluationSession, PermissionChecker, Policy, PolicyBuilder,
+};
 use std::future::{ready, Ready};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -288,9 +290,10 @@ pub async fn edit_post(
     let ctx = RequestContext {
         current_time: SystemTime::now(),
     };
+    let session = EvaluationSession::empty();
 
     match checker
-        .evaluate_access(&user, &Action::Edit, &Resource::Post(post), &ctx)
+        .evaluate_in_session(&session, &user, &Action::Edit, &Resource::Post(post), &ctx)
         .await
     {
         AccessEvaluation::Granted { .. } => HttpResponse::Ok().body("Post updated"),
@@ -311,9 +314,16 @@ pub async fn publish_post(
     let ctx = RequestContext {
         current_time: SystemTime::now(),
     };
+    let session = EvaluationSession::empty();
 
     match checker
-        .evaluate_access(&user, &Action::Publish, &Resource::Post(post), &ctx)
+        .evaluate_in_session(
+            &session,
+            &user,
+            &Action::Publish,
+            &Resource::Post(post),
+            &ctx,
+        )
         .await
     {
         AccessEvaluation::Granted { .. } => HttpResponse::Ok().body("Post published"),
@@ -341,9 +351,10 @@ pub async fn view_post(
     let ctx = RequestContext {
         current_time: SystemTime::now(),
     };
+    let session = EvaluationSession::empty();
 
     match checker
-        .evaluate_access(&user, &Action::View, &Resource::Post(post), &ctx)
+        .evaluate_in_session(&session, &user, &Action::View, &Resource::Post(post), &ctx)
         .await
     {
         AccessEvaluation::Granted { .. } => HttpResponse::Ok().body("Here is your post"),

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -1,14 +1,18 @@
 // Axum service that authorizes multiple resource types (Invoices, Payments)
 // using a single PermissionChecker. Demonstrates multiple policies and actions.
 
+use async_trait::async_trait;
 use axum::{
-    extract::{Extension, FromRequestParts, Path},
+    extract::{FromRequestParts, Path, State},
     http::{request::Parts, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
-    Router,
+    Json, Router,
 };
 use gatehouse::*;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
@@ -88,7 +92,7 @@ impl InvoiceOverrides {
     fn build_invoice(&self, invoice_id: Uuid) -> Invoice {
         Invoice {
             id: invoice_id,
-            owner_id: Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap(),
+            owner_id: demo_owner_id(),
             locked: self.locked.unwrap_or(false),
             created_at: SystemTime::now()
                 - Duration::from_secs(self.age_days.unwrap_or(10) * 24 * 60 * 60),
@@ -196,6 +200,133 @@ pub struct RequestContext {
     pub current_time: SystemTime,
 }
 
+impl RequestContext {
+    fn now() -> Self {
+        Self {
+            current_time: SystemTime::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Relation {
+    Viewer,
+}
+
+impl fmt::Display for Relation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Viewer => f.write_str("viewer"),
+        }
+    }
+}
+
+type InvoiceRelationship = RelationshipQuery<Uuid, Uuid, Relation>;
+
+#[derive(Clone)]
+pub struct InMemoryRelationshipSource {
+    grants: Arc<HashSet<InvoiceRelationship>>,
+}
+
+impl InMemoryRelationshipSource {
+    fn new(grants: impl IntoIterator<Item = InvoiceRelationship>) -> Self {
+        Self {
+            grants: Arc::new(grants.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl FactSource<InvoiceRelationship> for InMemoryRelationshipSource {
+    async fn load_many(&self, keys: &[InvoiceRelationship]) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InvoiceSummary {
+    pub id: Uuid,
+    pub owner_id: Uuid,
+    pub locked: bool,
+}
+
+impl From<Invoice> for InvoiceSummary {
+    fn from(invoice: Invoice) -> Self {
+        Self {
+            id: invoice.id,
+            owner_id: invoice.owner_id,
+            locked: invoice.locked,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    checker: PermissionChecker<User, Resource, Action, RequestContext>,
+    invoice_relationships: Arc<dyn FactSource<InvoiceRelationship>>,
+    invoices: Arc<Vec<Invoice>>,
+}
+
+impl AppState {
+    pub fn demo() -> Self {
+        let viewer_id = demo_viewer_id();
+        let invoices = Arc::new(demo_invoices());
+        let grants = invoices
+            .iter()
+            .filter(|invoice| invoice.owner_id != demo_owner_id())
+            .map(|invoice| InvoiceRelationship {
+                subject_id: viewer_id,
+                resource_id: invoice.id,
+                relation: Relation::Viewer,
+            });
+
+        Self {
+            checker: build_permission_checker(),
+            invoice_relationships: Arc::new(InMemoryRelationshipSource::new(grants)),
+            invoices,
+        }
+    }
+
+    fn request_session(&self) -> EvaluationSession {
+        let session = EvaluationSession::new();
+        session.register_arc::<InvoiceRelationship>(Arc::clone(&self.invoice_relationships));
+        session
+    }
+}
+
+fn demo_owner_id() -> Uuid {
+    Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap()
+}
+
+fn demo_viewer_id() -> Uuid {
+    Uuid::parse_str("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee").unwrap()
+}
+
+fn demo_invoices() -> Vec<Invoice> {
+    vec![
+        Invoice {
+            id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            owner_id: demo_owner_id(),
+            locked: false,
+            created_at: SystemTime::now() - Duration::from_secs(10 * 24 * 60 * 60),
+        },
+        Invoice {
+            id: Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
+            owner_id: Uuid::parse_str("cccccccc-cccc-cccc-cccc-cccccccccccc").unwrap(),
+            locked: false,
+            created_at: SystemTime::now() - Duration::from_secs(5 * 24 * 60 * 60),
+        },
+        Invoice {
+            id: Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap(),
+            owner_id: Uuid::parse_str("dddddddd-dddd-dddd-dddd-dddddddddddd").unwrap(),
+            locked: true,
+            created_at: SystemTime::now() - Duration::from_secs(2 * 24 * 60 * 60),
+        },
+    ]
+}
+
 /// --------------------------
 /// 2) Building Our Policies
 /// --------------------------
@@ -210,7 +341,37 @@ fn admin_override_policy() -> Box<dyn Policy<User, Resource, Action, RequestCont
         .build()
 }
 
-/// (B) `InvoiceEditingPolicy`
+/// (B) `InvoiceViewerPolicy`
+///     Allows viewing an invoice when the request user has a `viewer`
+///     relationship with that invoice. In a real service the source would wrap
+///     a database pool or graph client; this example uses an in-memory source
+///     so the request/session wiring is easy to see.
+fn invoice_viewer_policy() -> Box<dyn Policy<User, Resource, Action, RequestContext>> {
+    let is_invoice_view: Arc<dyn Policy<User, Resource, Action, RequestContext>> = Arc::from(
+        PolicyBuilder::<User, Resource, Action, RequestContext>::new("IsInvoiceView")
+            .when(|_user, action, resource, _ctx| {
+                matches!(action, Action::View) && matches!(resource, Resource::Invoice(_))
+            })
+            .build(),
+    );
+
+    let viewer_relationship: Arc<dyn Policy<User, Resource, Action, RequestContext>> =
+        Arc::new(RebacPolicy::new(
+            |user: &User| user.id,
+            |resource: &Resource| match resource {
+                Resource::Invoice(invoice) => invoice.id,
+                _ => Uuid::nil(),
+            },
+            Relation::Viewer,
+        ));
+
+    Box::new(
+        AndPolicy::try_new(vec![is_invoice_view, viewer_relationship])
+            .expect("invoice viewer policy should have guard and relationship checks"),
+    )
+}
+
+/// (C) `InvoiceEditingPolicy`
 ///     Allows editing an invoice if:
 ///       - It's an `Invoice` resource and the requested action is `Action::Edit`,
 ///       - The user is the invoice owner,
@@ -278,7 +439,7 @@ fn invoice_editing_policy() -> Box<dyn Policy<User, Resource, Action, RequestCon
     Box::new(and_policy)
 }
 
-/// (C) `PaymentApprovePolicy`
+/// (D) `PaymentApprovePolicy`
 ///     Allows approving a payment if:
 ///       - It's a `Payment` resource
 ///       - Action is `Action::ApprovePayment`
@@ -297,7 +458,7 @@ fn payment_approve_policy() -> Box<dyn Policy<User, Resource, Action, RequestCon
         .build()
 }
 
-/// (D) `PaymentRefundPolicy`
+/// (E) `PaymentRefundPolicy`
 ///     Allows refunding a payment if:
 ///       - It's a `Payment` resource
 ///       - Action is `Action::RefundPayment`
@@ -319,7 +480,7 @@ fn payment_refund_policy() -> Box<dyn Policy<User, Resource, Action, RequestCont
     ))
 }
 
-/// (E) Combine all relevant policies into a single `PermissionChecker`.
+/// (F) Combine all relevant policies into a single `PermissionChecker`.
 ///     The checker uses OR semantics by default: if ANY policy returns Granted,
 ///     the request is allowed.
 pub fn build_permission_checker() -> PermissionChecker<User, Resource, Action, RequestContext> {
@@ -329,6 +490,7 @@ pub fn build_permission_checker() -> PermissionChecker<User, Resource, Action, R
     // but note that OR short-circuits on the first Granted. So
     // e.g. if "AdminOverridePolicy" passes, we never evaluate the others.
     checker.add_policy(admin_override_policy());
+    checker.add_policy(invoice_viewer_policy());
     checker.add_policy(invoice_editing_policy());
     checker.add_policy(payment_approve_policy());
     checker.add_policy(payment_refund_policy());
@@ -342,19 +504,18 @@ pub fn build_permission_checker() -> PermissionChecker<User, Resource, Action, R
 
 pub async fn view_invoice_handler(
     Path(invoice_id): Path<Uuid>,
-    Extension(checker): Extension<PermissionChecker<User, Resource, Action, RequestContext>>,
+    State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
     overrides: InvoiceOverrides,
 ) -> impl IntoResponse {
     // Simulate DB fetch
     let invoice = overrides.build_invoice(invoice_id);
     let resource = Resource::Invoice(invoice.clone());
-    let context = RequestContext {
-        current_time: SystemTime::now(),
-    };
-    let session = EvaluationSession::empty();
+    let context = RequestContext::now();
+    let session = state.request_session();
 
-    if checker
+    if state
+        .checker
         .evaluate_in_session(&session, &user, &Action::View, &resource, &context)
         .await
         .is_granted()
@@ -363,15 +524,52 @@ pub async fn view_invoice_handler(
     } else {
         (
             StatusCode::FORBIDDEN,
-            "You are not authorized to edit this invoice",
+            "You are not authorized to view this invoice",
         )
             .into_response()
     }
 }
 
+pub async fn list_invoices_handler(
+    State(state): State<AppState>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> impl IntoResponse {
+    let context = RequestContext::now();
+    let action = Action::View;
+    let session = state.request_session();
+    let candidates = state
+        .invoices
+        .iter()
+        .cloned()
+        .map(Resource::Invoice)
+        .collect::<Vec<_>>();
+
+    // The session is request-scoped: app state owns the source, this request
+    // registers it, and the batch authorization call uses it for all invoices.
+    let visible = state
+        .checker
+        .filter_authorized_with_context_in_session_by(
+            &session,
+            &user,
+            &action,
+            candidates,
+            &context,
+            |resource| resource,
+        )
+        .await
+        .into_iter()
+        .filter_map(|resource| match resource {
+            Resource::Invoice(invoice) => Some(InvoiceSummary::from(invoice)),
+            Resource::Payment(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    Json(visible).into_response()
+}
+
 pub async fn edit_invoice_handler(
     Path(invoice_id): Path<Uuid>,
-    Extension(checker): Extension<PermissionChecker<User, Resource, Action, RequestContext>>,
+    State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
     overrides: InvoiceOverrides,
 ) -> impl IntoResponse {
@@ -380,12 +578,11 @@ pub async fn edit_invoice_handler(
 
     let resource = Resource::Invoice(invoice);
     let action = Action::Edit;
-    let context = RequestContext {
-        current_time: SystemTime::now(),
-    };
-    let session = EvaluationSession::empty();
+    let context = RequestContext::now();
+    let session = state.request_session();
 
-    let decision = checker
+    let decision = state
+        .checker
         .evaluate_in_session(&session, &user, &action, &resource, &context)
         .await;
 
@@ -403,7 +600,7 @@ pub async fn edit_invoice_handler(
 
 pub async fn approve_payment_handler(
     Path(payment_id): Path<Uuid>,
-    Extension(checker): Extension<PermissionChecker<User, Resource, Action, RequestContext>>,
+    State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
     headers: HeaderMap,
 ) -> impl IntoResponse {
@@ -413,12 +610,11 @@ pub async fn approve_payment_handler(
 
     let resource = Resource::Payment(payment);
     let action = Action::ApprovePayment;
-    let context = RequestContext {
-        current_time: SystemTime::now(),
-    };
-    let session = EvaluationSession::empty();
+    let context = RequestContext::now();
+    let session = state.request_session();
 
-    let decision = checker
+    let decision = state
+        .checker
         .evaluate_in_session(&session, &user, &action, &resource, &context)
         .await;
 
@@ -440,18 +636,20 @@ pub async fn approve_payment_handler(
 
 #[tokio::main]
 async fn main() {
-    // Build our single permission checker and share it with handlers as Extension state.
-    let checker = build_permission_checker();
+    // Build the long-lived checker and relationship source once, then create a
+    // fresh EvaluationSession inside each handler.
+    let state = AppState::demo();
 
     // Construct Axum Router
     let app = Router::new()
+        .route("/invoices", get(list_invoices_handler))
         .route("/invoices/{invoice_id}", get(view_invoice_handler))
         .route("/invoices/{invoice_id}/edit", post(edit_invoice_handler))
         .route(
             "/payments/{payment_id}/approve",
             post(approve_payment_handler),
         )
-        .layer(Extension(checker));
+        .with_state(state);
 
     // Run Axum App
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8000").await.unwrap();
@@ -809,10 +1007,9 @@ mod integration_tests {
     use tower::ServiceExt;
 
     fn test_app() -> Router {
-        let checker = build_permission_checker();
         Router::new()
             .route("/invoices/{invoice_id}/edit", post(edit_invoice_handler))
-            .layer(Extension(checker))
+            .with_state(AppState::demo())
     }
 
     #[tokio::test]

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -290,9 +290,9 @@ impl AppState {
     }
 
     fn request_session(&self) -> EvaluationSession {
-        let session = EvaluationSession::new();
-        session.register_arc::<InvoiceRelationship>(Arc::clone(&self.invoice_relationships));
-        session
+        EvaluationSession::builder()
+            .with_arc::<InvoiceRelationship>(Arc::clone(&self.invoice_relationships))
+            .build()
     }
 }
 

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -348,16 +348,14 @@ pub async fn view_invoice_handler(
 ) -> impl IntoResponse {
     // Simulate DB fetch
     let invoice = overrides.build_invoice(invoice_id);
+    let resource = Resource::Invoice(invoice.clone());
+    let context = RequestContext {
+        current_time: SystemTime::now(),
+    };
+    let session = EvaluationSession::empty();
 
     if checker
-        .evaluate_access(
-            &user,
-            &Action::View,
-            &Resource::Invoice(invoice.clone()),
-            &RequestContext {
-                current_time: SystemTime::now(),
-            },
-        )
+        .evaluate_in_session(&session, &user, &Action::View, &resource, &context)
         .await
         .is_granted()
     {
@@ -385,9 +383,10 @@ pub async fn edit_invoice_handler(
     let context = RequestContext {
         current_time: SystemTime::now(),
     };
+    let session = EvaluationSession::empty();
 
     let decision = checker
-        .evaluate_access(&user, &action, &resource, &context)
+        .evaluate_in_session(&session, &user, &action, &resource, &context)
         .await;
 
     if decision.is_granted() {
@@ -417,9 +416,10 @@ pub async fn approve_payment_handler(
     let context = RequestContext {
         current_time: SystemTime::now(),
     };
+    let session = EvaluationSession::empty();
 
     let decision = checker
-        .evaluate_access(&user, &action, &resource, &context)
+        .evaluate_in_session(&session, &user, &action, &resource, &context)
         .await;
 
     if decision.is_granted() {
@@ -463,6 +463,8 @@ async fn main() {
 mod tests {
     use super::*;
     use gatehouse::AccessEvaluation;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::time::{Duration, SystemTime};
 
     // Helper to quickly build an invoice with desired properties
@@ -489,6 +491,32 @@ mod tests {
     fn context_now() -> RequestContext {
         RequestContext {
             current_time: SystemTime::now(),
+        }
+    }
+
+    trait TestCheckerExt {
+        fn evaluate_access<'a>(
+            &'a self,
+            user: &'a User,
+            action: &'a Action,
+            resource: &'a Resource,
+            context: &'a RequestContext,
+        ) -> Pin<Box<dyn Future<Output = AccessEvaluation> + Send + 'a>>;
+    }
+
+    impl TestCheckerExt for PermissionChecker<User, Resource, Action, RequestContext> {
+        fn evaluate_access<'a>(
+            &'a self,
+            user: &'a User,
+            action: &'a Action,
+            resource: &'a Resource,
+            context: &'a RequestContext,
+        ) -> Pin<Box<dyn Future<Output = AccessEvaluation> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::empty();
+                self.evaluate_in_session(&session, user, action, resource, context)
+                    .await
+            })
         }
     }
 

--- a/examples/combinator_policy.rs
+++ b/examples/combinator_policy.rs
@@ -50,12 +50,9 @@ struct CountingPolicy {
 
 #[async_trait]
 impl Policy<User, Document, ViewAction, EmptyContext> for CountingPolicy {
-    async fn evaluate_access(
+    async fn evaluate(
         &self,
-        _subject: &User,
-        _action: &ViewAction,
-        _resource: &Document,
-        _context: &EmptyContext,
+        _ctx: &EvalCtx<'_, User, Document, ViewAction, EmptyContext>,
     ) -> PolicyEvalResult {
         // Increment evaluation counter
         self.counter.fetch_add(1, Ordering::SeqCst);
@@ -63,19 +60,19 @@ impl Policy<User, Document, ViewAction, EmptyContext> for CountingPolicy {
 
         if self.allow {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some(format!("{} grants access", self.name)),
             }
         } else {
             PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: format!("{} denies access", self.name),
             }
         }
     }
 
-    fn policy_type(&self) -> String {
-        format!("CountingPolicy({})", self.name)
+    fn policy_type(&self) -> &str {
+        &self.name
     }
 }
 
@@ -85,6 +82,7 @@ async fn main() {
     let document = Document::new();
     let action = ViewAction;
     let context = EmptyContext;
+    let session = EvaluationSession::new();
 
     println!("=== AND Policy Short-Circuit Example ===");
     {
@@ -107,7 +105,13 @@ async fn main() {
 
         println!("Evaluating AND(DenyFirst, AllowSecond):");
         let result = and_policy
-            .evaluate_access(&user, &action, &document, &context)
+            .evaluate(&EvalCtx {
+                session: &session,
+                subject: &user,
+                action: &action,
+                resource: &document,
+                context: &context,
+            })
             .await;
         println!(
             "Result: {}",
@@ -145,7 +149,13 @@ async fn main() {
 
         println!("Evaluating OR(AllowFirst, DenySecond):");
         let result = or_policy
-            .evaluate_access(&user, &action, &document, &context)
+            .evaluate(&EvalCtx {
+                session: &session,
+                subject: &user,
+                action: &action,
+                resource: &document,
+                context: &context,
+            })
             .await;
         println!(
             "Result: {}",
@@ -193,7 +203,13 @@ async fn main() {
 
         println!("Evaluating OR(AND(DenyInner, AllowInner), AllowOuter):");
         let result = complex_policy
-            .evaluate_access(&user, &action, &document, &context)
+            .evaluate(&EvalCtx {
+                session: &session,
+                subject: &user,
+                action: &action,
+                resource: &document,
+                context: &context,
+            })
             .await;
         println!(
             "Result: {} for document with ID {} for user with ID {}",

--- a/examples/groups_policy.rs
+++ b/examples/groups_policy.rs
@@ -36,28 +36,25 @@ struct OrgAdminPolicy;
 
 #[async_trait]
 impl Policy<SubjectV2, Group, GroupManagementAction, EmptyContext> for OrgAdminPolicy {
-    async fn evaluate_access(
+    async fn evaluate(
         &self,
-        subject: &SubjectV2,
-        _action: &GroupManagementAction,
-        _resource: &Group,
-        _context: &EmptyContext,
+        ctx: &EvalCtx<'_, SubjectV2, Group, GroupManagementAction, EmptyContext>,
     ) -> PolicyEvalResult {
-        if subject.authorization_details.is_org_admin {
+        if ctx.subject.authorization_details.is_org_admin {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some("User is organization admin".to_string()),
             }
         } else {
             PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: "User is not organization admin".to_string(),
             }
         }
     }
 
-    fn policy_type(&self) -> String {
-        "OrgAdminPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "OrgAdminPolicy"
     }
 }
 
@@ -66,33 +63,31 @@ struct StaffPolicy;
 
 #[async_trait]
 impl Policy<SubjectV2, Group, GroupManagementAction, EmptyContext> for StaffPolicy {
-    async fn evaluate_access(
+    async fn evaluate(
         &self,
-        subject: &SubjectV2,
-        _action: &GroupManagementAction,
-        _resource: &Group,
-        _context: &EmptyContext,
+        ctx: &EvalCtx<'_, SubjectV2, Group, GroupManagementAction, EmptyContext>,
     ) -> PolicyEvalResult {
-        if subject
+        if ctx
+            .subject
             .authorization_details
             .permissions
             .iter()
             .any(|p| p.scope == "staff")
         {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some("User has staff permission".to_string()),
             }
         } else {
             PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: "User lacks staff permission".to_string(),
             }
         }
     }
 
-    fn policy_type(&self) -> String {
-        "StaffPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "StaffPolicy"
     }
 }
 
@@ -124,8 +119,9 @@ async fn main() {
     let context = EmptyContext;
 
     let checker = create_group_management_checker();
+    let session = EvaluationSession::empty();
     let result = checker
-        .evaluate_access(&subject, &action, &group, &context)
+        .evaluate_in_session(&session, &subject, &action, &group, &context)
         .await;
     assert!(result.is_granted());
     println!(

--- a/examples/in_ram_rebac.rs
+++ b/examples/in_ram_rebac.rs
@@ -1,0 +1,172 @@
+//! In-RAM FactSource-backed ReBAC example.
+//!
+//! This is the small, production-shaped version of the v0.3 fact model: the
+//! application owns one shared relationship source, each request creates a fresh
+//! `EvaluationSession`, and list endpoints batch relationship checks through
+//! the same `PermissionChecker` used for single-resource checks.
+
+use async_trait::async_trait;
+use dashmap::DashSet;
+use gatehouse::{
+    EvaluationSession, FactLoadResult, FactSource, PermissionChecker, RebacPolicy,
+    RelationshipQuery,
+};
+use std::fmt;
+use std::sync::Arc;
+use uuid::Uuid;
+
+type RelationshipKey = RelationshipQuery<Uuid, Uuid, Relation>;
+
+#[derive(Debug, Clone)]
+struct User {
+    id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+struct Document {
+    id: Uuid,
+    title: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct View;
+
+#[derive(Debug, Clone)]
+struct RequestContext;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Relation {
+    Viewer,
+    Editor,
+}
+
+impl fmt::Display for Relation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Viewer => f.write_str("viewer"),
+            Self::Editor => f.write_str("editor"),
+        }
+    }
+}
+
+#[derive(Default)]
+struct InRamRelationships {
+    grants: DashSet<RelationshipKey>,
+}
+
+impl InRamRelationships {
+    fn grant(&self, subject_id: Uuid, resource_id: Uuid, relation: Relation) {
+        self.grants.insert(RelationshipKey {
+            subject_id,
+            resource_id,
+            relation,
+        });
+    }
+}
+
+#[async_trait]
+impl FactSource<RelationshipKey> for InRamRelationships {
+    async fn load_many(&self, keys: &[RelationshipKey]) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+            .collect()
+    }
+}
+
+fn request_session(relationships: &Arc<dyn FactSource<RelationshipKey>>) -> EvaluationSession {
+    EvaluationSession::builder()
+        .with_arc::<RelationshipKey>(Arc::clone(relationships))
+        .build()
+}
+
+fn build_checker() -> PermissionChecker<User, Document, View, RequestContext> {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(RebacPolicy::new(
+        |user: &User| user.id,
+        |document: &Document| document.id,
+        Relation::Viewer,
+    ));
+    checker
+}
+
+#[tokio::main]
+async fn main() {
+    let user = User { id: Uuid::new_v4() };
+    let documents = vec![
+        Document {
+            id: Uuid::new_v4(),
+            title: "roadmap",
+        },
+        Document {
+            id: Uuid::new_v4(),
+            title: "incident report",
+        },
+        Document {
+            id: Uuid::new_v4(),
+            title: "finance plan",
+        },
+    ];
+
+    let store = Arc::new(InRamRelationships::default());
+    store.grant(user.id, documents[0].id, Relation::Viewer);
+    store.grant(user.id, documents[1].id, Relation::Viewer);
+    store.grant(user.id, documents[1].id, Relation::Editor);
+    let relationships: Arc<dyn FactSource<RelationshipKey>> = store;
+
+    let checker = build_checker();
+    let context = RequestContext;
+
+    let first_request = request_session(&relationships);
+    let visible = checker
+        .filter_authorized_with_context_in_session_by(
+            &first_request,
+            &user,
+            &View,
+            documents.clone(),
+            &context,
+            |document| document,
+        )
+        .await;
+    println!(
+        "visible documents: {:?}",
+        visible
+            .iter()
+            .map(|document| document.title)
+            .collect::<Vec<_>>()
+    );
+
+    let second_request = request_session(&relationships);
+    let can_view_finance = checker
+        .evaluate_in_session(&second_request, &user, &View, &documents[2], &context)
+        .await;
+    assert!(!can_view_finance.is_granted());
+
+    let shared = Arc::clone(&relationships);
+    let concurrent_requests = (0..4)
+        .map(|_| {
+            let checker = checker.clone();
+            let user = user.clone();
+            let documents = documents.clone();
+            let relationships = Arc::clone(&shared);
+            tokio::spawn(async move {
+                let session = request_session(&relationships);
+                let context = RequestContext;
+                checker
+                    .filter_authorized_with_context_in_session_by(
+                        &session,
+                        &user,
+                        &View,
+                        documents,
+                        &context,
+                        |document| document,
+                    )
+                    .await
+                    .len()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for request in concurrent_requests {
+        assert_eq!(request.await.unwrap(), 2);
+    }
+}

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -1,0 +1,245 @@
+use async_trait::async_trait;
+use gatehouse::{PermissionChecker, RebacPolicy, RelationshipResolver};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio_postgres::{Client, NoTls, Statement};
+use uuid::Uuid;
+
+static UNIT_CONTEXT: () = ();
+
+#[derive(Clone)]
+struct User {
+    id: Uuid,
+}
+
+#[derive(Clone)]
+struct Post {
+    id: Uuid,
+}
+
+struct View;
+
+#[derive(Clone)]
+struct PgRelationshipResolver {
+    client: Arc<Client>,
+    point_stmt: Arc<Statement>,
+    bulk_stmt: Arc<Statement>,
+}
+
+#[async_trait]
+impl RelationshipResolver<User, Post, String> for PgRelationshipResolver {
+    async fn has_relationship(
+        &self,
+        subject: &User,
+        resource: &Post,
+        relationship: &String,
+    ) -> bool {
+        self.client
+            .query_one(
+                &*self.point_stmt,
+                &[&subject.id, relationship, &resource.id],
+            )
+            .await
+            .expect("point relationship query should succeed")
+            .get(0)
+    }
+
+    async fn has_relationship_batch<'item>(
+        &self,
+        subject: &'item User,
+        resources: &'item [&'item Post],
+        relationship: &'item String,
+    ) -> Vec<bool> {
+        let post_ids = resources.iter().map(|post| post.id).collect::<Vec<_>>();
+        self.client
+            .query(&*self.bulk_stmt, &[&subject.id, relationship, &post_ids])
+            .await
+            .expect("bulk relationship query should succeed")
+            .into_iter()
+            .map(|row| row.get("allowed"))
+            .collect()
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "host=localhost port=15432 user=postgres password=test dbname=awa_test".to_string()
+    });
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("connect to PostgreSQL 18");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("postgres connection error: {error}");
+        }
+    });
+    let client = Arc::new(client);
+
+    let version: String = client
+        .query_one("SELECT version()", &[])
+        .await
+        .expect("version query should succeed")
+        .get(0);
+    println!("{version}");
+
+    client
+        .batch_execute(
+            "
+            DROP TABLE IF EXISTS gatehouse_spike_post_grants;
+            CREATE UNLOGGED TABLE gatehouse_spike_post_grants (
+                subject_id uuid NOT NULL,
+                post_id uuid NOT NULL,
+                relationship text NOT NULL,
+                PRIMARY KEY (subject_id, post_id, relationship)
+            );
+            ",
+        )
+        .await
+        .expect("setup schema");
+
+    let subject = User { id: Uuid::new_v4() };
+    let relationship = "viewer".to_string();
+    let posts = (0..10_000)
+        .map(|_| Post { id: Uuid::new_v4() })
+        .collect::<Vec<_>>();
+    let granted_ids = posts
+        .iter()
+        .enumerate()
+        .filter_map(|(index, post)| (index % 2 == 0).then_some(post.id))
+        .collect::<Vec<_>>();
+    let relationships = vec![relationship.clone(); granted_ids.len()];
+    let subject_ids = vec![subject.id; granted_ids.len()];
+
+    client
+        .execute(
+            "
+            INSERT INTO gatehouse_spike_post_grants (subject_id, post_id, relationship)
+            SELECT *
+            FROM unnest($1::uuid[], $2::uuid[], $3::text[])
+            ",
+            &[&subject_ids, &granted_ids, &relationships],
+        )
+        .await
+        .expect("seed grants");
+
+    let point_stmt = Arc::new(
+        client
+            .prepare(
+                "
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM gatehouse_spike_post_grants
+                    WHERE subject_id = $1
+                      AND relationship = $2
+                      AND post_id = $3
+                ) AS allowed
+                ",
+            )
+            .await
+            .expect("prepare point query"),
+    );
+    let bulk_stmt = Arc::new(
+        client
+            .prepare(
+                "
+                WITH candidate_posts AS (
+                    SELECT post_id, ord
+                    FROM unnest($3::uuid[]) WITH ORDINALITY AS input(post_id, ord)
+                )
+                SELECT
+                    COALESCE(bool_or(g.post_id IS NOT NULL), false) AS allowed
+                FROM candidate_posts c
+                LEFT JOIN gatehouse_spike_post_grants g
+                  ON g.subject_id = $1
+                 AND g.relationship = $2
+                 AND g.post_id = c.post_id
+                GROUP BY c.ord, c.post_id
+                ORDER BY c.ord
+                ",
+            )
+            .await
+            .expect("prepare bulk query"),
+    );
+
+    let resolver = PgRelationshipResolver {
+        client,
+        point_stmt,
+        bulk_stmt,
+    };
+    let policy = RebacPolicy::<User, Post, View, (), _, _>::new(relationship, resolver);
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(policy);
+
+    println!("size,naive_ms,bulk_ms,allowed,improvement");
+    for &size in &[10usize, 100, 1_000, 5_000, 10_000] {
+        let sample = posts.iter().take(size).cloned().collect::<Vec<_>>();
+        let naive = measure(|| async {
+            let mut allowed = 0usize;
+            for post in &sample {
+                if checker
+                    .evaluate_access(&subject, &View, post, &UNIT_CONTEXT)
+                    .await
+                    .is_granted()
+                {
+                    allowed += 1;
+                }
+            }
+            allowed
+        })
+        .await;
+
+        let bulk = measure(|| async {
+            checker
+                .filter_authorized_with_context_by(
+                    &subject,
+                    &View,
+                    sample.clone(),
+                    &UNIT_CONTEXT,
+                    |post| post,
+                )
+                .await
+                .len()
+        })
+        .await;
+
+        assert_eq!(naive.output, bulk.output);
+        println!(
+            "{size},{:.3},{:.3},{},x{:.1}",
+            naive.elapsed.as_secs_f64() * 1_000.0,
+            bulk.elapsed.as_secs_f64() * 1_000.0,
+            bulk.output,
+            naive.elapsed.as_secs_f64() / bulk.elapsed.as_secs_f64()
+        );
+    }
+}
+
+struct Measurement<T> {
+    elapsed: Duration,
+    output: T,
+}
+
+async fn measure<F, Fut, T>(mut f: F) -> Measurement<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    let mut best_elapsed = Duration::MAX;
+    let mut best_output = None;
+
+    for _ in 0..3 {
+        let start = Instant::now();
+        let output = f().await;
+        let elapsed = start.elapsed();
+        if elapsed < best_elapsed {
+            best_elapsed = elapsed;
+            best_output = Some(output);
+        }
+    }
+
+    Measurement {
+        elapsed: best_elapsed,
+        output: best_output.expect("measurement should run at least once"),
+    }
+}

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -14,12 +14,14 @@ use gatehouse::{
     EvaluationSession, FactLoadError, FactLoadResult, FactSource, PermissionChecker, PolicyBuilder,
     RebacPolicy, RelationshipQuery,
 };
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_postgres::{Client, NoTls, Statement};
 use uuid::Uuid;
 
 static UNIT_CONTEXT: () = ();
+type RelationshipKey = RelationshipQuery<Uuid, Uuid, Relation>;
 
 #[derive(Clone)]
 struct User {
@@ -34,6 +36,25 @@ struct Post {
 
 struct View;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Relation {
+    Viewer,
+}
+
+impl Relation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Viewer => "viewer",
+        }
+    }
+}
+
+impl fmt::Display for Relation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Clone)]
 struct PgRelationshipSource {
     client: Arc<Client>,
@@ -42,15 +63,13 @@ struct PgRelationshipSource {
 }
 
 impl PgRelationshipSource {
-    async fn load_point(
-        &self,
-        key: &RelationshipQuery<Uuid, Uuid, String>,
-    ) -> FactLoadResult<bool> {
+    async fn load_point(&self, key: &RelationshipKey) -> FactLoadResult<bool> {
+        let relationship = key.relation.as_str();
         match self
             .client
             .query_one(
                 &*self.point_stmt,
-                &[&key.subject_id, &key.relation, &key.resource_id],
+                &[&key.subject_id, &relationship, &key.resource_id],
             )
             .await
         {
@@ -59,15 +78,12 @@ impl PgRelationshipSource {
         }
     }
 
-    async fn load_bulk(
-        &self,
-        keys: &[RelationshipQuery<Uuid, Uuid, String>],
-    ) -> Vec<FactLoadResult<bool>> {
+    async fn load_bulk(&self, keys: &[RelationshipKey]) -> Vec<FactLoadResult<bool>> {
         let subject_ids = keys.iter().map(|key| key.subject_id).collect::<Vec<_>>();
         let post_ids = keys.iter().map(|key| key.resource_id).collect::<Vec<_>>();
         let relationships = keys
             .iter()
-            .map(|key| key.relation.clone())
+            .map(|key| key.relation.as_str())
             .collect::<Vec<_>>();
 
         match self
@@ -90,11 +106,8 @@ impl PgRelationshipSource {
 }
 
 #[async_trait]
-impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource {
-    async fn load_many(
-        &self,
-        keys: &[RelationshipQuery<Uuid, Uuid, String>],
-    ) -> Vec<FactLoadResult<bool>> {
+impl FactSource<RelationshipKey> for PgRelationshipSource {
+    async fn load_many(&self, keys: &[RelationshipKey]) -> Vec<FactLoadResult<bool>> {
         if keys.len() == 1 {
             return vec![self.load_point(&keys[0]).await];
         }
@@ -103,10 +116,7 @@ impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource 
     }
 }
 
-async fn assert_point_and_bulk_agree(
-    source: &PgRelationshipSource,
-    keys: &[RelationshipQuery<Uuid, Uuid, String>],
-) {
+async fn assert_point_and_bulk_agree(source: &PgRelationshipSource, keys: &[RelationshipKey]) {
     for key in keys {
         let point = source.load_point(key).await;
         let bulk = source
@@ -127,6 +137,28 @@ async fn assert_point_and_bulk_agree(
             }
         }
     }
+}
+
+fn build_checker() -> PermissionChecker<User, Post, View, ()> {
+    let public_posts = PolicyBuilder::<User, Post, View, ()>::new("PublicPost")
+        .resources(|post| post.public)
+        .build();
+    let viewer_relationship = RebacPolicy::new(
+        |user: &User| user.id,
+        |post: &Post| post.id,
+        Relation::Viewer,
+    );
+
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(public_posts);
+    checker.add_policy(viewer_relationship);
+    checker
+}
+
+fn session_with(source: &Arc<dyn FactSource<RelationshipKey>>) -> EvaluationSession {
+    let session = EvaluationSession::new();
+    session.register_arc::<RelationshipKey>(Arc::clone(source));
+    session
 }
 
 #[tokio::main]
@@ -168,7 +200,6 @@ async fn main() {
         .expect("setup schema");
 
     let subject = User { id: Uuid::new_v4() };
-    let relationship = "viewer".to_string();
     let posts = (0..10_000)
         .map(|index| Post {
             id: Uuid::new_v4(),
@@ -180,7 +211,7 @@ async fn main() {
         .enumerate()
         .filter_map(|(index, post)| (!post.public && index % 2 == 0).then_some(post.id))
         .collect::<Vec<_>>();
-    let relationships = vec![relationship.clone(); granted_ids.len()];
+    let relationships = vec![Relation::Viewer.as_str(); granted_ids.len()];
     let subject_ids = vec![subject.id; granted_ids.len()];
 
     client
@@ -250,7 +281,7 @@ async fn main() {
                     .find(|post| granted_ids.contains(&post.id))
                     .expect("fixture should include a granted private post")
                     .id,
-                relation: relationship.clone(),
+                relation: Relation::Viewer,
             },
             RelationshipQuery {
                 subject_id: subject.id,
@@ -261,20 +292,13 @@ async fn main() {
                     .expect("fixture should include a denied private post")
                     .1
                     .id,
-                relation: relationship.clone(),
+                relation: Relation::Viewer,
             },
         ],
     )
     .await;
-    let source: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, String>>> = source;
-    let public_posts = PolicyBuilder::<User, Post, View, ()>::new("PublicPost")
-        .resources(|post| post.public)
-        .build();
-    let viewer_relationship =
-        RebacPolicy::new(|user: &User| user.id, |post: &Post| post.id, relationship);
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(public_posts);
-    checker.add_policy(viewer_relationship);
+    let source: Arc<dyn FactSource<RelationshipKey>> = source;
+    let checker = build_checker();
 
     println!("size,relationship_checks,naive_ms,bulk_ms,allowed,improvement");
     for &size in &[10usize, 100, 1_000, 5_000, 10_000] {
@@ -283,8 +307,7 @@ async fn main() {
         let naive = measure(|| async {
             let mut allowed = 0usize;
             for post in &sample {
-                let session = EvaluationSession::new();
-                session.register_arc::<RelationshipQuery<Uuid, Uuid, String>>(Arc::clone(&source));
+                let session = session_with(&source);
                 if checker
                     .evaluate_in_session(&session, &subject, &View, post, &UNIT_CONTEXT)
                     .await
@@ -298,8 +321,7 @@ async fn main() {
         .await;
 
         let bulk = measure(|| async {
-            let session = EvaluationSession::new();
-            session.register_arc::<RelationshipQuery<Uuid, Uuid, String>>(Arc::clone(&source));
+            let session = session_with(&source);
             checker
                 .filter_authorized_with_context_in_session_by(
                     &session,

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -1,7 +1,18 @@
+//! PostgreSQL-backed batch ReBAC example.
+//!
+//! This models a list endpoint with two policies:
+//!
+//! - public posts are visible through an in-memory predicate policy
+//! - private posts are visible when a `viewer` relationship exists in PostgreSQL
+//!
+//! The policy stack stays in Gatehouse. PostgreSQL is only responsible for
+//! loading relationship facts, and `EvaluationSession` batches, deduplicates,
+//! caches, and expands those facts back into caller order.
+
 use async_trait::async_trait;
 use gatehouse::{
-    EvaluationSession, FactLoadError, FactLoadResult, FactSource, PermissionChecker, RebacPolicy,
-    RelationshipQuery,
+    EvaluationSession, FactLoadError, FactLoadResult, FactSource, PermissionChecker, PolicyBuilder,
+    RebacPolicy, RelationshipQuery,
 };
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -18,6 +29,7 @@ struct User {
 #[derive(Clone)]
 struct Post {
     id: Uuid,
+    public: bool,
 }
 
 struct View;
@@ -143,8 +155,8 @@ async fn main() {
     client
         .batch_execute(
             "
-            DROP TABLE IF EXISTS gatehouse_spike_post_grants;
-            CREATE UNLOGGED TABLE gatehouse_spike_post_grants (
+            DROP TABLE IF EXISTS gatehouse_example_post_relationships;
+            CREATE UNLOGGED TABLE gatehouse_example_post_relationships (
                 subject_id uuid NOT NULL,
                 post_id uuid NOT NULL,
                 relationship text NOT NULL,
@@ -158,12 +170,15 @@ async fn main() {
     let subject = User { id: Uuid::new_v4() };
     let relationship = "viewer".to_string();
     let posts = (0..10_000)
-        .map(|_| Post { id: Uuid::new_v4() })
+        .map(|index| Post {
+            id: Uuid::new_v4(),
+            public: index % 5 == 0,
+        })
         .collect::<Vec<_>>();
     let granted_ids = posts
         .iter()
         .enumerate()
-        .filter_map(|(index, post)| (index % 2 == 0).then_some(post.id))
+        .filter_map(|(index, post)| (!post.public && index % 2 == 0).then_some(post.id))
         .collect::<Vec<_>>();
     let relationships = vec![relationship.clone(); granted_ids.len()];
     let subject_ids = vec![subject.id; granted_ids.len()];
@@ -171,7 +186,7 @@ async fn main() {
     client
         .execute(
             "
-            INSERT INTO gatehouse_spike_post_grants (subject_id, post_id, relationship)
+            INSERT INTO gatehouse_example_post_relationships (subject_id, post_id, relationship)
             SELECT *
             FROM unnest($1::uuid[], $2::uuid[], $3::text[])
             ",
@@ -186,7 +201,7 @@ async fn main() {
                 "
                 SELECT EXISTS (
                     SELECT 1
-                    FROM gatehouse_spike_post_grants
+                    FROM gatehouse_example_post_relationships
                     WHERE subject_id = $1
                       AND relationship = $2
                       AND post_id = $3
@@ -208,7 +223,7 @@ async fn main() {
                 SELECT
                     COALESCE(bool_or(g.post_id IS NOT NULL), false) AS allowed
                 FROM candidate_relationships c
-                LEFT JOIN gatehouse_spike_post_grants g
+                LEFT JOIN gatehouse_example_post_relationships g
                   ON g.subject_id = c.subject_id
                  AND g.relationship = c.relationship
                  AND g.post_id = c.post_id
@@ -230,25 +245,41 @@ async fn main() {
         &[
             RelationshipQuery {
                 subject_id: subject.id,
-                resource_id: posts[0].id,
+                resource_id: posts
+                    .iter()
+                    .find(|post| granted_ids.contains(&post.id))
+                    .expect("fixture should include a granted private post")
+                    .id,
                 relation: relationship.clone(),
             },
             RelationshipQuery {
                 subject_id: subject.id,
-                resource_id: posts[1].id,
+                resource_id: posts
+                    .iter()
+                    .enumerate()
+                    .find(|(index, post)| !post.public && index % 2 == 1)
+                    .expect("fixture should include a denied private post")
+                    .1
+                    .id,
                 relation: relationship.clone(),
             },
         ],
     )
     .await;
     let source: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, String>>> = source;
-    let policy = RebacPolicy::new(|user: &User| user.id, |post: &Post| post.id, relationship);
+    let public_posts = PolicyBuilder::<User, Post, View, ()>::new("PublicPost")
+        .resources(|post| post.public)
+        .build();
+    let viewer_relationship =
+        RebacPolicy::new(|user: &User| user.id, |post: &Post| post.id, relationship);
     let mut checker = PermissionChecker::new();
-    checker.add_policy(policy);
+    checker.add_policy(public_posts);
+    checker.add_policy(viewer_relationship);
 
-    println!("size,naive_ms,bulk_ms,allowed,improvement");
+    println!("size,relationship_checks,naive_ms,bulk_ms,allowed,improvement");
     for &size in &[10usize, 100, 1_000, 5_000, 10_000] {
         let sample = posts.iter().take(size).cloned().collect::<Vec<_>>();
+        let relationship_checks = sample.iter().filter(|post| !post.public).count();
         let naive = measure(|| async {
             let mut allowed = 0usize;
             for post in &sample {
@@ -285,7 +316,7 @@ async fn main() {
 
         assert_eq!(naive.output, bulk.output);
         println!(
-            "{size},{:.3},{:.3},{},x{:.1}",
+            "{size},{relationship_checks},{:.3},{:.3},{},x{:.1}",
             naive.elapsed.as_secs_f64() * 1_000.0,
             bulk.elapsed.as_secs_f64() * 1_000.0,
             bulk.output,

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use gatehouse::{PermissionChecker, RebacPolicy, RelationshipResolver};
+use gatehouse::{
+    EvaluationSession, FactLoadResult, FactSource, PermissionChecker, RebacPolicy,
+    RelationshipQuery,
+};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_postgres::{Client, NoTls, Statement};
@@ -20,43 +23,45 @@ struct Post {
 struct View;
 
 #[derive(Clone)]
-struct PgRelationshipResolver {
+struct PgRelationshipSource {
     client: Arc<Client>,
     point_stmt: Arc<Statement>,
     bulk_stmt: Arc<Statement>,
 }
 
 #[async_trait]
-impl RelationshipResolver<User, Post, String> for PgRelationshipResolver {
-    async fn has_relationship(
+impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource {
+    async fn load_many(
         &self,
-        subject: &User,
-        resource: &Post,
-        relationship: &String,
-    ) -> bool {
-        self.client
-            .query_one(
-                &*self.point_stmt,
-                &[&subject.id, relationship, &resource.id],
-            )
-            .await
-            .expect("point relationship query should succeed")
-            .get(0)
-    }
+        keys: &[RelationshipQuery<Uuid, Uuid, String>],
+    ) -> Vec<FactLoadResult<bool>> {
+        if keys.len() == 1 {
+            let key = &keys[0];
+            return vec![FactLoadResult::Found(
+                self.client
+                    .query_one(
+                        &*self.point_stmt,
+                        &[&key.subject_id, &key.relation, &key.resource_id],
+                    )
+                    .await
+                    .expect("point relationship query should succeed")
+                    .get(0),
+            )];
+        }
 
-    async fn has_relationship_batch<'item>(
-        &self,
-        subject: &'item User,
-        resources: &'item [&'item Post],
-        relationship: &'item String,
-    ) -> Vec<bool> {
-        let post_ids = resources.iter().map(|post| post.id).collect::<Vec<_>>();
+        let subject_ids = keys.iter().map(|key| key.subject_id).collect::<Vec<_>>();
+        let post_ids = keys.iter().map(|key| key.resource_id).collect::<Vec<_>>();
+        let relationships = keys
+            .iter()
+            .map(|key| key.relation.clone())
+            .collect::<Vec<_>>();
+
         self.client
-            .query(&*self.bulk_stmt, &[&subject.id, relationship, &post_ids])
+            .query(&*self.bulk_stmt, &[&subject_ids, &post_ids, &relationships])
             .await
             .expect("bulk relationship query should succeed")
             .into_iter()
-            .map(|row| row.get("allowed"))
+            .map(|row| FactLoadResult::Found(row.get("allowed")))
             .collect()
     }
 }
@@ -144,18 +149,19 @@ async fn main() {
         client
             .prepare(
                 "
-                WITH candidate_posts AS (
-                    SELECT post_id, ord
-                    FROM unnest($3::uuid[]) WITH ORDINALITY AS input(post_id, ord)
+                WITH candidate_relationships AS (
+                    SELECT subject_id, post_id, relationship, ord
+                    FROM unnest($1::uuid[], $2::uuid[], $3::text[])
+                        WITH ORDINALITY AS input(subject_id, post_id, relationship, ord)
                 )
                 SELECT
                     COALESCE(bool_or(g.post_id IS NOT NULL), false) AS allowed
-                FROM candidate_posts c
+                FROM candidate_relationships c
                 LEFT JOIN gatehouse_spike_post_grants g
-                  ON g.subject_id = $1
-                 AND g.relationship = $2
+                  ON g.subject_id = c.subject_id
+                 AND g.relationship = c.relationship
                  AND g.post_id = c.post_id
-                GROUP BY c.ord, c.post_id
+                GROUP BY c.ord, c.subject_id, c.post_id, c.relationship
                 ORDER BY c.ord
                 ",
             )
@@ -163,12 +169,13 @@ async fn main() {
             .expect("prepare bulk query"),
     );
 
-    let resolver = PgRelationshipResolver {
-        client,
-        point_stmt,
-        bulk_stmt,
-    };
-    let policy = RebacPolicy::<User, Post, View, (), _, _>::new(relationship, resolver);
+    let source: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, String>>> =
+        Arc::new(PgRelationshipSource {
+            client,
+            point_stmt,
+            bulk_stmt,
+        });
+    let policy = RebacPolicy::new(|user: &User| user.id, |post: &Post| post.id, relationship);
     let mut checker = PermissionChecker::new();
     checker.add_policy(policy);
 
@@ -178,8 +185,10 @@ async fn main() {
         let naive = measure(|| async {
             let mut allowed = 0usize;
             for post in &sample {
+                let session = EvaluationSession::new();
+                session.register_arc::<RelationshipQuery<Uuid, Uuid, String>>(Arc::clone(&source));
                 if checker
-                    .evaluate_access(&subject, &View, post, &UNIT_CONTEXT)
+                    .evaluate_in_session(&session, &subject, &View, post, &UNIT_CONTEXT)
                     .await
                     .is_granted()
                 {
@@ -191,8 +200,11 @@ async fn main() {
         .await;
 
         let bulk = measure(|| async {
+            let session = EvaluationSession::new();
+            session.register_arc::<RelationshipQuery<Uuid, Uuid, String>>(Arc::clone(&source));
             checker
-                .filter_authorized_with_context_by(
+                .filter_authorized_with_context_in_session_by(
+                    &session,
                     &subject,
                     &View,
                     sample.clone(),

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use gatehouse::{
-    EvaluationSession, FactLoadResult, FactSource, PermissionChecker, RebacPolicy,
+    EvaluationSession, FactLoadError, FactLoadResult, FactSource, PermissionChecker, RebacPolicy,
     RelationshipQuery,
 };
 use std::sync::Arc;
@@ -29,26 +29,28 @@ struct PgRelationshipSource {
     bulk_stmt: Arc<Statement>,
 }
 
-#[async_trait]
-impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource {
-    async fn load_many(
+impl PgRelationshipSource {
+    async fn load_point(
+        &self,
+        key: &RelationshipQuery<Uuid, Uuid, String>,
+    ) -> FactLoadResult<bool> {
+        match self
+            .client
+            .query_one(
+                &*self.point_stmt,
+                &[&key.subject_id, &key.relation, &key.resource_id],
+            )
+            .await
+        {
+            Ok(row) => FactLoadResult::Found(row.get("allowed")),
+            Err(error) => FactLoadResult::Error(FactLoadError::backend(error)),
+        }
+    }
+
+    async fn load_bulk(
         &self,
         keys: &[RelationshipQuery<Uuid, Uuid, String>],
     ) -> Vec<FactLoadResult<bool>> {
-        if keys.len() == 1 {
-            let key = &keys[0];
-            return vec![FactLoadResult::Found(
-                self.client
-                    .query_one(
-                        &*self.point_stmt,
-                        &[&key.subject_id, &key.relation, &key.resource_id],
-                    )
-                    .await
-                    .expect("point relationship query should succeed")
-                    .get(0),
-            )];
-        }
-
         let subject_ids = keys.iter().map(|key| key.subject_id).collect::<Vec<_>>();
         let post_ids = keys.iter().map(|key| key.resource_id).collect::<Vec<_>>();
         let relationships = keys
@@ -56,13 +58,62 @@ impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource 
             .map(|key| key.relation.clone())
             .collect::<Vec<_>>();
 
-        self.client
+        match self
+            .client
             .query(&*self.bulk_stmt, &[&subject_ids, &post_ids, &relationships])
             .await
-            .expect("bulk relationship query should succeed")
+        {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|row| FactLoadResult::Found(row.get("allowed")))
+                .collect(),
+            Err(error) => {
+                let error = FactLoadError::backend(error);
+                keys.iter()
+                    .map(|_| FactLoadResult::Error(error.clone()))
+                    .collect()
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for PgRelationshipSource {
+    async fn load_many(
+        &self,
+        keys: &[RelationshipQuery<Uuid, Uuid, String>],
+    ) -> Vec<FactLoadResult<bool>> {
+        if keys.len() == 1 {
+            return vec![self.load_point(&keys[0]).await];
+        }
+
+        self.load_bulk(keys).await
+    }
+}
+
+async fn assert_point_and_bulk_agree(
+    source: &PgRelationshipSource,
+    keys: &[RelationshipQuery<Uuid, Uuid, String>],
+) {
+    for key in keys {
+        let point = source.load_point(key).await;
+        let bulk = source
+            .load_bulk(std::slice::from_ref(key))
+            .await
             .into_iter()
-            .map(|row| FactLoadResult::Found(row.get("allowed")))
-            .collect()
+            .next()
+            .expect("bulk load for one key should return one result");
+
+        match (point, bulk) {
+            (FactLoadResult::Found(point), FactLoadResult::Found(bulk)) => {
+                assert_eq!(point, bulk, "point and bulk SQL should agree for {key:?}");
+            }
+            (point, bulk) => {
+                panic!(
+                    "point and bulk SQL should both succeed in the example: {point:?} vs {bulk:?}"
+                );
+            }
+        }
     }
 }
 
@@ -169,12 +220,28 @@ async fn main() {
             .expect("prepare bulk query"),
     );
 
-    let source: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, String>>> =
-        Arc::new(PgRelationshipSource {
-            client,
-            point_stmt,
-            bulk_stmt,
-        });
+    let source = Arc::new(PgRelationshipSource {
+        client,
+        point_stmt,
+        bulk_stmt,
+    });
+    assert_point_and_bulk_agree(
+        &source,
+        &[
+            RelationshipQuery {
+                subject_id: subject.id,
+                resource_id: posts[0].id,
+                relation: relationship.clone(),
+            },
+            RelationshipQuery {
+                subject_id: subject.id,
+                resource_id: posts[1].id,
+                relation: relationship.clone(),
+            },
+        ],
+    )
+    .await;
+    let source: Arc<dyn FactSource<RelationshipQuery<Uuid, Uuid, String>>> = source;
     let policy = RebacPolicy::new(|user: &User| user.id, |post: &Post| post.id, relationship);
     let mut checker = PermissionChecker::new();
     checker.add_policy(policy);

--- a/examples/pg18_bulk_rebac.rs
+++ b/examples/pg18_bulk_rebac.rs
@@ -156,9 +156,9 @@ fn build_checker() -> PermissionChecker<User, Post, View, ()> {
 }
 
 fn session_with(source: &Arc<dyn FactSource<RelationshipKey>>) -> EvaluationSession {
-    let session = EvaluationSession::new();
-    session.register_arc::<RelationshipKey>(Arc::clone(source));
-    session
+    EvaluationSession::builder()
+        .with_arc::<RelationshipKey>(Arc::clone(source))
+        .build()
 }
 
 #[tokio::main]

--- a/examples/policy_builder.rs
+++ b/examples/policy_builder.rs
@@ -92,37 +92,39 @@ async fn main() {
     };
 
     // Evaluate the policy with different target entities as context.
+    let session = EvaluationSession::empty();
+
     // 1. org1 should be granted access when the target is "org1".
     let result1 = checker
-        .evaluate_access(&org1, &(), &(), &"org1".to_string())
+        .evaluate_in_session(&session, &org1, &(), &(), &"org1".to_string())
         .await;
     println!("Org1 on 'org1': {}", result1);
     assert!(result1.is_granted());
 
     // 2. org2 should be denied access when the target is "org1".
     let result2 = checker
-        .evaluate_access(&org2, &(), &(), &"org1".to_string())
+        .evaluate_in_session(&session, &org2, &(), &(), &"org1".to_string())
         .await;
     println!("Org2 on 'org1': {}", result2);
     assert!(!result2.is_granted());
 
     // 3. org2 should be granted access when the target is "org2".
     let result3 = checker
-        .evaluate_access(&org2, &(), &(), &"org2".to_string())
+        .evaluate_in_session(&session, &org2, &(), &(), &"org2".to_string())
         .await;
     println!("Org2 on 'org2': {}", result3);
     assert!(result3.is_granted());
 
     // 4. org3 should be denied access regardless of the target since it doesn't have the correct permission.
     let result4 = checker
-        .evaluate_access(&org3, &(), &(), &"org1".to_string())
+        .evaluate_in_session(&session, &org3, &(), &(), &"org1".to_string())
         .await;
     println!("Org3 on 'org1': {}", result4);
     assert!(!result4.is_granted());
 
     // 5. org4 should be granted access since it has global admin permissions
     let result5 = checker
-        .evaluate_access(&org4, &(), &(), &"org1".to_string())
+        .evaluate_in_session(&session, &org4, &(), &(), &"org1".to_string())
         .await;
     println!("Org4 on 'org1': {}", result5);
     assert!(result5.is_granted());

--- a/examples/rbac_policy.rs
+++ b/examples/rbac_policy.rs
@@ -192,8 +192,11 @@ async fn test_access(
 ) {
     let context = EmptyContext;
     let action = ReadAction;
+    let session = EvaluationSession::empty();
 
-    let result = checker.evaluate_access(user, &action, doc, &context).await;
+    let result = checker
+        .evaluate_in_session(&session, user, &action, doc, &context)
+        .await;
 
     println!(
         "{} accessing {}: {}",

--- a/examples/rebac_policy.rs
+++ b/examples/rebac_policy.rs
@@ -1,8 +1,8 @@
 //! # Relationship-Based Access Control Policy Example
 //!
-//! This example demonstrates how to use the built-in ReBAC policy
-//! for relationship-based permissions management, including error handling
-//! during relationship resolution.
+//! This example demonstrates ReBAC in the v0.3 shape: `RebacPolicy` extracts
+//! flat IDs and loads relationship facts through a request-scoped
+//! `EvaluationSession`.
 //!
 //! To run this example:
 //! ```
@@ -11,11 +11,10 @@
 
 use async_trait::async_trait;
 use gatehouse::*;
+use std::collections::HashSet;
 use std::fmt;
-use std::time::Duration;
 use uuid::Uuid;
 
-// Define types for our permission system
 #[derive(Debug, Clone)]
 struct User {
     id: Uuid,
@@ -34,75 +33,48 @@ struct EditAction;
 #[derive(Debug, Clone)]
 struct EmptyContext;
 
-// A relationship resolver that simulates database access
-// and can demonstrate different error conditions
 #[derive(Debug, Clone)]
-struct ProjectRelationshipResolver {
-    // Simulate a database of relationships: (user_id, project_id, relationship_type)
-    relationships: Vec<(Uuid, Uuid, String)>,
-    // Flag to simulate a database error
-    simulate_error: bool,
-    // Flag to simulate a timeout
-    simulate_timeout: bool,
+struct ProjectRelationshipSource {
+    relationships: HashSet<RelationshipQuery<Uuid, Uuid, String>>,
+    fail: bool,
 }
 
-impl ProjectRelationshipResolver {
-    fn new(relationships: Vec<(Uuid, Uuid, String)>) -> Self {
+impl ProjectRelationshipSource {
+    fn new(relationships: HashSet<RelationshipQuery<Uuid, Uuid, String>>) -> Self {
         Self {
             relationships,
-            simulate_error: false,
-            simulate_timeout: false,
+            fail: false,
         }
     }
 
     fn with_error(mut self) -> Self {
-        self.simulate_error = true;
-        self
-    }
-
-    fn with_timeout(mut self) -> Self {
-        self.simulate_timeout = true;
+        self.fail = true;
         self
     }
 }
 
 #[async_trait]
-impl RelationshipResolver<User, Project, String> for ProjectRelationshipResolver {
-    async fn has_relationship(
+impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for ProjectRelationshipSource {
+    async fn load_many(
         &self,
-        user: &User,
-        project: &Project,
-        relationship: &String,
-    ) -> bool {
-        println!(
-            "Checking if user {} has '{}' relationship with project {}",
-            user.name, relationship, project.name
-        );
+        keys: &[RelationshipQuery<Uuid, Uuid, String>],
+    ) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|key| {
+                println!(
+                    "Loading relationship fact: subject={} relation={} resource={}",
+                    key.subject_id, key.relation, key.resource_id
+                );
 
-        // Simulate a database error
-        if self.simulate_error {
-            println!("⚠️  Database error while checking relationship!");
-            return false; // Return false on error
-        }
-
-        // Simulate a timeout
-        if self.simulate_timeout {
-            println!("⏱️  Simulating database timeout (3 seconds)...");
-            tokio::time::sleep(Duration::from_secs(3)).await;
-            println!("⚠️  Database timeout while checking relationship!");
-            return false; // Return false on timeout
-        }
-
-        // Normal processing - check if relationship exists
-        let has_rel = self.relationships.iter().any(|(user_id, project_id, rel)| {
-            *user_id == user.id && *project_id == project.id && rel == relationship
-        });
-
-        println!(
-            "Relationship check result: {}",
-            if has_rel { "EXISTS ✓" } else { "MISSING ✗" }
-        );
-        has_rel
+                if self.fail {
+                    FactLoadResult::Error(FactLoadError::backend_message(
+                        "simulated relationship store error",
+                    ))
+                } else {
+                    FactLoadResult::Found(self.relationships.contains(key))
+                }
+            })
+            .collect()
     }
 }
 
@@ -110,122 +82,81 @@ impl RelationshipResolver<User, Project, String> for ProjectRelationshipResolver
 async fn main() {
     println!("=== ReBAC Policy Example ===\n");
 
-    // Create some users
     let owner = User {
         id: Uuid::new_v4(),
         name: "Alice (Owner)".to_string(),
     };
-
     let contributor = User {
         id: Uuid::new_v4(),
         name: "Bob (Contributor)".to_string(),
     };
-
     let viewer = User {
         id: Uuid::new_v4(),
         name: "Charlie (Viewer)".to_string(),
     };
-
     let unauthorized = User {
         id: Uuid::new_v4(),
         name: "Dave (Unauthorized)".to_string(),
     };
-
-    println!("Users:");
-    println!("  Owner:        {}", owner.name);
-    println!("  Contributor:  {}", contributor.name);
-    println!("  Viewer:       {}", viewer.name);
-    println!("  Unauthorized: {}", unauthorized.name);
-    println!();
-
-    // Create a project
     let project = Project {
         id: Uuid::new_v4(),
         name: "Sample Project".to_string(),
     };
 
-    println!("Project:");
-    println!("  Name: {}", project.name);
-    println!("  ID:   {}", project.id);
-    println!();
+    let relationships = HashSet::from([
+        RelationshipQuery {
+            subject_id: owner.id,
+            resource_id: project.id,
+            relation: "owner".to_string(),
+        },
+        RelationshipQuery {
+            subject_id: contributor.id,
+            resource_id: project.id,
+            relation: "contributor".to_string(),
+        },
+        RelationshipQuery {
+            subject_id: viewer.id,
+            resource_id: project.id,
+            relation: "viewer".to_string(),
+        },
+    ]);
 
-    // Setup relationship database
-    let relationships = vec![
-        (owner.id, project.id, "owner".to_string()),
-        (contributor.id, project.id, "contributor".to_string()),
-        (viewer.id, project.id, "viewer".to_string()),
-    ];
+    let session = EvaluationSession::new();
+    session.register::<RelationshipQuery<Uuid, Uuid, String>, _>(ProjectRelationshipSource::new(
+        relationships.clone(),
+    ));
 
-    println!("=== Normal Relationship Resolution ===\n");
-
-    // Create resolver with normal operation
-    let normal_resolver = ProjectRelationshipResolver::new(relationships.clone());
-
-    // Create ReBAC policies for different relationships
-    let owner_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, _, _>::new(
-        "owner".to_string(),
-        normal_resolver.clone(),
-    );
-
-    let contributor_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, _, _>::new(
-        "contributor".to_string(),
-        normal_resolver.clone(),
-    );
-
-    let _viewer_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, String, _>::new(
-        "viewer".to_string(),
-        normal_resolver,
-    );
-
-    // Create a permission checker with multiple policies
-    // Only owners and contributors can edit, not viewers
     let mut checker = PermissionChecker::<User, Project, EditAction, EmptyContext>::new();
-    checker.add_policy(owner_policy);
-    checker.add_policy(contributor_policy);
+    checker.add_policy(RebacPolicy::new(
+        |user: &User| user.id,
+        |project: &Project| project.id,
+        "owner".to_string(),
+    ));
+    checker.add_policy(RebacPolicy::new(
+        |user: &User| user.id,
+        |project: &Project| project.id,
+        "contributor".to_string(),
+    ));
 
-    // Test normal access
     println!("Testing normal access patterns:");
-    test_access(&checker, &owner, &project).await;
-    test_access(&checker, &contributor, &project).await;
-    test_access(&checker, &viewer, &project).await;
-    test_access(&checker, &unauthorized, &project).await;
+    test_access(&checker, &session, &owner, &project).await;
+    test_access(&checker, &session, &contributor, &project).await;
+    test_access(&checker, &session, &viewer, &project).await;
+    test_access(&checker, &session, &unauthorized, &project).await;
 
-    println!("\n=== Error During Relationship Resolution ===\n");
-
-    // Create a resolver that simulates a database error
-    let error_resolver = ProjectRelationshipResolver::new(relationships.clone()).with_error();
-    let error_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, _, _>::new(
-        "owner".to_string(),
-        error_resolver,
+    println!("\n=== Error During Relationship Loading ===\n");
+    let error_session = EvaluationSession::new();
+    error_session.register::<RelationshipQuery<Uuid, Uuid, String>, _>(
+        ProjectRelationshipSource::new(relationships).with_error(),
     );
+    test_access(&checker, &error_session, &owner, &project).await;
 
-    let mut error_checker = PermissionChecker::<User, Project, EditAction, EmptyContext>::new();
-    error_checker.add_policy(error_policy);
-
-    println!("Testing with database error:");
-    test_access(&error_checker, &owner, &project).await;
-
-    println!("\n=== Timeout During Relationship Resolution ===\n");
-
-    // Create a resolver that simulates a timeout
-    let timeout_resolver = ProjectRelationshipResolver::new(relationships).with_timeout();
-    let timeout_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, _, _>::new(
-        "owner".to_string(),
-        timeout_resolver,
-    );
-
-    let mut timeout_checker = PermissionChecker::<User, Project, EditAction, EmptyContext>::new();
-    timeout_checker.add_policy(timeout_policy);
-
-    println!("Testing with database timeout:");
-    test_access(&timeout_checker, &owner, &project).await;
-
-    // Demonstrate enum-based relationships (type-safe alternative to strings)
     enum_relationship_example().await;
 }
 
 async fn test_access(
     checker: &PermissionChecker<User, Project, EditAction, EmptyContext>,
+    session: &EvaluationSession,
     user: &User,
     project: &Project,
 ) {
@@ -234,19 +165,18 @@ async fn test_access(
 
     println!("\nChecking if {} can edit {}:", user.name, project.name);
     let result = checker
-        .evaluate_access(user, &action, project, &context)
+        .evaluate_in_session(session, user, &action, project, &context)
         .await;
 
     println!(
         "Access {} for {}",
         if result.is_granted() {
-            "GRANTED ✓"
+            "GRANTED"
         } else {
-            "DENIED ✗"
+            "DENIED"
         },
         user.name
     );
-
     println!(
         "Evaluation trace:\n{}\n",
         match &result {
@@ -256,13 +186,7 @@ async fn test_access(
     );
 }
 
-// --- Enum-based relationship example ---
-//
-// The relationship type parameter is generic, so you can use enums instead
-// of strings for compile-time safety. A typo like "contibutor" becomes a
-// compile error rather than a silent permission failure.
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Relation {
     Owner,
     Contributor,
@@ -279,21 +203,19 @@ impl fmt::Display for Relation {
     }
 }
 
-struct EnumRelationshipResolver {
-    relationships: Vec<(Uuid, Uuid, Relation)>,
+struct EnumRelationshipSource {
+    relationships: HashSet<RelationshipQuery<Uuid, Uuid, Relation>>,
 }
 
 #[async_trait]
-impl RelationshipResolver<User, Project, Relation> for EnumRelationshipResolver {
-    async fn has_relationship(
+impl FactSource<RelationshipQuery<Uuid, Uuid, Relation>> for EnumRelationshipSource {
+    async fn load_many(
         &self,
-        user: &User,
-        project: &Project,
-        relationship: &Relation,
-    ) -> bool {
-        self.relationships
-            .iter()
-            .any(|(uid, pid, rel)| *uid == user.id && *pid == project.id && rel == relationship)
+        keys: &[RelationshipQuery<Uuid, Uuid, Relation>],
+    ) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|key| FactLoadResult::Found(self.relationships.contains(key)))
+            .collect()
     }
 }
 
@@ -308,33 +230,42 @@ async fn enum_relationship_example() {
         id: Uuid::new_v4(),
         name: "Bob".to_string(),
     };
-
+    let charlie = User {
+        id: Uuid::new_v4(),
+        name: "Charlie".to_string(),
+    };
     let project = Project {
         id: Uuid::new_v4(),
         name: "Typed Project".to_string(),
     };
 
-    let charlie = User {
-        id: Uuid::new_v4(),
-        name: "Charlie".to_string(),
-    };
+    let session = EvaluationSession::new();
+    session.register::<RelationshipQuery<Uuid, Uuid, Relation>, _>(EnumRelationshipSource {
+        relationships: HashSet::from([
+            RelationshipQuery {
+                subject_id: alice.id,
+                resource_id: project.id,
+                relation: Relation::Owner,
+            },
+            RelationshipQuery {
+                subject_id: bob.id,
+                resource_id: project.id,
+                relation: Relation::Contributor,
+            },
+            RelationshipQuery {
+                subject_id: charlie.id,
+                resource_id: project.id,
+                relation: Relation::Viewer,
+            },
+        ]),
+    });
 
-    let resolver = EnumRelationshipResolver {
-        relationships: vec![
-            (alice.id, project.id, Relation::Owner),
-            (bob.id, project.id, Relation::Contributor),
-            (charlie.id, project.id, Relation::Viewer),
-        ],
-    };
-
-    // Only owners can edit — using an enum variant instead of a string.
-    let owner_policy = RebacPolicy::<User, Project, EditAction, EmptyContext, _, _>::new(
+    let mut checker = PermissionChecker::<User, Project, EditAction, EmptyContext>::new();
+    checker.add_policy(RebacPolicy::new(
+        |user: &User| user.id,
+        |project: &Project| project.id,
         Relation::Owner,
-        resolver,
-    );
-
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(owner_policy);
+    ));
 
     let context = EmptyContext;
     let action = EditAction;
@@ -345,23 +276,17 @@ async fn enum_relationship_example() {
         (&charlie, false, "viewer"),
     ] {
         let result = checker
-            .evaluate_access(user, &action, &project, &context)
+            .evaluate_in_session(&session, user, &action, &project, &context)
             .await;
-        let status = if result.is_granted() {
-            "GRANTED ✓"
-        } else {
-            "DENIED ✗"
-        };
         println!(
-            "{} ({}) edit access: {} (expected: {})",
+            "{} ({}) edit access: {}",
             user.name,
             role,
-            status,
-            if expected_granted {
-                "granted"
+            if result.is_granted() {
+                "GRANTED"
             } else {
-                "denied"
-            }
+                "DENIED"
+            },
         );
         assert_eq!(result.is_granted(), expected_granted);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
-//! A flexible authorization library that combines role‐based (RBAC),
-//! attribute‐based (ABAC), and relationship‐based (ReBAC) policies.
-//! The library provides a generic `Policy` trait for defining custom policies,
-//! a builder pattern for creating custom policies as well as several built-in
-//! policies for common use cases, and combinators for composing complex
-//! authorization logic.
+//! An in-process authorization engine for Rust.
+//!
+//! Gatehouse composes role-based (RBAC), attribute-based (ABAC), and
+//! relationship-based (ReBAC) policies while keeping authorization logic in
+//! Rust. Relationship facts are loaded through request-scoped
+//! [`EvaluationSession`] values, so list endpoints can batch, deduplicate, and
+//! coalesce backend calls without moving policy logic into the data layer.
 //!
 //! # Overview
 //!
@@ -43,6 +44,20 @@
 //! evaluated. Because [`PermissionChecker`], [`AndPolicy`], and [`OrPolicy`]
 //! short-circuit, the trace tree does not include policies that were never run.
 //!
+//! ## Fact-Loaded Authorization
+//!
+//! Gatehouse treats non-trivial authorization as computation over facts loaded
+//! for one request. [`FactSource::load_many`] receives unique fact keys and
+//! returns exactly one result per key; [`EvaluationSession`] expands duplicate
+//! caller inputs, preserves caller order, caches results for the request, and
+//! joins concurrent in-flight loads for the same key.
+//!
+//! [`RebacPolicy`] is the first built-in policy backed by this model. It
+//! extracts flat subject/resource IDs, builds [`RelationshipQuery`] keys, and
+//! asks the session for relationship facts. [`LookupSource`] reserves the
+//! complementary "what can this subject see?" shape for backends that can
+//! enumerate visible resources directly.
+//!
 //! ## Quick Start
 //!
 //! The fastest way to define a policy is with [`PolicyBuilder`]:
@@ -80,7 +95,8 @@
 //! The library provides several built-in policies:
 //!  - [`RbacPolicy`]: A role-based access control policy.
 //!  - [`AbacPolicy`]: An attribute-based access control policy.
-//!  - [`RebacPolicy`]: A relationship-based access control policy.
+//!  - [`RebacPolicy`]: A relationship-based access control policy backed by
+//!    [`FactSource`] and [`EvaluationSession`].
 //!
 //! ## Custom Policies
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,17 @@ pub enum PolicyEvalResult {
     },
 }
 
+/// A borrowed resource/context pair passed to batch policy evaluators.
+///
+/// Values are borrowed from caller-owned batch items, so policy implementations
+/// can evaluate a batch without forcing resources or contexts to be cloned.
+pub struct PolicyBatchItem<'a, Resource, Context> {
+    /// The target resource for this item.
+    pub resource: &'a Resource,
+    /// Additional context for this item.
+    pub context: &'a Context,
+}
+
 /// The complete result of a permission evaluation.
 /// Contains both the final decision and a detailed trace for debugging.
 ///
@@ -655,7 +666,13 @@ impl fmt::Display for PolicyEvalResult {
 /// A policy determines if a subject is allowed to perform an action on
 /// a resource within a given context.
 #[async_trait]
-pub trait Policy<Subject, Resource, Action, Context>: Send + Sync {
+pub trait Policy<Subject, Resource, Action, Context>: Send + Sync
+where
+    Subject: Sync,
+    Resource: Sync,
+    Action: Sync,
+    Context: Sync,
+{
     /// Evaluates whether access should be granted.
     ///
     /// # Arguments
@@ -675,6 +692,28 @@ pub trait Policy<Subject, Resource, Action, Context>: Send + Sync {
         resource: &Resource,
         context: &Context,
     ) -> PolicyEvalResult;
+
+    /// Evaluates access for a batch of resource/context pairs.
+    ///
+    /// The default implementation preserves single-item semantics by evaluating
+    /// each item sequentially. Policies with set-oriented backends can override
+    /// this method to reduce round trips while returning one result per input
+    /// item in the same order.
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item Subject,
+        action: &'item Action,
+        items: &'item [PolicyBatchItem<'item, Resource, Context>],
+    ) -> Vec<PolicyEvalResult> {
+        let mut results = Vec::with_capacity(items.len());
+        for item in items {
+            results.push(
+                self.evaluate_access(subject, action, item.resource, item.context)
+                    .await,
+            );
+        }
+        results
+    }
 
     /// Policy name for debugging
     fn policy_type(&self) -> String;
@@ -698,13 +737,25 @@ pub struct PermissionChecker<S, R, A, C> {
     policies: Vec<Arc<dyn Policy<S, R, A, C>>>,
 }
 
-impl<S, R, A, C> Default for PermissionChecker<S, R, A, C> {
+impl<S, R, A, C> Default for PermissionChecker<S, R, A, C>
+where
+    S: Sync,
+    R: Sync,
+    A: Sync,
+    C: Sync,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<S, R, A, C> PermissionChecker<S, R, A, C> {
+impl<S, R, A, C> PermissionChecker<S, R, A, C>
+where
+    S: Sync,
+    R: Sync,
+    A: Sync,
+    C: Sync,
+{
     /// Creates a new `PermissionChecker` with no policies.
     pub fn new() -> Self {
         Self {
@@ -822,6 +873,266 @@ impl<S, R, A, C> PermissionChecker<S, R, A, C> {
             reason: "All policies denied access".to_string(),
         }
     }
+
+    /// Evaluates a batch of caller-owned items.
+    ///
+    /// The `parts` callback tells gatehouse how to borrow the resource and
+    /// context from each caller-owned item. Returned results preserve input
+    /// order, including duplicate resources. Policy evaluation still uses the
+    /// same OR semantics as [`Self::evaluate_access`], but the checker evaluates
+    /// each policy across the still-pending batch before moving to the next
+    /// policy. This lets policies with set-oriented backends override
+    /// [`Policy::evaluate_access_batch`] and collapse many point lookups into
+    /// one backend call.
+    ///
+    /// If a policy returns the wrong number of batch results, affected items are
+    /// denied rather than accidentally granted.
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # use async_trait::async_trait;
+    /// # #[derive(Clone)]
+    /// # struct User { id: u64 }
+    /// # #[derive(Clone)]
+    /// # struct Document { owner_id: u64 }
+    /// # struct Read;
+    /// # #[derive(Clone)]
+    /// # struct RequestContext;
+    /// # tokio_test::block_on(async {
+    /// let user = User { id: 7 };
+    /// let context = RequestContext;
+    /// let documents = vec![
+    ///     Document { owner_id: 7 },
+    ///     Document { owner_id: 42 },
+    /// ];
+    ///
+    /// let mut checker = PermissionChecker::new();
+    /// checker.add_policy(AbacPolicy::new(
+    ///     |user: &User, document: &Document, _action: &Read, _context: &RequestContext| {
+    ///         user.id == document.owner_id
+    ///     },
+    /// ));
+    ///
+    /// let visible = checker
+    ///     .filter_authorized_with_context_by(&user, &Read, documents, &context, |document| {
+    ///         document
+    ///     })
+    ///     .await;
+    ///
+    /// assert_eq!(visible.len(), 1);
+    /// # });
+    /// ```
+    #[tracing::instrument(skip_all, fields(item_count, granted_count, denied_count, policy_count = self.policies.len()))]
+    pub async fn evaluate_batch_by<I, F>(
+        &self,
+        subject: &S,
+        action: &A,
+        items: I,
+        parts: F,
+    ) -> Vec<(I::Item, AccessEvaluation)>
+    where
+        I: IntoIterator,
+        F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C),
+    {
+        let items: Vec<I::Item> = items.into_iter().collect();
+        let item_count = items.len();
+        tracing::Span::current().record("item_count", item_count);
+
+        let mut traces = vec![Vec::new(); item_count];
+        let mut evaluations: Vec<Option<AccessEvaluation>> = vec![None; item_count];
+
+        if self.policies.is_empty() {
+            let mut denied_count = 0usize;
+            let results = items
+                .into_iter()
+                .map(|item| {
+                    denied_count += 1;
+                    let result = PolicyEvalResult::Denied {
+                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                        reason: "No policies configured".to_string(),
+                    };
+                    (
+                        item,
+                        AccessEvaluation::Denied {
+                            trace: EvalTrace::with_root(result),
+                            reason: "No policies configured".to_string(),
+                        },
+                    )
+                })
+                .collect();
+            tracing::Span::current().record("granted_count", 0usize);
+            tracing::Span::current().record("denied_count", denied_count);
+            return results;
+        }
+
+        let mut pending: Vec<usize> = (0..item_count).collect();
+
+        for policy in &self.policies {
+            if pending.is_empty() {
+                break;
+            }
+
+            let batch_items: Vec<_> = pending
+                .iter()
+                .map(|&index| {
+                    let (resource, context) = parts(&items[index]);
+                    PolicyBatchItem { resource, context }
+                })
+                .collect();
+
+            let policy_results = policy
+                .evaluate_access_batch(subject, action, &batch_items)
+                .await;
+
+            if policy_results.len() != pending.len() {
+                for index in pending {
+                    let policy_result = PolicyEvalResult::Denied {
+                        policy_type: policy.policy_type(),
+                        reason: "Policy batch result count did not match input count".to_string(),
+                    };
+                    traces[index].push(policy_result);
+                    let combined = PolicyEvalResult::Combined {
+                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                        operation: CombineOp::Or,
+                        children: std::mem::take(&mut traces[index]),
+                        outcome: false,
+                    };
+                    evaluations[index] = Some(AccessEvaluation::Denied {
+                        trace: EvalTrace::with_root(combined),
+                        reason: "Policy batch result count did not match input count".to_string(),
+                    });
+                }
+                pending = Vec::new();
+                break;
+            }
+
+            let mut still_pending = Vec::new();
+            for (index, result) in pending.into_iter().zip(policy_results) {
+                let result_passes = result.is_granted();
+                let policy_type = policy.policy_type();
+                let reason = result.reason();
+
+                traces[index].push(result);
+
+                if result_passes {
+                    let combined = PolicyEvalResult::Combined {
+                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                        operation: CombineOp::Or,
+                        children: std::mem::take(&mut traces[index]),
+                        outcome: true,
+                    };
+                    evaluations[index] = Some(AccessEvaluation::Granted {
+                        policy_type,
+                        reason,
+                        trace: EvalTrace::with_root(combined),
+                    });
+                } else {
+                    still_pending.push(index);
+                }
+            }
+            pending = still_pending;
+        }
+
+        for index in pending {
+            let combined = PolicyEvalResult::Combined {
+                policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                operation: CombineOp::Or,
+                children: std::mem::take(&mut traces[index]),
+                outcome: false,
+            };
+            evaluations[index] = Some(AccessEvaluation::Denied {
+                trace: EvalTrace::with_root(combined),
+                reason: "All policies denied access".to_string(),
+            });
+        }
+
+        let mut granted_count = 0usize;
+        let results = items
+            .into_iter()
+            .zip(evaluations.into_iter())
+            .map(|(item, evaluation)| {
+                let evaluation = evaluation.expect("every batch item should be evaluated");
+                if evaluation.is_granted() {
+                    granted_count += 1;
+                }
+                (item, evaluation)
+            })
+            .collect::<Vec<_>>();
+        let denied_count = item_count - granted_count;
+        tracing::Span::current().record("granted_count", granted_count);
+        tracing::Span::current().record("denied_count", denied_count);
+        results
+    }
+
+    /// Returns only the items granted by [`Self::evaluate_batch_by`].
+    pub async fn filter_authorized_by<I, F>(
+        &self,
+        subject: &S,
+        action: &A,
+        items: I,
+        parts: F,
+    ) -> Vec<I::Item>
+    where
+        I: IntoIterator,
+        F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C),
+    {
+        self.evaluate_batch_by(subject, action, items, parts)
+            .await
+            .into_iter()
+            .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
+            .collect()
+    }
+
+    /// Evaluates caller-owned items that all share one context value.
+    ///
+    /// This is a convenience wrapper around [`Self::evaluate_batch_by`] for the
+    /// common list-endpoint shape where every candidate resource is evaluated in
+    /// the same request context.
+    pub async fn evaluate_batch_with_context_by<I, F>(
+        &self,
+        subject: &S,
+        action: &A,
+        items: I,
+        context: &C,
+        resource: F,
+    ) -> Vec<(I::Item, AccessEvaluation)>
+    where
+        I: IntoIterator,
+        F: for<'item> Fn(&'item I::Item) -> &'item R,
+    {
+        let wrapped_items = items
+            .into_iter()
+            .map(|item| (item, context))
+            .collect::<Vec<_>>();
+
+        self.evaluate_batch_by(subject, action, wrapped_items, |(item, context)| {
+            (resource(item), *context)
+        })
+        .await
+        .into_iter()
+        .map(|((item, _context), evaluation)| (item, evaluation))
+        .collect()
+    }
+
+    /// Returns only authorized items when all items share one context value.
+    pub async fn filter_authorized_with_context_by<I, F>(
+        &self,
+        subject: &S,
+        action: &A,
+        items: I,
+        context: &C,
+        resource: F,
+    ) -> Vec<I::Item>
+    where
+        I: IntoIterator,
+        F: for<'item> Fn(&'item I::Item) -> &'item R,
+    {
+        self.evaluate_batch_with_context_by(subject, action, items, context, resource)
+            .await
+            .into_iter()
+            .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
+            .collect()
+    }
 }
 
 /// Represents the intended effect of a policy.
@@ -902,6 +1213,15 @@ where
         (**self)
             .evaluate_access(subject, action, resource, context)
             .await
+    }
+
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item S,
+        action: &'item A,
+        items: &'item [PolicyBatchItem<'item, R, C>],
+    ) -> Vec<PolicyEvalResult> {
+        (**self).evaluate_access_batch(subject, action, items).await
     }
 
     fn policy_type(&self) -> String {
@@ -1295,9 +1615,33 @@ where
 /// The relationship type `Re` is generic, so you can use strings, enums, or
 /// other domain-specific types.
 #[async_trait]
-pub trait RelationshipResolver<S, R, Re>: Send + Sync {
+pub trait RelationshipResolver<S, R, Re>: Send + Sync
+where
+    S: Sync,
+    R: Sync,
+    Re: Sync,
+{
     /// Returns `true` if `relationship` exists between `subject` and `resource`.
     async fn has_relationship(&self, subject: &S, resource: &R, relationship: &Re) -> bool;
+
+    /// Returns one relationship decision per resource, in input order.
+    ///
+    /// The default implementation loops over [`Self::has_relationship`].
+    /// Resolvers backed by SQL, graph stores, or remote authorization services
+    /// can override this method to perform one set-oriented lookup for the
+    /// whole batch.
+    async fn has_relationship_batch<'item>(
+        &self,
+        subject: &'item S,
+        resources: &'item [&'item R],
+        relationship: &'item Re,
+    ) -> Vec<bool> {
+        let mut results = Vec::with_capacity(resources.len());
+        for resource in resources {
+            results.push(self.has_relationship(subject, resource, relationship).await);
+        }
+        results
+    }
 }
 
 /// ### ReBAC Policy
@@ -1432,6 +1776,53 @@ where
                 ),
             }
         }
+    }
+
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item S,
+        _action: &'item A,
+        items: &'item [PolicyBatchItem<'item, R, C>],
+    ) -> Vec<PolicyEvalResult> {
+        let resources = items.iter().map(|item| item.resource).collect::<Vec<_>>();
+        let relationship_results = self
+            .resolver
+            .has_relationship_batch(subject, &resources, &self.relationship)
+            .await;
+
+        if relationship_results.len() != items.len() {
+            return items
+                .iter()
+                .map(|_| PolicyEvalResult::Denied {
+                    policy_type: self.policy_type(),
+                    reason: "Relationship resolver returned the wrong number of batch results"
+                        .to_string(),
+                })
+                .collect();
+        }
+
+        relationship_results
+            .into_iter()
+            .map(|has_relationship| {
+                if has_relationship {
+                    PolicyEvalResult::Granted {
+                        policy_type: self.policy_type(),
+                        reason: Some(format!(
+                            "Subject has '{}' relationship with resource",
+                            self.relationship
+                        )),
+                    }
+                } else {
+                    PolicyEvalResult::Denied {
+                        policy_type: self.policy_type(),
+                        reason: format!(
+                            "Subject does not have '{}' relationship with resource",
+                            self.relationship
+                        ),
+                    }
+                }
+            })
+            .collect()
     }
 
     fn policy_type(&self) -> String {
@@ -1598,7 +1989,13 @@ pub struct NotPolicy<S, R, A, C> {
     policy: Arc<dyn Policy<S, R, A, C>>,
 }
 
-impl<S, R, A, C> NotPolicy<S, R, A, C> {
+impl<S, R, A, C> NotPolicy<S, R, A, C>
+where
+    S: Sync,
+    R: Sync,
+    A: Sync,
+    C: Sync,
+{
     /// Creates a new `NotPolicy` that inverts the given policy's decision.
     pub fn new(policy: impl Policy<S, R, A, C> + 'static) -> Self {
         Self {
@@ -1645,6 +2042,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // Dummy resource/action/context types for testing
     #[derive(Debug, Clone)]
@@ -1731,6 +2129,56 @@ mod tests {
         }
     }
 
+    struct EvenResourceBatchPolicy {
+        batch_calls: Arc<AtomicUsize>,
+        single_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Policy<TestSubject, TestResource, TestAction, TestContext> for EvenResourceBatchPolicy {
+        async fn evaluate_access(
+            &self,
+            _subject: &TestSubject,
+            _action: &TestAction,
+            resource: &TestResource,
+            _context: &TestContext,
+        ) -> PolicyEvalResult {
+            self.single_calls.fetch_add(1, Ordering::SeqCst);
+            if resource.id.as_u128().is_multiple_of(2) {
+                PolicyEvalResult::Granted {
+                    policy_type: self.policy_type(),
+                    reason: Some("even resource".to_string()),
+                }
+            } else {
+                PolicyEvalResult::Denied {
+                    policy_type: self.policy_type(),
+                    reason: "odd resource".to_string(),
+                }
+            }
+        }
+
+        async fn evaluate_access_batch<'item>(
+            &self,
+            subject: &'item TestSubject,
+            action: &'item TestAction,
+            items: &'item [PolicyBatchItem<'item, TestResource, TestContext>],
+        ) -> Vec<PolicyEvalResult> {
+            self.batch_calls.fetch_add(1, Ordering::SeqCst);
+            let mut results = Vec::with_capacity(items.len());
+            for item in items {
+                results.push(
+                    self.evaluate_access(subject, action, item.resource, item.context)
+                        .await,
+                );
+            }
+            results
+        }
+
+        fn policy_type(&self) -> String {
+            "EvenResourceBatchPolicy".to_string()
+        }
+    }
+
     #[tokio::test]
     async fn test_no_policies() {
         let checker =
@@ -1752,6 +2200,101 @@ mod tests {
             }
             _ => panic!("Expected Denied(No policies configured), got {:?}", result),
         }
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_batch_by_matches_single_item_loop() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..8)
+            .map(|value| TestResource {
+                id: uuid::Uuid::from_u128(value),
+            })
+            .collect::<Vec<_>>();
+
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(EvenResourceBatchPolicy {
+            batch_calls: Arc::clone(&batch_calls),
+            single_calls: Arc::clone(&single_calls),
+        });
+
+        let mut loop_results = Vec::new();
+        for resource in &resources {
+            loop_results.push(
+                checker
+                    .evaluate_access(&subject, &TestAction, resource, &TestContext)
+                    .await
+                    .is_granted(),
+            );
+        }
+
+        let batch_items = resources
+            .clone()
+            .into_iter()
+            .map(|resource| (resource, TestContext))
+            .collect::<Vec<_>>();
+        let batch_results = checker
+            .evaluate_batch_by(&subject, &TestAction, batch_items, |item| {
+                (&item.0, &item.1)
+            })
+            .await
+            .into_iter()
+            .map(|(_item, evaluation)| evaluation.is_granted())
+            .collect::<Vec<_>>();
+
+        assert_eq!(loop_results, batch_results);
+        assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(single_calls.load(Ordering::SeqCst), 16);
+    }
+
+    #[tokio::test]
+    async fn test_filter_authorized_by_preserves_authorized_items_in_order() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = vec![
+            TestResource {
+                id: uuid::Uuid::from_u128(3),
+            },
+            TestResource {
+                id: uuid::Uuid::from_u128(2),
+            },
+            TestResource {
+                id: uuid::Uuid::from_u128(4),
+            },
+            TestResource {
+                id: uuid::Uuid::from_u128(5),
+            },
+        ];
+
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(EvenResourceBatchPolicy {
+            batch_calls,
+            single_calls,
+        });
+
+        let batch_items = resources
+            .into_iter()
+            .map(|resource| (resource, TestContext))
+            .collect::<Vec<_>>();
+        let authorized = checker
+            .filter_authorized_by(&subject, &TestAction, batch_items, |item| {
+                (&item.0, &item.1)
+            })
+            .await;
+
+        assert_eq!(
+            authorized
+                .into_iter()
+                .map(|(resource, _context)| resource.id.as_u128())
+                .collect::<Vec<_>>(),
+            vec![2, 4]
+        );
     }
 
     #[tokio::test]
@@ -2308,9 +2851,10 @@ mod tests {
     #[tokio::test]
     async fn test_abac_policy_grants_when_condition_true() {
         let policy = AbacPolicy::new(
-            |_subject: &TestSubject, _resource: &TestResource, _action: &TestAction, _context: &TestContext| {
-                true
-            },
+            |_subject: &TestSubject,
+             _resource: &TestResource,
+             _action: &TestAction,
+             _context: &TestContext| { true },
         );
 
         let subject = TestSubject {
@@ -2324,16 +2868,20 @@ mod tests {
             .evaluate_access(&subject, &TestAction, &resource, &TestContext)
             .await;
 
-        assert!(result.is_granted(), "AbacPolicy should grant when condition returns true");
+        assert!(
+            result.is_granted(),
+            "AbacPolicy should grant when condition returns true"
+        );
         assert_eq!(policy.policy_type(), "AbacPolicy");
     }
 
     #[tokio::test]
     async fn test_abac_policy_denies_when_condition_false() {
         let policy = AbacPolicy::new(
-            |_subject: &TestSubject, _resource: &TestResource, _action: &TestAction, _context: &TestContext| {
-                false
-            },
+            |_subject: &TestSubject,
+             _resource: &TestResource,
+             _action: &TestAction,
+             _context: &TestContext| { false },
         );
 
         let subject = TestSubject {
@@ -2347,9 +2895,15 @@ mod tests {
             .evaluate_access(&subject, &TestAction, &resource, &TestContext)
             .await;
 
-        assert!(!result.is_granted(), "AbacPolicy should deny when condition returns false");
+        assert!(
+            !result.is_granted(),
+            "AbacPolicy should deny when condition returns false"
+        );
         match result {
-            PolicyEvalResult::Denied { policy_type, reason } => {
+            PolicyEvalResult::Denied {
+                policy_type,
+                reason,
+            } => {
                 assert_eq!(policy_type, "AbacPolicy");
                 assert!(reason.contains("false"));
             }
@@ -2361,9 +2915,10 @@ mod tests {
     async fn test_abac_policy_with_attribute_check() {
         // Policy that checks if the subject owns the resource
         let policy = AbacPolicy::new(
-            |subject: &TestSubject, resource: &TestResource, _action: &TestAction, _context: &TestContext| {
-                subject.id == resource.id
-            },
+            |subject: &TestSubject,
+             resource: &TestResource,
+             _action: &TestAction,
+             _context: &TestContext| { subject.id == resource.id },
         );
 
         let owner_id = uuid::Uuid::new_v4();
@@ -2377,13 +2932,19 @@ mod tests {
         let result = policy
             .evaluate_access(&owner, &TestAction, &owned_resource, &TestContext)
             .await;
-        assert!(result.is_granted(), "Owner should have access to owned resource");
+        assert!(
+            result.is_granted(),
+            "Owner should have access to owned resource"
+        );
 
         // Owner should not have access to other resource
         let result = policy
             .evaluate_access(&owner, &TestAction, &other_resource, &TestContext)
             .await;
-        assert!(!result.is_granted(), "Owner should not have access to other resource");
+        assert!(
+            !result.is_granted(),
+            "Owner should not have access to other resource"
+        );
     }
 
     // ==================== RbacPolicy Tests ====================
@@ -2410,16 +2971,20 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult = Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-            &policy,
-            &admin_user,
-            &TestAction,
-            &resource,
-            &TestContext,
-        )
-        .await;
+        let result: PolicyEvalResult =
+            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+                &policy,
+                &admin_user,
+                &TestAction,
+                &resource,
+                &TestContext,
+            )
+            .await;
 
-        assert!(result.is_granted(), "User with required role should be granted access");
+        assert!(
+            result.is_granted(),
+            "User with required role should be granted access"
+        );
         assert_eq!(
             Policy::<RbacUser, TestResource, TestAction, TestContext>::policy_type(&policy),
             "RbacPolicy"
@@ -2448,18 +3013,25 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult = Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-            &policy,
-            &regular_user,
-            &TestAction,
-            &resource,
-            &TestContext,
-        )
-        .await;
+        let result: PolicyEvalResult =
+            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+                &policy,
+                &regular_user,
+                &TestAction,
+                &resource,
+                &TestContext,
+            )
+            .await;
 
-        assert!(!result.is_granted(), "User without required role should be denied");
+        assert!(
+            !result.is_granted(),
+            "User without required role should be denied"
+        );
         match result {
-            PolicyEvalResult::Denied { policy_type, reason } => {
+            PolicyEvalResult::Denied {
+                policy_type,
+                reason,
+            } => {
                 assert_eq!(policy_type, "RbacPolicy");
                 assert!(reason.contains("doesn't have required role"));
             }
@@ -2492,16 +3064,20 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult = Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-            &policy,
-            &user,
-            &TestAction,
-            &resource,
-            &TestContext,
-        )
-        .await;
+        let result: PolicyEvalResult =
+            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+                &policy,
+                &user,
+                &TestAction,
+                &resource,
+                &TestContext,
+            )
+            .await;
 
-        assert!(result.is_granted(), "User with any required role should be granted access");
+        assert!(
+            result.is_granted(),
+            "User with any required role should be granted access"
+        );
     }
 
     #[tokio::test]
@@ -2523,14 +3099,15 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult = Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-            &policy,
-            &user_no_roles,
-            &TestAction,
-            &resource,
-            &TestContext,
-        )
-        .await;
+        let result: PolicyEvalResult =
+            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+                &policy,
+                &user_no_roles,
+                &TestAction,
+                &resource,
+                &TestContext,
+            )
+            .await;
 
         assert!(!result.is_granted(), "User with no roles should be denied");
     }
@@ -2557,17 +3134,21 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult = Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-            &policy,
-            &user,
-            &TestAction,
-            &resource,
-            &TestContext,
-        )
-        .await;
+        let result: PolicyEvalResult =
+            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+                &policy,
+                &user,
+                &TestAction,
+                &resource,
+                &TestContext,
+            )
+            .await;
 
         // With empty required roles, no role can match, so access is denied
-        assert!(!result.is_granted(), "Empty required roles means no match is possible");
+        assert!(
+            !result.is_granted(),
+            "Empty required roles means no match is possible"
+        );
     }
 
     #[tokio::test]
@@ -2691,7 +3272,10 @@ mod tests {
 
         // to_result should return Ok for granted access
         let converted: Result<(), String> = result.to_result(|reason| reason.to_string());
-        assert!(converted.is_ok(), "to_result should return Ok for granted access");
+        assert!(
+            converted.is_ok(),
+            "to_result should return Ok for granted access"
+        );
     }
 
     #[tokio::test]
@@ -2712,7 +3296,10 @@ mod tests {
 
         // to_result should return Err for denied access
         let converted: Result<(), String> = result.to_result(|reason| reason.to_string());
-        assert!(converted.is_err(), "to_result should return Err for denied access");
+        assert!(
+            converted.is_err(),
+            "to_result should return Err for denied access"
+        );
         assert!(converted.unwrap_err().contains("denied"));
     }
 
@@ -2733,9 +3320,18 @@ mod tests {
             .await;
 
         let trace_display = result.display_trace();
-        assert!(trace_display.contains("GRANTED"), "Trace should show GRANTED");
-        assert!(trace_display.contains("AlwaysAllowPolicy"), "Trace should show policy name");
-        assert!(trace_display.contains("Evaluation Trace"), "Trace should include trace section");
+        assert!(
+            trace_display.contains("GRANTED"),
+            "Trace should show GRANTED"
+        );
+        assert!(
+            trace_display.contains("AlwaysAllowPolicy"),
+            "Trace should show policy name"
+        );
+        assert!(
+            trace_display.contains("Evaluation Trace"),
+            "Trace should include trace section"
+        );
     }
 
     #[tokio::test]
@@ -2756,7 +3352,10 @@ mod tests {
 
         let trace_display = result.display_trace();
         assert!(trace_display.contains("Denied"), "Trace should show Denied");
-        assert!(trace_display.contains("Test denial"), "Trace should show denial reason");
+        assert!(
+            trace_display.contains("Test denial"),
+            "Trace should show denial reason"
+        );
     }
 
     #[tokio::test]
@@ -2777,8 +3376,14 @@ mod tests {
 
         // Test Display trait
         let display_str = format!("{}", result);
-        assert!(display_str.contains("GRANTED"), "Display should show GRANTED");
-        assert!(display_str.contains("AlwaysAllowPolicy"), "Display should show policy name");
+        assert!(
+            display_str.contains("GRANTED"),
+            "Display should show GRANTED"
+        );
+        assert!(
+            display_str.contains("AlwaysAllowPolicy"),
+            "Display should show policy name"
+        );
     }
 
     // ==================== EvalTrace Tests ====================
@@ -2804,8 +3409,14 @@ mod tests {
 
         assert!(trace.root().is_some(), "Trace with root should have a root");
         let formatted = trace.format();
-        assert!(formatted.contains("TestPolicy"), "Formatted trace should contain policy name");
-        assert!(formatted.contains("GRANTED"), "Formatted trace should contain GRANTED");
+        assert!(
+            formatted.contains("TestPolicy"),
+            "Formatted trace should contain policy name"
+        );
+        assert!(
+            formatted.contains("GRANTED"),
+            "Formatted trace should contain GRANTED"
+        );
     }
 
     #[test]
@@ -2819,7 +3430,10 @@ mod tests {
         };
         trace.set_root(result);
 
-        assert!(trace.root().is_some(), "After set_root, trace should have a root");
+        assert!(
+            trace.root().is_some(),
+            "After set_root, trace should have a root"
+        );
         let formatted = trace.format();
         assert!(formatted.contains("DenyPolicy"));
         assert!(formatted.contains("DENIED"));
@@ -2866,7 +3480,11 @@ mod tests {
             children: vec![],
             outcome: true,
         };
-        assert_eq!(result.reason(), None, "Combined result should have no reason");
+        assert_eq!(
+            result.reason(),
+            None,
+            "Combined result should have no reason"
+        );
     }
 
     #[test]
@@ -2879,8 +3497,14 @@ mod tests {
         let formatted_0 = result.format(0);
         let formatted_4 = result.format(4);
 
-        assert!(formatted_0.starts_with("✔"), "Indent 0 should start with checkmark");
-        assert!(formatted_4.starts_with("    ✔"), "Indent 4 should have 4 spaces before checkmark");
+        assert!(
+            formatted_0.starts_with("✔"),
+            "Indent 0 should start with checkmark"
+        );
+        assert!(
+            formatted_4.starts_with("    ✔"),
+            "Indent 4 should have 4 spaces before checkmark"
+        );
     }
 
     #[test]
@@ -2924,7 +3548,10 @@ mod tests {
             .await;
 
         // Default checker has no policies, so should deny
-        assert!(!result.is_granted(), "Default checker with no policies should deny");
+        assert!(
+            !result.is_granted(),
+            "Default checker with no policies should deny"
+        );
     }
 
     // ==================== SecurityRuleMetadata Tests ====================
@@ -2968,7 +3595,8 @@ mod tests {
     async fn test_policy_default_security_rule() {
         // Test that the default security_rule implementation returns empty metadata
         let policy = AlwaysAllowPolicy;
-        let metadata = Policy::<TestSubject, TestResource, TestAction, TestContext>::security_rule(&policy);
+        let metadata =
+            Policy::<TestSubject, TestResource, TestAction, TestContext>::security_rule(&policy);
 
         assert_eq!(metadata, SecurityRuleMetadata::default());
     }
@@ -3177,16 +3805,21 @@ mod policy_builder_tests {
             pub name: String,
         }
 
-        let policy =
-            PolicyBuilder::<TestSubject, TestResource, ActionType, TestContext>::new("ActionPolicy")
-                .actions(|a: &ActionType| a.name == "read")
-                .build();
+        let policy = PolicyBuilder::<TestSubject, TestResource, ActionType, TestContext>::new(
+            "ActionPolicy",
+        )
+        .actions(|a: &ActionType| a.name == "read")
+        .build();
 
         // Should allow for "read" action
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
-                &ActionType { name: "read".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
+                &ActionType {
+                    name: "read".into(),
+                },
                 &TestResource,
                 &TestContext,
             )
@@ -3196,8 +3829,12 @@ mod policy_builder_tests {
         // Should deny for "write" action
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
-                &ActionType { name: "write".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
+                &ActionType {
+                    name: "write".into(),
+                },
                 &TestResource,
                 &TestContext,
             )
@@ -3222,7 +3859,9 @@ mod policy_builder_tests {
         // Should allow access to public resource
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
                 &TestAction,
                 &ResourceType { public: true },
                 &TestContext,
@@ -3233,7 +3872,9 @@ mod policy_builder_tests {
         // Should deny access to private resource
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
                 &TestAction,
                 &ResourceType { public: false },
                 &TestContext,
@@ -3259,7 +3900,9 @@ mod policy_builder_tests {
         // Should allow for internal requests
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
                 &TestAction,
                 &TestResource,
                 &RequestContext { is_internal: true },
@@ -3270,16 +3913,15 @@ mod policy_builder_tests {
         // Should deny for external requests
         let result = policy
             .evaluate_access(
-                &TestSubject { name: "Anyone".into() },
+                &TestSubject {
+                    name: "Anyone".into(),
+                },
                 &TestAction,
                 &TestResource,
                 &RequestContext { is_internal: false },
             )
             .await;
-        assert!(
-            !result.is_granted(),
-            "Policy should deny external requests"
-        );
+        assert!(!result.is_granted(), "Policy should deny external requests");
     }
 
     // Test combining all predicates
@@ -3317,7 +3959,9 @@ mod policy_builder_tests {
                 &FullSubject {
                     role: "admin".into(),
                 },
-                &FullAction { name: "read".into() },
+                &FullAction {
+                    name: "read".into(),
+                },
                 &FullResource {
                     category: "document".into(),
                 },
@@ -3337,7 +3981,9 @@ mod policy_builder_tests {
                 &FullSubject {
                     role: "user".into(),
                 },
-                &FullAction { name: "read".into() },
+                &FullAction {
+                    name: "read".into(),
+                },
                 &FullResource {
                     category: "document".into(),
                 },
@@ -3373,7 +4019,9 @@ mod policy_builder_tests {
                 &FullSubject {
                     role: "admin".into(),
                 },
-                &FullAction { name: "read".into() },
+                &FullAction {
+                    name: "read".into(),
+                },
                 &FullResource {
                     category: "video".into(),
                 },
@@ -3390,7 +4038,9 @@ mod policy_builder_tests {
                 &FullSubject {
                     role: "admin".into(),
                 },
-                &FullAction { name: "read".into() },
+                &FullAction {
+                    name: "read".into(),
+                },
                 &FullResource {
                     category: "document".into(),
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2365,6 +2365,14 @@ where
 /// then loads relationship facts through the request-scoped
 /// [`EvaluationSession`].
 ///
+/// The `Relation` type can be a domain enum rather than a string. That keeps
+/// policy code type-safe while leaving backend-specific serialization inside
+/// the [`FactSource`]. For example, a SQL-backed source can load
+/// `RelationshipQuery<Uuid, Uuid, Relation>` keys and convert
+/// `Relation::Viewer` to a `text` column value only when binding query
+/// parameters. The session deduplicates and caches by the typed key, not by the
+/// serialized storage representation.
+///
 /// ```rust
 /// use async_trait::async_trait;
 /// use std::collections::HashSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,13 +601,59 @@ where
     }
 }
 
+/// Error returned by non-panicking fact-source registration helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FactSourceRegistrationError {
+    /// The session is the process-wide empty session and cannot accept sources.
+    SharedEmptySession {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+    },
+    /// A source is already registered for this exact fact key type.
+    AlreadyRegistered {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+    },
+    /// Loads for this fact key type are currently in flight.
+    InFlight {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+    },
+}
+
+impl fmt::Display for FactSourceRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SharedEmptySession { .. } => write!(
+                f,
+                "EvaluationSession::shared_empty() cannot register fact sources; use EvaluationSession::new() or EvaluationSession::builder()",
+            ),
+            Self::AlreadyRegistered { fact_name } => write!(
+                f,
+                "fact source for '{fact_name}' is already registered; use replace or replace_arc to overwrite it",
+            ),
+            Self::InFlight { .. } => write!(
+                f,
+                "fact sources should not be registered or replaced while loads for the same key type are in flight",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FactSourceRegistrationError {}
+
 #[derive(Default)]
 struct EvaluationSessionInner {
-    sources: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
-    caches: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
-    in_flight: Mutex<HashMap<TypeId, Box<dyn Any + Send>>>,
+    registry: Mutex<FactRegistry>,
     next_load_id: AtomicU64,
     shared_empty: bool,
+}
+
+#[derive(Default)]
+struct FactRegistry {
+    sources: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+    caches: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+    in_flight: HashMap<TypeId, Box<dyn Any + Send>>,
 }
 
 /// Request-scoped fact loading and caching state.
@@ -665,7 +711,10 @@ impl EvaluationSession {
     /// Registers a fact source for one key type.
     ///
     /// Panics if a source for `K` is already registered. Use [`Self::replace`]
-    /// when replacing a source is intentional.
+    /// when replacing a source is intentional. Register sources during session
+    /// setup; registering while loads for the same key type are in flight is
+    /// not a supported operation and will panic. Use [`Self::try_register`]
+    /// when the caller should handle registration errors without panicking.
     pub fn register<K, S>(&self, source: S)
     where
         K: FactKey,
@@ -674,11 +723,22 @@ impl EvaluationSession {
         self.register_arc::<K>(Arc::new(source));
     }
 
+    /// Attempts to register a fact source for one key type.
+    pub fn try_register<K, S>(&self, source: S) -> Result<(), FactSourceRegistrationError>
+    where
+        K: FactKey,
+        S: FactSource<K> + 'static,
+    {
+        self.try_register_arc::<K>(Arc::new(source))
+    }
+
     /// Registers a shared fact source for one key type.
     ///
     /// Panics if a source for `K` is already registered. Register sources
     /// during session setup; use [`Self::replace_arc`] only when overwriting is
-    /// deliberate.
+    /// deliberate. Registering while loads for the same key type are in flight
+    /// is not a supported operation and will panic. Use [`Self::try_register_arc`]
+    /// when the caller should handle registration errors without panicking.
     ///
     /// The registry is keyed by the exact Rust fact key type. If two production
     /// backends serve the same logical shape, such as the same
@@ -690,7 +750,19 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
-        self.insert_source::<K>(source, false);
+        self.try_register_arc::<K>(source)
+            .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    /// Attempts to register a shared fact source for one key type.
+    pub fn try_register_arc<K>(
+        &self,
+        source: Arc<dyn FactSource<K>>,
+    ) -> Result<(), FactSourceRegistrationError>
+    where
+        K: FactKey,
+    {
+        self.insert_source::<K>(source, false)
     }
 
     /// Explicitly replaces a fact source for one key type.
@@ -706,6 +778,15 @@ impl EvaluationSession {
         self.replace_arc::<K>(Arc::new(source));
     }
 
+    /// Attempts to replace a fact source for one key type.
+    pub fn try_replace<K, S>(&self, source: S) -> Result<(), FactSourceRegistrationError>
+    where
+        K: FactKey,
+        S: FactSource<K> + 'static,
+    {
+        self.try_replace_arc::<K>(Arc::new(source))
+    }
+
     /// Explicitly replaces a shared fact source for one key type.
     ///
     /// Replacing a source clears any cached facts for that key type in this
@@ -715,56 +796,52 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
-        self.insert_source::<K>(source, true);
+        self.try_replace_arc::<K>(source)
+            .unwrap_or_else(|error| panic!("{error}"));
     }
 
-    fn insert_source<K>(&self, source: Arc<dyn FactSource<K>>, replace: bool)
+    /// Attempts to replace a shared fact source for one key type.
+    pub fn try_replace_arc<K>(
+        &self,
+        source: Arc<dyn FactSource<K>>,
+    ) -> Result<(), FactSourceRegistrationError>
     where
         K: FactKey,
     {
-        assert!(
-            !self.inner.shared_empty,
-            "EvaluationSession::shared_empty() cannot register fact sources; use EvaluationSession::new() or EvaluationSession::builder()",
-        );
-        let type_id = TypeId::of::<K>();
-        let in_flight_empty = {
-            let mut in_flight = self
-                .inner
-                .in_flight
-                .lock()
-                .expect("fact in-flight registry mutex should not be poisoned");
-            Self::in_flight_for::<K>(&mut in_flight).is_empty()
-        };
-        assert!(
-            in_flight_empty,
-            "fact sources should not be replaced while loads for the same key type are in flight",
-        );
-        let duplicate_registration = {
-            let mut sources = self
-                .inner
-                .sources
-                .lock()
-                .expect("fact source registry mutex should not be poisoned");
-            if !replace && sources.contains_key(&type_id) {
-                true
-            } else {
-                sources.insert(type_id, Box::new(source));
-                false
-            }
-        };
+        self.insert_source::<K>(source, true)
+    }
 
-        if duplicate_registration {
-            panic!(
-                "fact source for '{}' is already registered; use replace or replace_arc to overwrite it",
-                K::NAME
-            );
+    fn insert_source<K>(
+        &self,
+        source: Arc<dyn FactSource<K>>,
+        replace: bool,
+    ) -> Result<(), FactSourceRegistrationError>
+    where
+        K: FactKey,
+    {
+        if self.inner.shared_empty {
+            return Err(FactSourceRegistrationError::SharedEmptySession { fact_name: K::NAME });
         }
 
-        self.inner
-            .caches
-            .lock()
-            .expect("fact cache mutex should not be poisoned")
-            .remove(&type_id);
+        let type_id = TypeId::of::<K>();
+        {
+            let mut registry = self
+                .inner
+                .registry
+                .lock()
+                .expect("fact registry mutex should not be poisoned");
+
+            if !replace && registry.sources.contains_key(&type_id) {
+                return Err(FactSourceRegistrationError::AlreadyRegistered { fact_name: K::NAME });
+            } else if !Self::in_flight_for::<K>(&mut registry.in_flight).is_empty() {
+                return Err(FactSourceRegistrationError::InFlight { fact_name: K::NAME });
+            } else {
+                registry.sources.insert(type_id, Box::new(source));
+                registry.caches.remove(&type_id);
+            }
+        }
+
+        Ok(())
     }
 
     /// Loads one fact through the session cache.
@@ -798,12 +875,15 @@ impl EvaluationSession {
             return Vec::new();
         }
 
-        let source = self.source::<K>();
         let load_plan = self.plan_loads(keys);
+        if let Some(results) = load_plan.cached_results {
+            return results;
+        }
+
         let mut in_flight_guard = InFlightGuard::new(self.clone(), load_plan.keys.clone());
 
         if !load_plan.keys.is_empty() {
-            if let Some(source) = source {
+            if let Some(source) = load_plan.source.clone() {
                 let chunk_size = source
                     .max_batch_size()
                     .map_or(load_plan.keys.len(), NonZeroUsize::get)
@@ -864,44 +944,59 @@ impl EvaluationSession {
         self.results_from_cache(keys)
     }
 
-    fn source<K>(&self) -> Option<Arc<dyn FactSource<K>>>
-    where
-        K: FactKey,
-    {
-        self.inner
-            .sources
-            .lock()
-            .expect("fact source registry mutex should not be poisoned")
-            .get(&TypeId::of::<K>())
-            .and_then(|source| source.downcast_ref::<Arc<dyn FactSource<K>>>().cloned())
-    }
-
     fn plan_loads<K>(&self, keys: &[K]) -> LoadPlan<K>
     where
         K: FactKey,
     {
         let mut seen = HashSet::new();
         let mut missing = Vec::new();
-        let mut caches = self
+        let mut registry = self
             .inner
-            .caches
+            .registry
             .lock()
-            .expect("fact cache mutex should not be poisoned");
-        let cache = Self::cache_for::<K>(&mut caches);
+            .expect("fact registry mutex should not be poisoned");
+        let source = registry
+            .sources
+            .get(&TypeId::of::<K>())
+            .and_then(|source| source.downcast_ref::<Arc<dyn FactSource<K>>>().cloned());
+        let cached_results = {
+            let cache = Self::cache_for::<K>(&mut registry.caches);
+            let mut results = Vec::with_capacity(keys.len());
+            let mut all_cached = true;
 
-        let mut in_flight = self
-            .inner
-            .in_flight
-            .lock()
-            .expect("fact in-flight registry mutex should not be poisoned");
-        let in_flight = Self::in_flight_for::<K>(&mut in_flight);
+            for key in keys {
+                if let Some(result) = cache.get(key) {
+                    results.push(result.clone());
+                } else {
+                    all_cached = false;
+                    break;
+                }
+            }
+
+            all_cached.then_some(results)
+        };
+
+        if let Some(cached_results) = cached_results {
+            return LoadPlan {
+                source,
+                cached_results: Some(cached_results),
+                keys: Vec::new(),
+                waiters: Vec::new(),
+            };
+        }
+
         let mut waiters = Vec::new();
 
         for key in keys.iter().filter(|key| seen.insert((*key).clone())) {
-            if cache.contains_key(key) {
+            let is_cached = {
+                let cache = Self::cache_for::<K>(&mut registry.caches);
+                cache.contains_key(key)
+            };
+            if is_cached {
                 continue;
             }
 
+            let in_flight = Self::in_flight_for::<K>(&mut registry.in_flight);
             if let Some(existing_waiters) = in_flight.get_mut(key) {
                 let (sender, receiver) = oneshot::channel();
                 existing_waiters.push(sender);
@@ -913,6 +1008,8 @@ impl EvaluationSession {
         }
 
         LoadPlan {
+            source,
+            cached_results: None,
             keys: missing,
             waiters,
         }
@@ -922,12 +1019,12 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
-        let mut in_flight = self
+        let mut registry = self
             .inner
-            .in_flight
+            .registry
             .lock()
-            .expect("fact in-flight registry mutex should not be poisoned");
-        let in_flight = Self::in_flight_for::<K>(&mut in_flight);
+            .expect("fact registry mutex should not be poisoned");
+        let in_flight = Self::in_flight_for::<K>(&mut registry.in_flight);
 
         for key in keys {
             if let Some(waiters) = in_flight.remove(key) {
@@ -942,12 +1039,12 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
-        let mut caches = self
+        let mut registry = self
             .inner
-            .caches
+            .registry
             .lock()
-            .expect("fact cache mutex should not be poisoned");
-        let cache = Self::cache_for::<K>(&mut caches);
+            .expect("fact registry mutex should not be poisoned");
+        let cache = Self::cache_for::<K>(&mut registry.caches);
 
         for (key, result) in keys.iter().cloned().zip(results) {
             cache.insert(key, result);
@@ -958,12 +1055,12 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
-        let mut caches = self
+        let mut registry = self
             .inner
-            .caches
+            .registry
             .lock()
-            .expect("fact cache mutex should not be poisoned");
-        let cache = Self::cache_for::<K>(&mut caches);
+            .expect("fact registry mutex should not be poisoned");
+        let cache = Self::cache_for::<K>(&mut registry.caches);
         keys.iter()
             .map(|key| {
                 cache.get(key).cloned().unwrap_or_else(|| {
@@ -1046,7 +1143,12 @@ impl EvaluationSessionBuilder {
     }
 }
 
-struct LoadPlan<K> {
+struct LoadPlan<K>
+where
+    K: FactKey,
+{
+    source: Option<Arc<dyn FactSource<K>>>,
+    cached_results: Option<Vec<FactLoadResult<K::Value>>>,
     keys: Vec<K>,
     waiters: Vec<oneshot::Receiver<()>>,
 }
@@ -1785,23 +1887,23 @@ where
             }
 
             let policy_type = policy.policy_type();
-            let policy_span = tracing::debug_span!(
-                "gatehouse.batch_policy",
-                policy.type = policy_type,
-                policy.pending_count = pending.len(),
-                policy.granted_count = tracing::field::Empty,
-                policy.denied_count = tracing::field::Empty,
-            );
-
             let mut still_pending = Vec::new();
-            let mut policy_granted_count = 0usize;
-            let mut policy_denied_count = 0usize;
             let chunk_size = self
                 .max_batch_size
                 .map_or(pending.len(), NonZeroUsize::get)
                 .max(1);
+            let chunk_count = pending.len().div_ceil(chunk_size);
 
-            for pending_chunk in pending.chunks(chunk_size) {
+            for (chunk_index, pending_chunk) in pending.chunks(chunk_size).enumerate() {
+                let policy_span = tracing::debug_span!(
+                    "gatehouse.batch_policy",
+                    policy.type = policy_type,
+                    policy.pending_count = pending_chunk.len(),
+                    policy.chunk_index = chunk_index,
+                    policy.chunk_count = chunk_count,
+                    policy.granted_count = tracing::field::Empty,
+                    policy.denied_count = tracing::field::Empty,
+                );
                 let batch_items: Vec<_> = pending_chunk
                     .iter()
                     .map(|&index| PolicyBatchItem {
@@ -1821,9 +1923,12 @@ where
                     .instrument(policy_span.clone())
                     .await;
 
+                let mut chunk_granted_count = 0usize;
+                let mut chunk_denied_count = 0usize;
+
                 if policy_results.len() != pending_chunk.len() {
                     for &index in pending_chunk {
-                        policy_denied_count += 1;
+                        chunk_denied_count += 1;
                         let policy_result = PolicyEvalResult::Denied {
                             policy_type: policy_type.to_string(),
                             reason: "Policy batch result count did not match input count"
@@ -1842,6 +1947,8 @@ where
                                 .to_string(),
                         });
                     }
+                    policy_span.record("policy.granted_count", chunk_granted_count);
+                    policy_span.record("policy.denied_count", chunk_denied_count);
                     continue;
                 }
 
@@ -1852,7 +1959,7 @@ where
                     traces[index].push(result);
 
                     if result_passes {
-                        policy_granted_count += 1;
+                        chunk_granted_count += 1;
                         let combined = PolicyEvalResult::Combined {
                             policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
                             operation: CombineOp::Or,
@@ -1865,13 +1972,13 @@ where
                             trace: EvalTrace::with_root(combined),
                         });
                     } else {
-                        policy_denied_count += 1;
+                        chunk_denied_count += 1;
                         still_pending.push(index);
                     }
                 }
+                policy_span.record("policy.granted_count", chunk_granted_count);
+                policy_span.record("policy.denied_count", chunk_denied_count);
             }
-            policy_span.record("policy.granted_count", policy_granted_count);
-            policy_span.record("policy.denied_count", policy_denied_count);
             pending = still_pending;
         }
 
@@ -2655,11 +2762,12 @@ where
         &self,
         ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
+        let subject_id = (self.subject_id)(ctx.subject);
         let keys = ctx
             .items
             .iter()
             .map(|item| RelationshipQuery {
-                subject_id: (self.subject_id)(ctx.subject),
+                subject_id: subject_id.clone(),
                 resource_id: (self.resource_id)(item.resource),
                 relation: self.relation.clone(),
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2871,6 +2871,9 @@ fn delegated_evaluation_to_result(
 /// The subject and action mappers run once per batch. Resource and context
 /// mappers run once per item. Mapper closures return child-domain values; use
 /// lightweight IDs, newtypes, or `Arc` values when mapping larger objects.
+///
+/// `DelegatingPolicy` does not detect cycles or self-delegation; avoid wiring a
+/// child checker that can delegate back into the same decision path.
 pub struct DelegatingPolicy<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext> {
     policy_type: String,
     security_rule: SecurityRuleMetadata,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@
 #![allow(clippy::type_complexity)]
 use async_trait::async_trait;
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 const DEFAULT_SECURITY_RULE_CATEGORY: &str = "Access Control";
@@ -735,6 +736,7 @@ where
 #[derive(Clone)]
 pub struct PermissionChecker<S, R, A, C> {
     policies: Vec<Arc<dyn Policy<S, R, A, C>>>,
+    max_batch_size: Option<NonZeroUsize>,
 }
 
 impl<S, R, A, C> Default for PermissionChecker<S, R, A, C>
@@ -760,7 +762,18 @@ where
     pub fn new() -> Self {
         Self {
             policies: Vec::new(),
+            max_batch_size: None,
         }
+    }
+
+    /// Sets the maximum number of pending items passed to a policy batch call.
+    ///
+    /// By default, batch evaluation passes all pending items to each policy in a
+    /// single call. Configure this when backend limits, query planner behavior,
+    /// or remote service constraints require smaller chunks.
+    pub fn with_max_batch_size(mut self, max_batch_size: NonZeroUsize) -> Self {
+        self.max_batch_size = Some(max_batch_size);
+        self
     }
 
     /// Adds a policy to the checker.
@@ -922,7 +935,7 @@ where
     /// assert_eq!(visible.len(), 1);
     /// # });
     /// ```
-    #[tracing::instrument(skip_all, fields(item_count, granted_count, denied_count, policy_count = self.policies.len()))]
+    #[tracing::instrument(skip_all, fields(item_count, granted_count, denied_count, max_batch_size, policy_count = self.policies.len()))]
     pub async fn evaluate_batch_by<I, F>(
         &self,
         subject: &S,
@@ -937,6 +950,9 @@ where
         let items: Vec<I::Item> = items.into_iter().collect();
         let item_count = items.len();
         tracing::Span::current().record("item_count", item_count);
+        if let Some(max_batch_size) = self.max_batch_size {
+            tracing::Span::current().record("max_batch_size", max_batch_size.get());
+        }
 
         let mut traces = vec![Vec::new(); item_count];
         let mut evaluations: Vec<Option<AccessEvaluation>> = vec![None; item_count];
@@ -972,62 +988,70 @@ where
                 break;
             }
 
-            let batch_items: Vec<_> = pending
-                .iter()
-                .map(|&index| {
-                    let (resource, context) = parts(&items[index]);
-                    PolicyBatchItem { resource, context }
-                })
-                .collect();
-
-            let policy_results = policy
-                .evaluate_access_batch(subject, action, &batch_items)
-                .await;
-
-            if policy_results.len() != pending.len() {
-                for index in pending {
-                    let policy_result = PolicyEvalResult::Denied {
-                        policy_type: policy.policy_type(),
-                        reason: "Policy batch result count did not match input count".to_string(),
-                    };
-                    traces[index].push(policy_result);
-                    let combined = PolicyEvalResult::Combined {
-                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
-                        operation: CombineOp::Or,
-                        children: std::mem::take(&mut traces[index]),
-                        outcome: false,
-                    };
-                    evaluations[index] = Some(AccessEvaluation::Denied {
-                        trace: EvalTrace::with_root(combined),
-                        reason: "Policy batch result count did not match input count".to_string(),
-                    });
-                }
-                pending = Vec::new();
-                break;
-            }
-
             let mut still_pending = Vec::new();
-            for (index, result) in pending.into_iter().zip(policy_results) {
-                let result_passes = result.is_granted();
-                let policy_type = policy.policy_type();
-                let reason = result.reason();
+            let chunk_size = self
+                .max_batch_size
+                .map_or(pending.len(), NonZeroUsize::get)
+                .max(1);
 
-                traces[index].push(result);
+            for pending_chunk in pending.chunks(chunk_size) {
+                let batch_items: Vec<_> = pending_chunk
+                    .iter()
+                    .map(|&index| {
+                        let (resource, context) = parts(&items[index]);
+                        PolicyBatchItem { resource, context }
+                    })
+                    .collect();
 
-                if result_passes {
-                    let combined = PolicyEvalResult::Combined {
-                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
-                        operation: CombineOp::Or,
-                        children: std::mem::take(&mut traces[index]),
-                        outcome: true,
-                    };
-                    evaluations[index] = Some(AccessEvaluation::Granted {
-                        policy_type,
-                        reason,
-                        trace: EvalTrace::with_root(combined),
-                    });
-                } else {
-                    still_pending.push(index);
+                let policy_results = policy
+                    .evaluate_access_batch(subject, action, &batch_items)
+                    .await;
+
+                if policy_results.len() != pending_chunk.len() {
+                    for &index in pending_chunk {
+                        let policy_result = PolicyEvalResult::Denied {
+                            policy_type: policy.policy_type(),
+                            reason: "Policy batch result count did not match input count"
+                                .to_string(),
+                        };
+                        traces[index].push(policy_result);
+                        let combined = PolicyEvalResult::Combined {
+                            policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                            operation: CombineOp::Or,
+                            children: std::mem::take(&mut traces[index]),
+                            outcome: false,
+                        };
+                        evaluations[index] = Some(AccessEvaluation::Denied {
+                            trace: EvalTrace::with_root(combined),
+                            reason: "Policy batch result count did not match input count"
+                                .to_string(),
+                        });
+                    }
+                    continue;
+                }
+
+                for (&index, result) in pending_chunk.iter().zip(policy_results) {
+                    let result_passes = result.is_granted();
+                    let policy_type = policy.policy_type();
+                    let reason = result.reason();
+
+                    traces[index].push(result);
+
+                    if result_passes {
+                        let combined = PolicyEvalResult::Combined {
+                            policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                            operation: CombineOp::Or,
+                            children: std::mem::take(&mut traces[index]),
+                            outcome: true,
+                        };
+                        evaluations[index] = Some(AccessEvaluation::Granted {
+                            policy_type,
+                            reason,
+                            trace: EvalTrace::with_root(combined),
+                        });
+                    } else {
+                        still_pending.push(index);
+                    }
                 }
             }
             pending = still_pending;
@@ -1909,6 +1933,82 @@ where
             outcome: true,
         }
     }
+
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item S,
+        action: &'item A,
+        items: &'item [PolicyBatchItem<'item, R, C>],
+    ) -> Vec<PolicyEvalResult> {
+        let mut children_by_item = vec![Vec::new(); items.len()];
+        let mut results = vec![None; items.len()];
+        let mut pending = (0..items.len()).collect::<Vec<_>>();
+
+        for policy in &self.policies {
+            if pending.is_empty() {
+                break;
+            }
+
+            let batch_items = pending
+                .iter()
+                .map(|&index| PolicyBatchItem {
+                    resource: items[index].resource,
+                    context: items[index].context,
+                })
+                .collect::<Vec<_>>();
+            let child_results = policy
+                .evaluate_access_batch(subject, action, &batch_items)
+                .await;
+
+            if child_results.len() != pending.len() {
+                for index in pending.drain(..) {
+                    children_by_item[index].push(PolicyEvalResult::Denied {
+                        policy_type: policy.policy_type(),
+                        reason: "Policy batch result count did not match input count".to_string(),
+                    });
+                    results[index] = Some(PolicyEvalResult::Combined {
+                        policy_type: self.policy_type(),
+                        operation: CombineOp::And,
+                        children: std::mem::take(&mut children_by_item[index]),
+                        outcome: false,
+                    });
+                }
+                break;
+            }
+
+            let mut still_pending = Vec::new();
+            for (index, child_result) in pending.into_iter().zip(child_results) {
+                let is_granted = child_result.is_granted();
+                children_by_item[index].push(child_result);
+
+                if is_granted {
+                    still_pending.push(index);
+                } else {
+                    results[index] = Some(PolicyEvalResult::Combined {
+                        policy_type: self.policy_type(),
+                        operation: CombineOp::And,
+                        children: std::mem::take(&mut children_by_item[index]),
+                        outcome: false,
+                    });
+                }
+            }
+            pending = still_pending;
+        }
+
+        for index in pending {
+            results[index] = Some(PolicyEvalResult::Combined {
+                policy_type: self.policy_type(),
+                operation: CombineOp::And,
+                children: std::mem::take(&mut children_by_item[index]),
+                outcome: true,
+            });
+        }
+
+        results
+            .into_iter()
+            .map(|result| result.expect("every batch item should be evaluated"))
+            .collect()
+    }
 }
 
 /// OrPolicy
@@ -1979,6 +2079,82 @@ where
             outcome: false,
         }
     }
+
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item S,
+        action: &'item A,
+        items: &'item [PolicyBatchItem<'item, R, C>],
+    ) -> Vec<PolicyEvalResult> {
+        let mut children_by_item = vec![Vec::new(); items.len()];
+        let mut results = vec![None; items.len()];
+        let mut pending = (0..items.len()).collect::<Vec<_>>();
+
+        for policy in &self.policies {
+            if pending.is_empty() {
+                break;
+            }
+
+            let batch_items = pending
+                .iter()
+                .map(|&index| PolicyBatchItem {
+                    resource: items[index].resource,
+                    context: items[index].context,
+                })
+                .collect::<Vec<_>>();
+            let child_results = policy
+                .evaluate_access_batch(subject, action, &batch_items)
+                .await;
+
+            if child_results.len() != pending.len() {
+                for index in pending.drain(..) {
+                    children_by_item[index].push(PolicyEvalResult::Denied {
+                        policy_type: policy.policy_type(),
+                        reason: "Policy batch result count did not match input count".to_string(),
+                    });
+                    results[index] = Some(PolicyEvalResult::Combined {
+                        policy_type: self.policy_type(),
+                        operation: CombineOp::Or,
+                        children: std::mem::take(&mut children_by_item[index]),
+                        outcome: false,
+                    });
+                }
+                break;
+            }
+
+            let mut still_pending = Vec::new();
+            for (index, child_result) in pending.into_iter().zip(child_results) {
+                let is_granted = child_result.is_granted();
+                children_by_item[index].push(child_result);
+
+                if is_granted {
+                    results[index] = Some(PolicyEvalResult::Combined {
+                        policy_type: self.policy_type(),
+                        operation: CombineOp::Or,
+                        children: std::mem::take(&mut children_by_item[index]),
+                        outcome: true,
+                    });
+                } else {
+                    still_pending.push(index);
+                }
+            }
+            pending = still_pending;
+        }
+
+        for index in pending {
+            results[index] = Some(PolicyEvalResult::Combined {
+                policy_type: self.policy_type(),
+                operation: CombineOp::Or,
+                children: std::mem::take(&mut children_by_item[index]),
+                outcome: false,
+            });
+        }
+
+        results
+            .into_iter()
+            .map(|result| result.expect("every batch item should be evaluated"))
+            .collect()
+    }
 }
 
 /// NotPolicy
@@ -2036,6 +2212,41 @@ where
             children: vec![inner_result],
             outcome: !is_granted,
         }
+    }
+
+    async fn evaluate_access_batch<'item>(
+        &self,
+        subject: &'item S,
+        action: &'item A,
+        items: &'item [PolicyBatchItem<'item, R, C>],
+    ) -> Vec<PolicyEvalResult> {
+        let inner_results = self
+            .policy
+            .evaluate_access_batch(subject, action, items)
+            .await;
+
+        if inner_results.len() != items.len() {
+            return items
+                .iter()
+                .map(|_| PolicyEvalResult::Denied {
+                    policy_type: self.policy_type(),
+                    reason: "Policy batch result count did not match input count".to_string(),
+                })
+                .collect();
+        }
+
+        inner_results
+            .into_iter()
+            .map(|inner_result| {
+                let is_granted = inner_result.is_granted();
+                PolicyEvalResult::Combined {
+                    policy_type: self.policy_type(),
+                    operation: CombineOp::Not,
+                    children: vec![inner_result],
+                    outcome: !is_granted,
+                }
+            })
+            .collect()
     }
 }
 
@@ -2295,6 +2506,149 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2, 4]
         );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_batch_by_respects_max_batch_size() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..8)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut checker =
+            PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(3).unwrap());
+        checker.add_policy(EvenResourceBatchPolicy {
+            batch_calls: Arc::clone(&batch_calls),
+            single_calls: Arc::clone(&single_calls),
+        });
+
+        let results = checker
+            .filter_authorized_by(&subject, &TestAction, resources, |item| (&item.0, &item.1))
+            .await;
+
+        assert_eq!(
+            results
+                .into_iter()
+                .map(|(resource, _context)| resource.id.as_u128())
+                .collect::<Vec<_>>(),
+            vec![0, 2, 4, 6]
+        );
+        assert_eq!(batch_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(single_calls.load(Ordering::SeqCst), 8);
+    }
+
+    #[tokio::test]
+    async fn test_and_policy_batch_uses_inner_batch_hook() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..4)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let inner: Arc<dyn Policy<TestSubject, TestResource, TestAction, TestContext>> =
+            Arc::new(EvenResourceBatchPolicy {
+                batch_calls: Arc::clone(&batch_calls),
+                single_calls: Arc::clone(&single_calls),
+            });
+        let policy = AndPolicy::try_new(vec![inner]).unwrap();
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(policy);
+
+        let authorized = checker
+            .filter_authorized_by(&subject, &TestAction, resources, |item| (&item.0, &item.1))
+            .await;
+
+        assert_eq!(authorized.len(), 2);
+        assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(single_calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn test_or_policy_batch_uses_inner_batch_hook() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..4)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let inner: Arc<dyn Policy<TestSubject, TestResource, TestAction, TestContext>> =
+            Arc::new(EvenResourceBatchPolicy {
+                batch_calls: Arc::clone(&batch_calls),
+                single_calls: Arc::clone(&single_calls),
+            });
+        let policy = OrPolicy::try_new(vec![inner]).unwrap();
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(policy);
+
+        let authorized = checker
+            .filter_authorized_by(&subject, &TestAction, resources, |item| (&item.0, &item.1))
+            .await;
+
+        assert_eq!(authorized.len(), 2);
+        assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(single_calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn test_not_policy_batch_uses_inner_batch_hook() {
+        let batch_calls = Arc::new(AtomicUsize::new(0));
+        let single_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..4)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let policy = NotPolicy::new(EvenResourceBatchPolicy {
+            batch_calls: Arc::clone(&batch_calls),
+            single_calls: Arc::clone(&single_calls),
+        });
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(policy);
+
+        let authorized = checker
+            .filter_authorized_by(&subject, &TestAction, resources, |item| (&item.0, &item.1))
+            .await;
+
+        assert_eq!(authorized.len(), 2);
+        assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(single_calls.load(Ordering::SeqCst), 4);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,9 @@
 //! - [`OrPolicy`]: Grants access if any inner policy allows access; otherwise returns a
 //!   combined error.
 //! - [`NotPolicy`]: Inverts the decision of an inner policy.
+//! - [`DelegatingPolicy`]: Maps the current inputs into another authorization
+//!   domain and delegates to a child [`PermissionChecker`] while preserving
+//!   batching.
 //!
 //!
 
@@ -269,7 +272,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tracing::Instrument;
 
 const DEFAULT_SECURITY_RULE_CATEGORY: &str = "Access Control";
@@ -395,6 +398,8 @@ pub enum CombineOp {
     Or,
     /// The inner policy's decision is inverted.
     Not,
+    /// A parent policy delegated the decision to another checker.
+    Delegate,
 }
 
 impl fmt::Display for CombineOp {
@@ -403,6 +408,7 @@ impl fmt::Display for CombineOp {
             CombineOp::And => write!(f, "AND"),
             CombineOp::Or => write!(f, "OR"),
             CombineOp::Not => write!(f, "NOT"),
+            CombineOp::Delegate => write!(f, "DELEGATE"),
         }
     }
 }
@@ -506,6 +512,12 @@ pub enum FactLoadError {
         actual: usize,
     },
     /// The leader task for a fact load was cancelled before it completed.
+    ///
+    /// The session caches this error for the affected keys and wakes any
+    /// waiters. This is correct for request-scoped sessions: the request fails
+    /// closed and the next request builds a fresh session. Do not share a
+    /// fact-loaded session across independent requests, because cancellation in
+    /// one request would cache this error for the others.
     LoaderCancelled {
         /// Diagnostic fact name from [`FactKey::NAME`].
         fact_name: &'static str,
@@ -595,6 +607,7 @@ struct EvaluationSessionInner {
     caches: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
     in_flight: Mutex<HashMap<TypeId, Box<dyn Any + Send>>>,
     next_load_id: AtomicU64,
+    shared_empty: bool,
 }
 
 /// Request-scoped fact loading and caching state.
@@ -619,8 +632,28 @@ impl EvaluationSession {
     ///
     /// This is equivalent to [`Self::new`]. It can make call sites clearer when
     /// only RBAC/ABAC policies are expected and no fact sources are registered.
+    /// For very hot RBAC/ABAC-only loops, use [`Self::shared_empty`] to avoid
+    /// allocating a new empty session per call.
     pub fn empty() -> Self {
         Self::new()
+    }
+
+    /// Returns a process-wide empty session for hot paths that never use fact
+    /// sources.
+    ///
+    /// This avoids allocating a new empty session for RBAC/ABAC-only checks in
+    /// tight loops such as fanout or SSE frame authorization. It is only safe
+    /// when no fact-backed policies are expected. Calling [`Self::register`],
+    /// [`Self::register_arc`], [`Self::replace`], or [`Self::replace_arc`] on
+    /// this session will panic.
+    pub fn shared_empty() -> &'static Self {
+        static SHARED_EMPTY: OnceLock<EvaluationSession> = OnceLock::new();
+        SHARED_EMPTY.get_or_init(|| EvaluationSession {
+            inner: Arc::new(EvaluationSessionInner {
+                shared_empty: true,
+                ..EvaluationSessionInner::default()
+            }),
+        })
     }
 
     /// Starts building a request-scoped session with all fact sources declared
@@ -646,6 +679,13 @@ impl EvaluationSession {
     /// Panics if a source for `K` is already registered. Register sources
     /// during session setup; use [`Self::replace_arc`] only when overwriting is
     /// deliberate.
+    ///
+    /// The registry is keyed by the exact Rust fact key type. If two production
+    /// backends serve the same logical shape, such as the same
+    /// `RelationshipQuery<UserId, ConversationId, ParticipantRelation>`, they
+    /// cannot both be registered under that exact type in one session. Wrap one
+    /// ID/relation type or define distinct fact keys so each backend has a
+    /// separate registry entry.
     pub fn register_arc<K>(&self, source: Arc<dyn FactSource<K>>)
     where
         K: FactKey,
@@ -682,6 +722,10 @@ impl EvaluationSession {
     where
         K: FactKey,
     {
+        assert!(
+            !self.inner.shared_empty,
+            "EvaluationSession::shared_empty() cannot register fact sources; use EvaluationSession::new() or EvaluationSession::builder()",
+        );
         let type_id = TypeId::of::<K>();
         let in_flight_empty = {
             let mut in_flight = self
@@ -711,7 +755,7 @@ impl EvaluationSession {
 
         if duplicate_registration {
             panic!(
-                "fact source for '{}' is already registered; use replace_arc to overwrite it",
+                "fact source for '{}' is already registered; use replace or replace_arc to overwrite it",
                 K::NAME
             );
         }
@@ -1389,6 +1433,9 @@ impl fmt::Display for PolicyEvalResult {
 /// A generic async trait representing a single authorization policy.
 /// A policy determines if a subject is allowed to perform an action on
 /// a resource within a given context.
+///
+/// The input types must be [`Sync`] because policies receive borrowed inputs
+/// across async evaluation, including [`BatchEvalCtx`] batch evaluation.
 #[async_trait]
 pub trait Policy<Subject, Resource, Action, Context>: Send + Sync
 where
@@ -1944,6 +1991,58 @@ where
         .into_iter()
         .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
         .collect()
+    }
+}
+
+impl<S, R, A> PermissionChecker<S, R, A, ()>
+where
+    S: Sync,
+    R: Sync,
+    A: Sync,
+{
+    /// Evaluates a batch where each caller-owned item is the resource and the
+    /// context type is `()`.
+    ///
+    /// This is the ergonomic shortcut for list-like checks that do not need a
+    /// per-item context value.
+    pub async fn evaluate_batch_resources_in_session<I>(
+        &self,
+        session: &EvaluationSession,
+        subject: &S,
+        action: &A,
+        resources: I,
+    ) -> Vec<(R, AccessEvaluation)>
+    where
+        I: IntoIterator<Item = R>,
+    {
+        self.evaluate_batch_with_context_in_session_by(
+            session,
+            subject,
+            action,
+            resources,
+            &(),
+            |resource| resource,
+        )
+        .await
+    }
+
+    /// Returns only resources granted by
+    /// [`Self::evaluate_batch_resources_in_session`].
+    pub async fn filter_authorized_resources_in_session<I>(
+        &self,
+        session: &EvaluationSession,
+        subject: &S,
+        action: &A,
+        resources: I,
+    ) -> Vec<R>
+    where
+        I: IntoIterator<Item = R>,
+    {
+        self.evaluate_batch_resources_in_session(session, subject, action, resources)
+            .await
+            .into_iter()
+            .filter_map(|(resource, evaluation)| evaluation.is_granted().then_some(resource))
+            .collect()
     }
 }
 
@@ -2620,6 +2719,167 @@ where
                 reason: format!("Relationship '{}' fact load failed: {error}", self.relation),
             },
         }
+    }
+}
+
+fn delegated_evaluation_to_result(
+    policy_type: &str,
+    evaluation: AccessEvaluation,
+) -> PolicyEvalResult {
+    match evaluation {
+        AccessEvaluation::Granted {
+            policy_type: child_policy_type,
+            reason,
+            trace,
+        } => PolicyEvalResult::Combined {
+            policy_type: policy_type.to_string(),
+            operation: CombineOp::Delegate,
+            children: vec![trace.root().cloned().unwrap_or(PolicyEvalResult::Granted {
+                policy_type: child_policy_type,
+                reason,
+            })],
+            outcome: true,
+        },
+        AccessEvaluation::Denied { reason, trace } => PolicyEvalResult::Combined {
+            policy_type: policy_type.to_string(),
+            operation: CombineOp::Delegate,
+            children: vec![trace.root().cloned().unwrap_or(PolicyEvalResult::Denied {
+                policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                reason,
+            })],
+            outcome: false,
+        },
+    }
+}
+
+/// A policy that delegates its decision to another [`PermissionChecker`].
+///
+/// Use this when one authorization domain needs to ask another domain's checker
+/// for a decision while preserving the policy-layer trace. For example, a
+/// messaging `ReadConversation` policy can map a conversation to the
+/// procurement object it represents, then delegate to the procurement checker
+/// using the same [`EvaluationSession`].
+///
+/// The subject and action mappers run once per batch. Resource and context
+/// mappers run once per item. Mapper closures return child-domain values; use
+/// lightweight IDs, newtypes, or `Arc` values when mapping larger objects.
+pub struct DelegatingPolicy<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext> {
+    policy_type: String,
+    security_rule: SecurityRuleMetadata,
+    checker: PermissionChecker<ChildSubject, ChildResource, ChildAction, ChildContext>,
+    subject: Arc<dyn Fn(&S) -> ChildSubject + Send + Sync>,
+    action: Arc<dyn Fn(&A) -> ChildAction + Send + Sync>,
+    resource: Arc<dyn Fn(&S, &R, &A, &C) -> ChildResource + Send + Sync>,
+    context: Arc<dyn Fn(&S, &R, &A, &C) -> ChildContext + Send + Sync>,
+}
+
+impl<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext>
+    DelegatingPolicy<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext>
+{
+    /// Creates a delegating policy from a child checker and mapping functions.
+    pub fn new<SubjectFn, ActionFn, ResourceFn, ContextFn>(
+        policy_type: impl Into<String>,
+        checker: PermissionChecker<ChildSubject, ChildResource, ChildAction, ChildContext>,
+        subject: SubjectFn,
+        action: ActionFn,
+        resource: ResourceFn,
+        context: ContextFn,
+    ) -> Self
+    where
+        SubjectFn: Fn(&S) -> ChildSubject + Send + Sync + 'static,
+        ActionFn: Fn(&A) -> ChildAction + Send + Sync + 'static,
+        ResourceFn: Fn(&S, &R, &A, &C) -> ChildResource + Send + Sync + 'static,
+        ContextFn: Fn(&S, &R, &A, &C) -> ChildContext + Send + Sync + 'static,
+    {
+        Self {
+            policy_type: policy_type.into(),
+            security_rule: SecurityRuleMetadata::default(),
+            checker,
+            subject: Arc::new(subject),
+            action: Arc::new(action),
+            resource: Arc::new(resource),
+            context: Arc::new(context),
+        }
+    }
+
+    /// Sets the telemetry metadata emitted for the delegating policy itself.
+    pub fn with_security_rule(mut self, security_rule: SecurityRuleMetadata) -> Self {
+        self.security_rule = security_rule;
+        self
+    }
+}
+
+#[async_trait]
+impl<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext> Policy<S, R, A, C>
+    for DelegatingPolicy<S, R, A, C, ChildSubject, ChildResource, ChildAction, ChildContext>
+where
+    S: Send + Sync,
+    R: Send + Sync,
+    A: Send + Sync,
+    C: Send + Sync,
+    ChildSubject: Send + Sync,
+    ChildResource: Send + Sync,
+    ChildAction: Send + Sync,
+    ChildContext: Send + Sync,
+{
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        let child_subject = (self.subject)(ctx.subject);
+        let child_action = (self.action)(ctx.action);
+        let child_resource = (self.resource)(ctx.subject, ctx.resource, ctx.action, ctx.context);
+        let child_context = (self.context)(ctx.subject, ctx.resource, ctx.action, ctx.context);
+        let evaluation = self
+            .checker
+            .evaluate_in_session(
+                ctx.session,
+                &child_subject,
+                &child_action,
+                &child_resource,
+                &child_context,
+            )
+            .await;
+
+        delegated_evaluation_to_result(&self.policy_type, evaluation)
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
+    ) -> Vec<PolicyEvalResult> {
+        let child_subject = (self.subject)(ctx.subject);
+        let child_action = (self.action)(ctx.action);
+        let child_items = ctx
+            .items
+            .iter()
+            .map(|item| {
+                (
+                    (self.resource)(ctx.subject, item.resource, ctx.action, item.context),
+                    (self.context)(ctx.subject, item.resource, ctx.action, item.context),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        self.checker
+            .evaluate_batch_in_session_by(
+                ctx.session,
+                &child_subject,
+                &child_action,
+                child_items,
+                |(resource, context)| (resource, context),
+            )
+            .await
+            .into_iter()
+            .map(|(_item, evaluation)| {
+                delegated_evaluation_to_result(&self.policy_type, evaluation)
+            })
+            .collect()
+    }
+
+    fn policy_type(&self) -> &str {
+        &self.policy_type
+    }
+
+    fn security_rule(&self) -> SecurityRuleMetadata {
+        self.security_rule.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,19 +420,19 @@ pub enum FactLoadError {
         /// Diagnostic fact name from [`FactKey::NAME`].
         fact_name: &'static str,
     },
-    /// A source returned fewer results than requested.
-    SourceReturnedNoResult {
-        /// Diagnostic fact name from [`FactKey::NAME`].
-        fact_name: &'static str,
-    },
     /// A source violated the one-result-per-input-key contract.
-    WrongResultCount {
+    SourceContractViolation {
         /// Diagnostic fact name from [`FactKey::NAME`].
         fact_name: &'static str,
         /// Number of keys passed to the source.
         expected: usize,
         /// Number of results returned by the source.
         actual: usize,
+    },
+    /// The leader task for a fact load was cancelled before it completed.
+    LoaderCancelled {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
     },
     /// The registered source reported a backend error.
     Backend(Arc<dyn std::error::Error + Send + Sync>),
@@ -456,10 +456,7 @@ impl fmt::Display for FactLoadError {
             Self::SourceNotRegistered { fact_name } => {
                 write!(f, "No fact source registered for '{fact_name}'")
             }
-            Self::SourceReturnedNoResult { fact_name } => {
-                write!(f, "Fact source '{fact_name}' returned no result")
-            }
-            Self::WrongResultCount {
+            Self::SourceContractViolation {
                 fact_name,
                 expected,
                 actual,
@@ -467,6 +464,9 @@ impl fmt::Display for FactLoadError {
                 f,
                 "Fact source '{fact_name}' returned {actual} results for {expected} keys"
             ),
+            Self::LoaderCancelled { fact_name } => {
+                write!(f, "Fact load for '{fact_name}' was cancelled")
+            }
             Self::Backend(error) => write!(f, "{error}"),
         }
     }
@@ -549,12 +549,26 @@ impl EvaluationSession {
     /// Registers a shared fact source for one key type.
     ///
     /// Re-registering a source clears any cached facts for that key type in
-    /// this session.
+    /// this session. Register sources during session setup; replacing a source
+    /// while loads for the same key type are in flight is not a supported
+    /// operation.
     pub fn register_arc<K>(&self, source: Arc<dyn FactSource<K>>)
     where
         K: FactKey,
     {
         let type_id = TypeId::of::<K>();
+        let in_flight_empty = {
+            let mut in_flight = self
+                .inner
+                .in_flight
+                .lock()
+                .expect("fact in-flight registry mutex should not be poisoned");
+            Self::in_flight_for::<K>(&mut in_flight).is_empty()
+        };
+        debug_assert!(
+            in_flight_empty,
+            "fact sources should not be replaced while loads for the same key type are in flight",
+        );
         self.inner
             .sources
             .lock()
@@ -577,7 +591,11 @@ impl EvaluationSession {
             .into_iter()
             .next()
             .unwrap_or_else(|| {
-                FactLoadResult::Error(FactLoadError::SourceReturnedNoResult { fact_name: K::NAME })
+                FactLoadResult::Error(FactLoadError::SourceContractViolation {
+                    fact_name: K::NAME,
+                    expected: 1,
+                    actual: 0,
+                })
             })
     }
 
@@ -596,6 +614,7 @@ impl EvaluationSession {
 
         let source = self.source::<K>();
         let load_plan = self.plan_loads(keys);
+        let mut in_flight_guard = InFlightGuard::new(self.clone(), load_plan.keys.clone());
 
         if !load_plan.keys.is_empty() {
             if let Some(source) = source {
@@ -611,6 +630,7 @@ impl EvaluationSession {
                         fact.name = K::NAME,
                         fact.load_id = load_id,
                         fact.key_count = chunk.len(),
+                        fact.unique_key_count = chunk.len(),
                     );
                     let loaded = source.load_many(chunk).instrument(load_span).await;
                     if loaded.len() == chunk.len() {
@@ -621,7 +641,7 @@ impl EvaluationSession {
                             chunk
                                 .iter()
                                 .map(|_| {
-                                    FactLoadResult::Error(FactLoadError::WrongResultCount {
+                                    FactLoadResult::Error(FactLoadError::SourceContractViolation {
                                         fact_name: K::NAME,
                                         expected: chunk.len(),
                                         actual: loaded.len(),
@@ -630,7 +650,7 @@ impl EvaluationSession {
                                 .collect(),
                         );
                     }
-                    self.finish_in_flight::<K>(chunk);
+                    in_flight_guard.finish(chunk);
                 }
             } else {
                 self.cache_loaded(
@@ -645,7 +665,7 @@ impl EvaluationSession {
                         })
                         .collect(),
                 );
-                self.finish_in_flight::<K>(&load_plan.keys);
+                in_flight_guard.finish(&load_plan.keys);
             }
         }
 
@@ -759,8 +779,10 @@ impl EvaluationSession {
         keys.iter()
             .map(|key| {
                 cache.get(key).cloned().unwrap_or_else(|| {
-                    FactLoadResult::Error(FactLoadError::SourceReturnedNoResult {
+                    FactLoadResult::Error(FactLoadError::SourceContractViolation {
                         fact_name: K::NAME,
+                        expected: 1,
+                        actual: 0,
                     })
                 })
             })
@@ -797,6 +819,58 @@ impl EvaluationSession {
 struct LoadPlan<K> {
     keys: Vec<K>,
     waiters: Vec<oneshot::Receiver<()>>,
+}
+
+struct InFlightGuard<K>
+where
+    K: FactKey,
+{
+    session: EvaluationSession,
+    remaining: Vec<K>,
+}
+
+impl<K> InFlightGuard<K>
+where
+    K: FactKey,
+{
+    fn new(session: EvaluationSession, keys: Vec<K>) -> Self {
+        Self {
+            session,
+            remaining: keys,
+        }
+    }
+
+    fn finish(&mut self, keys: &[K]) {
+        self.session.finish_in_flight(keys);
+        if self.remaining.is_empty() {
+            return;
+        }
+
+        let finished = keys.iter().cloned().collect::<HashSet<_>>();
+        self.remaining.retain(|key| !finished.contains(key));
+    }
+}
+
+impl<K> Drop for InFlightGuard<K>
+where
+    K: FactKey,
+{
+    fn drop(&mut self) {
+        if self.remaining.is_empty() {
+            return;
+        }
+
+        self.session.cache_loaded(
+            &self.remaining,
+            self.remaining
+                .iter()
+                .map(|_| {
+                    FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name: K::NAME })
+                })
+                .collect(),
+        );
+        self.session.finish_in_flight(&self.remaining);
+    }
 }
 
 /// Per-item policy evaluation context.
@@ -1301,7 +1375,7 @@ where
     ///
     /// Policies are evaluated sequentially with OR semantics (short-circuiting on first success).
     /// Returns an [`AccessEvaluation`] with detailed tracing.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(policy_count = self.policies.len(), outcome = tracing::field::Empty, policy.type = tracing::field::Empty))]
     pub async fn evaluate_in_session(
         &self,
         session: &EvaluationSession,
@@ -1311,6 +1385,7 @@ where
         context: &C,
     ) -> AccessEvaluation {
         if self.policies.is_empty() {
+            tracing::Span::current().record("outcome", "denied");
             tracing::debug!("No policies configured");
             let result = PolicyEvalResult::Denied {
                 policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
@@ -1375,6 +1450,8 @@ where
 
             // If any policy allows access, return immediately
             if result_passes {
+                tracing::Span::current().record("outcome", "granted");
+                tracing::Span::current().record("policy.type", policy_type);
                 let combined = PolicyEvalResult::Combined {
                     policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
                     operation: CombineOp::Or,
@@ -1391,6 +1468,7 @@ where
         }
 
         // If all policies denied access
+        tracing::Span::current().record("outcome", "denied");
         tracing::trace!("No policies allowed access, returning Forbidden");
         let combined = PolicyEvalResult::Combined {
             policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ use async_trait::async_trait;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use tracing::Instrument;
 
 const DEFAULT_SECURITY_RULE_CATEGORY: &str = "Access Control";
 const PERMISSION_CHECKER_POLICY_TYPE: &str = "PermissionChecker";
@@ -700,6 +701,11 @@ where
     /// each item sequentially. Policies with set-oriented backends can override
     /// this method to reduce round trips while returning one result per input
     /// item in the same order.
+    ///
+    /// The checker still evaluates policies in policy order, so batched
+    /// evaluation can differ from a naive item-outer loop when later policies
+    /// have side effects or observe mutable external state. Prefer pure policy
+    /// predicates and use traces to audit the policy-ordered batch behavior.
     async fn evaluate_access_batch<'item>(
         &self,
         subject: &'item Subject,
@@ -898,6 +904,12 @@ where
     /// [`Policy::evaluate_access_batch`] and collapse many point lookups into
     /// one backend call.
     ///
+    /// The loop is intentionally policy-outer/items-inner, not a naive
+    /// item-outer loop. OR short-circuiting is preserved per item and policy
+    /// order is preserved globally, but callers should avoid relying on
+    /// side effects from interleaving one item through every policy before the
+    /// next item starts.
+    ///
     /// If a policy returns the wrong number of batch results, affected items are
     /// denied rather than accidentally granted.
     ///
@@ -981,6 +993,14 @@ where
             return results;
         }
 
+        let item_parts = items
+            .iter()
+            .map(|item| {
+                let (resource, context) = parts(item);
+                PolicyBatchItem { resource, context }
+            })
+            .collect::<Vec<_>>();
+
         let mut pending: Vec<usize> = (0..item_count).collect();
 
         for policy in &self.policies {
@@ -988,7 +1008,18 @@ where
                 break;
             }
 
+            let policy_type = policy.policy_type();
+            let policy_span = tracing::debug_span!(
+                "gatehouse.batch_policy",
+                policy.type = policy_type.as_str(),
+                policy.pending_count = pending.len(),
+                policy.granted_count = tracing::field::Empty,
+                policy.denied_count = tracing::field::Empty,
+            );
+
             let mut still_pending = Vec::new();
+            let mut policy_granted_count = 0usize;
+            let mut policy_denied_count = 0usize;
             let chunk_size = self
                 .max_batch_size
                 .map_or(pending.len(), NonZeroUsize::get)
@@ -997,20 +1028,22 @@ where
             for pending_chunk in pending.chunks(chunk_size) {
                 let batch_items: Vec<_> = pending_chunk
                     .iter()
-                    .map(|&index| {
-                        let (resource, context) = parts(&items[index]);
-                        PolicyBatchItem { resource, context }
+                    .map(|&index| PolicyBatchItem {
+                        resource: item_parts[index].resource,
+                        context: item_parts[index].context,
                     })
                     .collect();
 
                 let policy_results = policy
                     .evaluate_access_batch(subject, action, &batch_items)
+                    .instrument(policy_span.clone())
                     .await;
 
                 if policy_results.len() != pending_chunk.len() {
                     for &index in pending_chunk {
+                        policy_denied_count += 1;
                         let policy_result = PolicyEvalResult::Denied {
-                            policy_type: policy.policy_type(),
+                            policy_type: policy_type.clone(),
                             reason: "Policy batch result count did not match input count"
                                 .to_string(),
                         };
@@ -1032,12 +1065,12 @@ where
 
                 for (&index, result) in pending_chunk.iter().zip(policy_results) {
                     let result_passes = result.is_granted();
-                    let policy_type = policy.policy_type();
                     let reason = result.reason();
 
                     traces[index].push(result);
 
                     if result_passes {
+                        policy_granted_count += 1;
                         let combined = PolicyEvalResult::Combined {
                             policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
                             operation: CombineOp::Or,
@@ -1045,15 +1078,18 @@ where
                             outcome: true,
                         };
                         evaluations[index] = Some(AccessEvaluation::Granted {
-                            policy_type,
+                            policy_type: policy_type.clone(),
                             reason,
                             trace: EvalTrace::with_root(combined),
                         });
                     } else {
+                        policy_denied_count += 1;
                         still_pending.push(index);
                     }
                 }
             }
+            policy_span.record("policy.granted_count", policy_granted_count);
+            policy_span.record("policy.denied_count", policy_denied_count);
             pending = still_pending;
         }
 
@@ -1070,12 +1106,23 @@ where
             });
         }
 
+        drop(item_parts);
+
         let mut granted_count = 0usize;
         let results = items
             .into_iter()
             .zip(evaluations.into_iter())
             .map(|(item, evaluation)| {
-                let evaluation = evaluation.expect("every batch item should be evaluated");
+                let evaluation = evaluation.unwrap_or_else(|| {
+                    let result = PolicyEvalResult::Denied {
+                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+                        reason: "Batch item was not evaluated".to_string(),
+                    };
+                    AccessEvaluation::Denied {
+                        trace: EvalTrace::with_root(result),
+                        reason: "Batch item was not evaluated".to_string(),
+                    }
+                });
                 if evaluation.is_granted() {
                     granted_count += 1;
                 }
@@ -1648,6 +1695,15 @@ where
     /// Returns `true` if `relationship` exists between `subject` and `resource`.
     async fn has_relationship(&self, subject: &S, resource: &R, relationship: &Re) -> bool;
 
+    /// Maximum number of resources this resolver wants in one batch call.
+    ///
+    /// The default leaves batches unconstrained. Backend resolvers can override
+    /// this when query planner behavior, parameter limits, or service limits
+    /// make smaller chunks safer.
+    fn max_batch_size(&self) -> Option<NonZeroUsize> {
+        None
+    }
+
     /// Returns one relationship decision per resource, in input order.
     ///
     /// The default implementation loops over [`Self::has_relationship`].
@@ -1808,26 +1864,35 @@ where
         _action: &'item A,
         items: &'item [PolicyBatchItem<'item, R, C>],
     ) -> Vec<PolicyEvalResult> {
-        let resources = items.iter().map(|item| item.resource).collect::<Vec<_>>();
-        let relationship_results = self
+        let mut results = Vec::with_capacity(items.len());
+        let chunk_size = self
             .resolver
-            .has_relationship_batch(subject, &resources, &self.relationship)
-            .await;
+            .max_batch_size()
+            .map_or(items.len(), NonZeroUsize::get)
+            .max(1);
 
-        if relationship_results.len() != items.len() {
-            return items
+        for item_chunk in items.chunks(chunk_size) {
+            let resources = item_chunk
                 .iter()
-                .map(|_| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
-                    reason: "Relationship resolver returned the wrong number of batch results"
-                        .to_string(),
-                })
-                .collect();
-        }
+                .map(|item| item.resource)
+                .collect::<Vec<_>>();
+            let relationship_results = self
+                .resolver
+                .has_relationship_batch(subject, &resources, &self.relationship)
+                .await;
 
-        relationship_results
-            .into_iter()
-            .map(|has_relationship| {
+            if relationship_results.len() != item_chunk.len() {
+                results.extend(item_chunk.iter().map(|_| {
+                    PolicyEvalResult::Denied {
+                        policy_type: self.policy_type(),
+                        reason: "Relationship resolver returned the wrong number of batch results"
+                            .to_string(),
+                    }
+                }));
+                continue;
+            }
+
+            results.extend(relationship_results.into_iter().map(|has_relationship| {
                 if has_relationship {
                     PolicyEvalResult::Granted {
                         policy_type: self.policy_type(),
@@ -1845,8 +1910,10 @@ where
                         ),
                     }
                 }
-            })
-            .collect()
+            }));
+        }
+
+        results
     }
 
     fn policy_type(&self) -> String {
@@ -2006,7 +2073,12 @@ where
 
         results
             .into_iter()
-            .map(|result| result.expect("every batch item should be evaluated"))
+            .map(|result| {
+                result.unwrap_or_else(|| PolicyEvalResult::Denied {
+                    policy_type: self.policy_type(),
+                    reason: "Batch item was not evaluated".to_string(),
+                })
+            })
             .collect()
     }
 }
@@ -2152,7 +2224,12 @@ where
 
         results
             .into_iter()
-            .map(|result| result.expect("every batch item should be evaluated"))
+            .map(|result| {
+                result.unwrap_or_else(|| PolicyEvalResult::Denied {
+                    policy_type: self.policy_type(),
+                    reason: "Batch item was not evaluated".to_string(),
+                })
+            })
             .collect()
     }
 }
@@ -2254,6 +2331,7 @@ where
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     // Dummy resource/action/context types for testing
     #[derive(Debug, Clone)]
@@ -2387,6 +2465,44 @@ mod tests {
 
         fn policy_type(&self) -> String {
             "EvenResourceBatchPolicy".to_string()
+        }
+    }
+
+    struct MismatchedBatchPolicy;
+
+    #[async_trait]
+    impl Policy<TestSubject, TestResource, TestAction, TestContext> for MismatchedBatchPolicy {
+        async fn evaluate_access(
+            &self,
+            _subject: &TestSubject,
+            _action: &TestAction,
+            _resource: &TestResource,
+            _context: &TestContext,
+        ) -> PolicyEvalResult {
+            PolicyEvalResult::Granted {
+                policy_type: self.policy_type(),
+                reason: Some("single item fallback".to_string()),
+            }
+        }
+
+        async fn evaluate_access_batch<'item>(
+            &self,
+            _subject: &'item TestSubject,
+            _action: &'item TestAction,
+            items: &'item [PolicyBatchItem<'item, TestResource, TestContext>],
+        ) -> Vec<PolicyEvalResult> {
+            items
+                .iter()
+                .skip(1)
+                .map(|_| PolicyEvalResult::Granted {
+                    policy_type: self.policy_type(),
+                    reason: Some("wrong batch length".to_string()),
+                })
+                .collect()
+        }
+
+        fn policy_type(&self) -> String {
+            "MismatchedBatchPolicy".to_string()
         }
     }
 
@@ -2549,6 +2665,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_evaluate_batch_by_invokes_parts_once_per_item() {
+        let parts_calls = Arc::new(AtomicUsize::new(0));
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..4)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(AlwaysDenyPolicy("first denial"));
+        checker.add_policy(AlwaysDenyPolicy("second denial"));
+
+        let results = checker
+            .evaluate_batch_by(&subject, &TestAction, resources, |item| {
+                parts_calls.fetch_add(1, Ordering::SeqCst);
+                (&item.0, &item.1)
+            })
+            .await;
+
+        assert_eq!(results.len(), 4);
+        assert!(results
+            .iter()
+            .all(|(_item, evaluation)| !evaluation.is_granted()));
+        assert_eq!(parts_calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_batch_by_fails_closed_on_policy_length_mismatch() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resources = (0..3)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(MismatchedBatchPolicy);
+        checker.add_policy(AlwaysAllowPolicy);
+
+        let results = checker
+            .evaluate_batch_by(&subject, &TestAction, resources, |item| (&item.0, &item.1))
+            .await;
+
+        assert_eq!(results.len(), 3);
+        for (_item, evaluation) in results {
+            assert!(!evaluation.is_granted());
+            match evaluation {
+                AccessEvaluation::Denied { reason, trace } => {
+                    assert_eq!(
+                        reason,
+                        "Policy batch result count did not match input count"
+                    );
+                    assert!(trace.format().contains("MismatchedBatchPolicy"));
+                }
+                AccessEvaluation::Granted { .. } => {
+                    panic!("mismatched batch result should fail closed");
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_and_policy_batch_uses_inner_batch_hook() {
         let batch_calls = Arc::new(AtomicUsize::new(0));
         let single_calls = Arc::new(AtomicUsize::new(0));
@@ -2581,6 +2774,40 @@ mod tests {
         assert_eq!(authorized.len(), 2);
         assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
         assert_eq!(single_calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn test_and_policy_batch_fails_closed_on_inner_length_mismatch() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let owned_items = (0..2)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let batch_items = owned_items
+            .iter()
+            .map(|(resource, context)| PolicyBatchItem { resource, context })
+            .collect::<Vec<_>>();
+        let inner: Arc<dyn Policy<TestSubject, TestResource, TestAction, TestContext>> =
+            Arc::new(MismatchedBatchPolicy);
+        let policy = AndPolicy::try_new(vec![inner]).unwrap();
+
+        let results = policy
+            .evaluate_access_batch(&subject, &TestAction, &batch_items)
+            .await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| !result.is_granted()));
+        assert!(results
+            .iter()
+            .all(|result| result.format(0).contains("MismatchedBatchPolicy")));
     }
 
     #[tokio::test]
@@ -2619,6 +2846,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_or_policy_batch_fails_closed_on_inner_length_mismatch() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let owned_items = (0..2)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let batch_items = owned_items
+            .iter()
+            .map(|(resource, context)| PolicyBatchItem { resource, context })
+            .collect::<Vec<_>>();
+        let inner: Arc<dyn Policy<TestSubject, TestResource, TestAction, TestContext>> =
+            Arc::new(MismatchedBatchPolicy);
+        let policy = OrPolicy::try_new(vec![inner]).unwrap();
+
+        let results = policy
+            .evaluate_access_batch(&subject, &TestAction, &batch_items)
+            .await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| !result.is_granted()));
+        assert!(results
+            .iter()
+            .all(|result| result.format(0).contains("MismatchedBatchPolicy")));
+    }
+
+    #[tokio::test]
     async fn test_not_policy_batch_uses_inner_batch_hook() {
         let batch_calls = Arc::new(AtomicUsize::new(0));
         let single_calls = Arc::new(AtomicUsize::new(0));
@@ -2649,6 +2910,41 @@ mod tests {
         assert_eq!(authorized.len(), 2);
         assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
         assert_eq!(single_calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn test_not_policy_batch_fails_closed_on_inner_length_mismatch() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let owned_items = (0..2)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let batch_items = owned_items
+            .iter()
+            .map(|(resource, context)| PolicyBatchItem { resource, context })
+            .collect::<Vec<_>>();
+        let policy = NotPolicy::new(MismatchedBatchPolicy);
+
+        let results = policy
+            .evaluate_access_batch(&subject, &TestAction, &batch_items)
+            .await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| !result.is_granted()));
+        assert!(results.iter().all(|result| {
+            result
+                .reason()
+                .as_deref()
+                .is_some_and(|reason| reason.contains("batch result count"))
+        }));
     }
 
     #[tokio::test]
@@ -2795,6 +3091,62 @@ mod tests {
         }
     }
 
+    struct ChunkedRelationshipResolver {
+        batch_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    #[async_trait]
+    impl RelationshipResolver<TestSubject, TestResource, String> for ChunkedRelationshipResolver {
+        async fn has_relationship(
+            &self,
+            _subject: &TestSubject,
+            resource: &TestResource,
+            _relationship: &String,
+        ) -> bool {
+            resource.id.as_u128().is_multiple_of(2)
+        }
+
+        fn max_batch_size(&self) -> Option<NonZeroUsize> {
+            NonZeroUsize::new(2)
+        }
+
+        async fn has_relationship_batch<'item>(
+            &self,
+            _subject: &'item TestSubject,
+            resources: &'item [&'item TestResource],
+            _relationship: &'item String,
+        ) -> Vec<bool> {
+            self.batch_sizes.lock().unwrap().push(resources.len());
+            resources
+                .iter()
+                .map(|resource| resource.id.as_u128().is_multiple_of(2))
+                .collect()
+        }
+    }
+
+    struct MismatchedRelationshipResolver;
+
+    #[async_trait]
+    impl RelationshipResolver<TestSubject, TestResource, String> for MismatchedRelationshipResolver {
+        async fn has_relationship(
+            &self,
+            _subject: &TestSubject,
+            _resource: &TestResource,
+            _relationship: &String,
+        ) -> bool {
+            true
+        }
+
+        async fn has_relationship_batch<'item>(
+            &self,
+            _subject: &'item TestSubject,
+            resources: &'item [&'item TestResource],
+            _relationship: &'item String,
+        ) -> Vec<bool> {
+            resources.iter().skip(1).map(|_| true).collect()
+        }
+    }
+
     #[tokio::test]
     async fn test_rebac_policy_allows_when_relationship_exists() {
         let subject_id = uuid::Uuid::new_v4();
@@ -2849,6 +3201,86 @@ mod tests {
             !result.is_granted(),
             "Access should be denied if relationship does not exist"
         );
+    }
+
+    #[tokio::test]
+    async fn test_rebac_policy_batch_respects_resolver_max_batch_size() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let relationship = "viewer".to_string();
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let resolver = ChunkedRelationshipResolver {
+            batch_sizes: Arc::clone(&batch_sizes),
+        };
+        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
+            relationship,
+            resolver,
+        );
+        let owned_items = (0..5)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let batch_items = owned_items
+            .iter()
+            .map(|(resource, context)| PolicyBatchItem { resource, context })
+            .collect::<Vec<_>>();
+
+        let results = policy
+            .evaluate_access_batch(&subject, &TestAction, &batch_items)
+            .await;
+
+        assert_eq!(*batch_sizes.lock().unwrap(), vec![2, 2, 1]);
+        assert_eq!(
+            results
+                .iter()
+                .map(PolicyEvalResult::is_granted)
+                .collect::<Vec<_>>(),
+            vec![true, false, true, false, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rebac_policy_batch_fails_closed_on_resolver_length_mismatch() {
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
+            "viewer".to_string(),
+            MismatchedRelationshipResolver,
+        );
+        let owned_items = (0..3)
+            .map(|value| {
+                (
+                    TestResource {
+                        id: uuid::Uuid::from_u128(value),
+                    },
+                    TestContext,
+                )
+            })
+            .collect::<Vec<_>>();
+        let batch_items = owned_items
+            .iter()
+            .map(|(resource, context)| PolicyBatchItem { resource, context })
+            .collect::<Vec<_>>();
+
+        let results = policy
+            .evaluate_access_batch(&subject, &TestAction, &batch_items)
+            .await;
+
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|result| !result.is_granted()));
+        assert!(results.iter().all(|result| {
+            result.reason().as_deref().is_some_and(|reason| {
+                reason.contains("Relationship resolver returned the wrong number")
+            })
+        }));
     }
 
     // RebacPolicy test with enum relationship type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,7 @@
 //!
 //! [`RebacPolicy`] is the first built-in policy backed by this model. It
 //! extracts flat subject/resource IDs, builds [`RelationshipQuery`] keys, and
-//! asks the session for relationship facts. [`LookupSource`] reserves the
-//! complementary "what can this subject see?" shape for backends that can
-//! enumerate visible resources directly.
+//! asks the session for relationship facts.
 //!
 //! ## Quick Start
 //!
@@ -463,6 +461,11 @@ pub struct PolicyBatchItem<'a, Resource, Context> {
 ///
 /// Keys are flat, cloneable, and hashable so the session can deduplicate and
 /// cache fact loads for the lifetime of one authorization request.
+///
+/// Session caching is deliberately request-scoped. Cached facts and cached
+/// errors are dropped with the [`EvaluationSession`], so permission revocations
+/// or backend changes are observed by the next request's session rather than
+/// being held in a process-global cache.
 pub trait FactKey: Eq + Hash + Clone + Send + Sync + 'static {
     /// The value returned by a [`FactSource`] for this key.
     type Value: Clone + Send + Sync + 'static;
@@ -508,6 +511,10 @@ pub enum FactLoadError {
         fact_name: &'static str,
     },
     /// The registered source reported a backend error.
+    ///
+    /// Backend errors are held behind [`Arc`], so cloned
+    /// [`FactLoadResult::Error`] values share the same error object rather than
+    /// requiring the backend error type itself to be cloneable.
     Backend(Arc<dyn std::error::Error + Send + Sync>),
 }
 
@@ -559,6 +566,10 @@ pub enum FactLoadResult<V> {
 }
 
 /// A batched source for one fact key type.
+///
+/// Sources can be shared across many request sessions. The source owns
+/// backend-specific serialization and I/O; the session owns per-request
+/// deduplication, caching, chunking, and in-flight coalescing.
 #[async_trait]
 pub trait FactSource<K>: Send + Sync
 where
@@ -590,7 +601,9 @@ struct EvaluationSessionInner {
 ///
 /// A session is intended to live for one request or one authorization pass. It
 /// owns registered fact sources and caches loaded facts by key type. The cache
-/// is deliberately not process-global.
+/// is deliberately not process-global. Cached facts and cached errors are
+/// dropped with the session, so permission revocations or backend changes are
+/// observed by the next request's session rather than being held process-wide.
 #[derive(Clone, Default)]
 pub struct EvaluationSession {
     inner: Arc<EvaluationSessionInner>,
@@ -610,7 +623,16 @@ impl EvaluationSession {
         Self::new()
     }
 
+    /// Starts building a request-scoped session with all fact sources declared
+    /// in one place.
+    pub fn builder() -> EvaluationSessionBuilder {
+        EvaluationSessionBuilder::new()
+    }
+
     /// Registers a fact source for one key type.
+    ///
+    /// Panics if a source for `K` is already registered. Use [`Self::replace`]
+    /// when replacing a source is intentional.
     pub fn register<K, S>(&self, source: S)
     where
         K: FactKey,
@@ -621,11 +643,42 @@ impl EvaluationSession {
 
     /// Registers a shared fact source for one key type.
     ///
-    /// Re-registering a source clears any cached facts for that key type in
-    /// this session. Register sources during session setup; replacing a source
-    /// while loads for the same key type are in flight is not a supported
-    /// operation.
+    /// Panics if a source for `K` is already registered. Register sources
+    /// during session setup; use [`Self::replace_arc`] only when overwriting is
+    /// deliberate.
     pub fn register_arc<K>(&self, source: Arc<dyn FactSource<K>>)
+    where
+        K: FactKey,
+    {
+        self.insert_source::<K>(source, false);
+    }
+
+    /// Explicitly replaces a fact source for one key type.
+    ///
+    /// Replacing a source clears any cached facts for that key type in this
+    /// session. Replacing while loads for the same key type are in flight is
+    /// not a supported operation and will panic.
+    pub fn replace<K, S>(&self, source: S)
+    where
+        K: FactKey,
+        S: FactSource<K> + 'static,
+    {
+        self.replace_arc::<K>(Arc::new(source));
+    }
+
+    /// Explicitly replaces a shared fact source for one key type.
+    ///
+    /// Replacing a source clears any cached facts for that key type in this
+    /// session. Replacing while loads for the same key type are in flight is
+    /// not a supported operation and will panic.
+    pub fn replace_arc<K>(&self, source: Arc<dyn FactSource<K>>)
+    where
+        K: FactKey,
+    {
+        self.insert_source::<K>(source, true);
+    }
+
+    fn insert_source<K>(&self, source: Arc<dyn FactSource<K>>, replace: bool)
     where
         K: FactKey,
     {
@@ -638,15 +691,31 @@ impl EvaluationSession {
                 .expect("fact in-flight registry mutex should not be poisoned");
             Self::in_flight_for::<K>(&mut in_flight).is_empty()
         };
-        debug_assert!(
+        assert!(
             in_flight_empty,
             "fact sources should not be replaced while loads for the same key type are in flight",
         );
-        self.inner
-            .sources
-            .lock()
-            .expect("fact source registry mutex should not be poisoned")
-            .insert(type_id, Box::new(source));
+        let duplicate_registration = {
+            let mut sources = self
+                .inner
+                .sources
+                .lock()
+                .expect("fact source registry mutex should not be poisoned");
+            if !replace && sources.contains_key(&type_id) {
+                true
+            } else {
+                sources.insert(type_id, Box::new(source));
+                false
+            }
+        };
+
+        if duplicate_registration {
+            panic!(
+                "fact source for '{}' is already registered; use replace_arc to overwrite it",
+                K::NAME
+            );
+        }
+
         self.inner
             .caches
             .lock()
@@ -891,6 +960,48 @@ impl EvaluationSession {
     }
 }
 
+/// Builder for declaring all fact sources needed by a request-scoped
+/// [`EvaluationSession`].
+pub struct EvaluationSessionBuilder {
+    session: EvaluationSession,
+}
+
+impl EvaluationSessionBuilder {
+    fn new() -> Self {
+        Self {
+            session: EvaluationSession::new(),
+        }
+    }
+
+    /// Registers a source for one fact key type.
+    ///
+    /// Panics if the same fact key type is registered twice.
+    pub fn with<K, S>(self, source: S) -> Self
+    where
+        K: FactKey,
+        S: FactSource<K> + 'static,
+    {
+        self.session.register::<K, _>(source);
+        self
+    }
+
+    /// Registers a shared source for one fact key type.
+    ///
+    /// Panics if the same fact key type is registered twice.
+    pub fn with_arc<K>(self, source: Arc<dyn FactSource<K>>) -> Self
+    where
+        K: FactKey,
+    {
+        self.session.register_arc::<K>(source);
+        self
+    }
+
+    /// Finishes the session.
+    pub fn build(self) -> EvaluationSession {
+        self.session
+    }
+}
+
 struct LoadPlan<K> {
     keys: Vec<K>,
     waiters: Vec<oneshot::Receiver<()>>,
@@ -994,65 +1105,6 @@ where
     type Value = bool;
 
     const NAME: &'static str = "relationship";
-}
-
-/// Error returned by lookup-oriented relationship sources.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LookupError {
-    message: String,
-}
-
-impl LookupError {
-    /// Creates a lookup error with a human-readable message.
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-
-    /// Returns the error message.
-    pub fn message(&self) -> &str {
-        &self.message
-    }
-}
-
-impl fmt::Display for LookupError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for LookupError {}
-
-/// One page of lookup-oriented relationship results.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LookupPage<ResourceId, Cursor> {
-    /// Resources visible in this page.
-    pub resources: Vec<ResourceId>,
-    /// Cursor to request the next page, if more resources are available.
-    pub next_cursor: Option<Cursor>,
-}
-
-/// Optional graph-style relationship lookup source.
-#[async_trait]
-pub trait LookupSource<SubjectId, ResourceId, Relation>:
-    FactSource<RelationshipQuery<SubjectId, ResourceId, Relation>>
-where
-    SubjectId: Eq + Hash + Clone + Send + Sync + 'static,
-    ResourceId: Eq + Hash + Clone + Send + Sync + 'static,
-    Relation: Eq + Hash + Clone + Send + Sync + 'static,
-{
-    /// Opaque pagination cursor type used by this source.
-    type Cursor: Clone + Send + Sync + 'static;
-
-    /// Looks up one page of resources related to the subject by `relation`.
-    async fn lookup_resources(
-        &self,
-        subject: &SubjectId,
-        relation: &Relation,
-        cursor: Option<Self::Cursor>,
-        limit: Option<NonZeroUsize>,
-    ) -> Result<LookupPage<ResourceId, Self::Cursor>, LookupError>;
 }
 
 /// The complete result of a permission evaluation.
@@ -2372,6 +2424,21 @@ where
 /// `Relation::Viewer` to a `text` column value only when binding query
 /// parameters. The session deduplicates and caches by the typed key, not by the
 /// serialized storage representation.
+///
+/// When several relationship domains have the same ID shape, such as
+/// `Uuid -> Uuid`, use a domain relation enum and dispatch inside one
+/// `FactSource`, or newtype the IDs so each domain has a distinct
+/// `RelationshipQuery` type and therefore a distinct session registration.
+///
+/// `RebacPolicy` is the convenience policy for boolean relationship checks. If
+/// a relationship carries payload, such as rank, weight, or a scope set, define
+/// a custom [`FactKey`] with `Value = YourPayload` and write a [`Policy`] that
+/// interprets the loaded value.
+///
+/// `Relation` must implement [`fmt::Display`] only so Gatehouse can produce
+/// human-readable denial reasons and traces. Backend serialization should live
+/// in the [`FactSource`], not in the display string unless that is explicitly
+/// your storage format.
 ///
 /// ```rust
 /// use async_trait::async_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,6 +650,8 @@ impl EvaluationSession {
                                 .collect(),
                         );
                     }
+                    // Keep this immediately after the cache write, with no await in between.
+                    // The drop guard treats remaining keys as cancelled.
                     in_flight_guard.finish(chunk);
                 }
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,12 @@
 //! checker.add_policy(policy);
 //!
 //! # tokio_test::block_on(async {
+//! let session = EvaluationSession::empty();
 //! let admin = User { roles: vec!["admin".into()] };
-//! assert!(checker.evaluate_access(&admin, &ReadAction, &Document, &AppContext).await.is_granted());
+//! assert!(checker.evaluate_in_session(&session, &admin, &ReadAction, &Document, &AppContext).await.is_granted());
 //!
 //! let guest = User { roles: vec!["guest".into()] };
-//! assert!(!checker.evaluate_access(&guest, &ReadAction, &Document, &AppContext).await.is_granted());
+//! assert!(!checker.evaluate_in_session(&session, &guest, &ReadAction, &Document, &AppContext).await.is_granted());
 //! # });
 //! ```
 //!
@@ -86,26 +87,20 @@
 //! struct AdminPolicy;
 //! #[async_trait]
 //! impl Policy<User, Document, ReadAction, EmptyContext> for AdminPolicy {
-//!     async fn evaluate_access(
-//!         &self,
-//!         user: &User,
-//!         _action: &ReadAction,
-//!         _resource: &Document,
-//!         _context: &EmptyContext,
-//!     ) -> PolicyEvalResult {
-//!         if user.roles.contains(&"admin".to_string()) {
+//!     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Document, ReadAction, EmptyContext>) -> PolicyEvalResult {
+//!         if ctx.subject.roles.contains(&"admin".to_string()) {
 //!             PolicyEvalResult::Granted {
-//!                 policy_type: self.policy_type(),
+//!                 policy_type: self.policy_type().to_string(),
 //!                 reason: Some("User is admin".to_string()),
 //!             }
 //!         } else {
 //!             PolicyEvalResult::Denied {
-//!                 policy_type: self.policy_type(),
+//!                 policy_type: self.policy_type().to_string(),
 //!                 reason: "User is not admin".to_string(),
 //!             }
 //!         }
 //!     }
-//!     fn policy_type(&self) -> String { "AdminPolicy".to_string() }
+//!     fn policy_type(&self) -> &str { "AdminPolicy" }
 //! }
 //!
 //! // An ABAC policy: grant access if the user is the owner of the document.
@@ -113,27 +108,21 @@
 //!
 //! #[async_trait]
 //! impl Policy<User, Document, ReadAction, EmptyContext> for OwnerPolicy {
-//!     async fn evaluate_access(
-//!         &self,
-//!         user: &User,
-//!         _action: &ReadAction,
-//!         document: &Document,
-//!         _context: &EmptyContext,
-//!     ) -> PolicyEvalResult {
-//!         if user.id == document.owner_id {
+//!     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Document, ReadAction, EmptyContext>) -> PolicyEvalResult {
+//!         if ctx.subject.id == ctx.resource.owner_id {
 //!             PolicyEvalResult::Granted {
-//!                 policy_type: self.policy_type(),
+//!                 policy_type: self.policy_type().to_string(),
 //!                 reason: Some("User is the owner".to_string()),
 //!             }
 //!         } else {
 //!             PolicyEvalResult::Denied {
-//!                policy_type: self.policy_type(),
+//!                policy_type: self.policy_type().to_string(),
 //!                reason: "User is not the owner".to_string(),
 //!            }
 //!         }
 //!     }
-//!     fn policy_type(&self) -> String {
-//!         "OwnerPolicy".to_string()
+//!     fn policy_type(&self) -> &str {
+//!         "OwnerPolicy"
 //!     }
 //! }
 //!
@@ -162,19 +151,20 @@
 //! };
 //!
 //! let checker = create_document_checker();
+//! let session = EvaluationSession::empty();
 //!
 //! // An admin should have access.
-//! assert!(checker.evaluate_access(&admin_user, &ReadAction, &document, &EmptyContext).await.is_granted());
+//! assert!(checker.evaluate_in_session(&session, &admin_user, &ReadAction, &document, &EmptyContext).await.is_granted());
 //!
 //! // The owner should have access.
-//! assert!(checker.evaluate_access(&owner_user, &ReadAction, &document, &EmptyContext).await.is_granted());
+//! assert!(checker.evaluate_in_session(&session, &owner_user, &ReadAction, &document, &EmptyContext).await.is_granted());
 //!
 //! // A random user should be denied access.
 //! let random_user = User {
 //!     id: Uuid::new_v4(),
 //!     roles: vec!["user".into()],
 //! };
-//! assert!(!checker.evaluate_access(&random_user, &ReadAction, &document, &EmptyContext).await.is_granted());
+//! assert!(!checker.evaluate_in_session(&session, &random_user, &ReadAction, &document, &EmptyContext).await.is_granted());
 //! # });
 //! ```
 //!
@@ -201,9 +191,14 @@
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
 use async_trait::async_trait;
+use futures_channel::oneshot;
+use std::any::{Any, TypeId};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::hash::Hash;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use tracing::Instrument;
 
 const DEFAULT_SECURITY_RULE_CATEGORY: &str = "Access Control";
@@ -391,6 +386,526 @@ pub struct PolicyBatchItem<'a, Resource, Context> {
     pub context: &'a Context,
 }
 
+/// A typed fact key that can be loaded through an [`EvaluationSession`].
+///
+/// Keys are flat, cloneable, and hashable so the session can deduplicate and
+/// cache fact loads for the lifetime of one authorization request.
+pub trait FactKey: Eq + Hash + Clone + Send + Sync + 'static {
+    /// The value returned by a [`FactSource`] for this key.
+    type Value: Clone + Send + Sync + 'static;
+
+    /// Stable fact name used only in diagnostics and tracing.
+    ///
+    /// The session registry is keyed by [`TypeId`], not by this name, so two
+    /// unrelated key types with the same name do not share a source or cache.
+    const NAME: &'static str;
+}
+
+#[derive(Debug)]
+struct MessageError(String);
+
+impl fmt::Display for MessageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for MessageError {}
+
+/// Error raised while loading a fact.
+#[derive(Debug, Clone)]
+pub enum FactLoadError {
+    /// No source is registered for the requested fact key type.
+    SourceNotRegistered {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+    },
+    /// A source returned fewer results than requested.
+    SourceReturnedNoResult {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+    },
+    /// A source violated the one-result-per-input-key contract.
+    WrongResultCount {
+        /// Diagnostic fact name from [`FactKey::NAME`].
+        fact_name: &'static str,
+        /// Number of keys passed to the source.
+        expected: usize,
+        /// Number of results returned by the source.
+        actual: usize,
+    },
+    /// The registered source reported a backend error.
+    Backend(Arc<dyn std::error::Error + Send + Sync>),
+}
+
+impl FactLoadError {
+    /// Wraps a backend error.
+    pub fn backend(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::Backend(Arc::new(error))
+    }
+
+    /// Wraps a human-readable backend error message.
+    pub fn backend_message(message: impl Into<String>) -> Self {
+        Self::backend(MessageError(message.into()))
+    }
+}
+
+impl fmt::Display for FactLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SourceNotRegistered { fact_name } => {
+                write!(f, "No fact source registered for '{fact_name}'")
+            }
+            Self::SourceReturnedNoResult { fact_name } => {
+                write!(f, "Fact source '{fact_name}' returned no result")
+            }
+            Self::WrongResultCount {
+                fact_name,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "Fact source '{fact_name}' returned {actual} results for {expected} keys"
+            ),
+            Self::Backend(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for FactLoadError {}
+
+/// Result of loading one fact.
+#[derive(Debug, Clone)]
+pub enum FactLoadResult<V> {
+    /// The fact exists and has the given value.
+    Found(V),
+    /// The fact source was reached, but no value exists for the key.
+    Missing,
+    /// Loading failed. Policies should map this to a denied decision.
+    Error(FactLoadError),
+}
+
+/// A batched source for one fact key type.
+#[async_trait]
+pub trait FactSource<K>: Send + Sync
+where
+    K: FactKey,
+{
+    /// Loads one result per key, in input order.
+    ///
+    /// The session deduplicates before calling a source, so `keys` are unique
+    /// within each call. Implementations must return exactly one
+    /// [`FactLoadResult`] per input key, in the same order. The session expands
+    /// results back to caller-visible order, including duplicate keys.
+    async fn load_many(&self, keys: &[K]) -> Vec<FactLoadResult<K::Value>>;
+
+    /// Maximum number of keys this source wants to load in one call.
+    fn max_batch_size(&self) -> Option<NonZeroUsize> {
+        None
+    }
+}
+
+#[derive(Default)]
+struct EvaluationSessionInner {
+    sources: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    caches: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    in_flight: Mutex<HashMap<TypeId, Box<dyn Any + Send>>>,
+    next_load_id: AtomicU64,
+}
+
+/// Request-scoped fact loading and caching state.
+///
+/// A session is intended to live for one request or one authorization pass. It
+/// owns registered fact sources and caches loaded facts by key type. The cache
+/// is deliberately not process-global.
+#[derive(Clone, Default)]
+pub struct EvaluationSession {
+    inner: Arc<EvaluationSessionInner>,
+}
+
+impl EvaluationSession {
+    /// Creates an empty request-scoped session.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates an explicitly empty request-scoped session.
+    ///
+    /// This is equivalent to [`Self::new`]. It can make call sites clearer when
+    /// only RBAC/ABAC policies are expected and no fact sources are registered.
+    pub fn empty() -> Self {
+        Self::new()
+    }
+
+    /// Registers a fact source for one key type.
+    pub fn register<K, S>(&self, source: S)
+    where
+        K: FactKey,
+        S: FactSource<K> + 'static,
+    {
+        self.register_arc::<K>(Arc::new(source));
+    }
+
+    /// Registers a shared fact source for one key type.
+    ///
+    /// Re-registering a source clears any cached facts for that key type in
+    /// this session.
+    pub fn register_arc<K>(&self, source: Arc<dyn FactSource<K>>)
+    where
+        K: FactKey,
+    {
+        let type_id = TypeId::of::<K>();
+        self.inner
+            .sources
+            .lock()
+            .expect("fact source registry mutex should not be poisoned")
+            .insert(type_id, Box::new(source));
+        self.inner
+            .caches
+            .lock()
+            .expect("fact cache mutex should not be poisoned")
+            .remove(&type_id);
+    }
+
+    /// Loads one fact through the session cache.
+    pub async fn get<K>(&self, key: K) -> FactLoadResult<K::Value>
+    where
+        K: FactKey,
+    {
+        self.get_many(&[key])
+            .await
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| {
+                FactLoadResult::Error(FactLoadError::SourceReturnedNoResult { fact_name: K::NAME })
+            })
+    }
+
+    /// Loads facts through the session cache.
+    ///
+    /// Results preserve input order and duplicate keys. Missing cache entries
+    /// are deduplicated before they are loaded, then chunked according to the
+    /// source's [`FactSource::max_batch_size`] hint.
+    pub async fn get_many<K>(&self, keys: &[K]) -> Vec<FactLoadResult<K::Value>>
+    where
+        K: FactKey,
+    {
+        if keys.is_empty() {
+            return Vec::new();
+        }
+
+        let source = self.source::<K>();
+        let load_plan = self.plan_loads(keys);
+
+        if !load_plan.keys.is_empty() {
+            if let Some(source) = source {
+                let chunk_size = source
+                    .max_batch_size()
+                    .map_or(load_plan.keys.len(), NonZeroUsize::get)
+                    .max(1);
+
+                for chunk in load_plan.keys.chunks(chunk_size) {
+                    let load_id = self.inner.next_load_id.fetch_add(1, Ordering::Relaxed);
+                    let load_span = tracing::debug_span!(
+                        "gatehouse.fact_load",
+                        fact.name = K::NAME,
+                        fact.load_id = load_id,
+                        fact.key_count = chunk.len(),
+                    );
+                    let loaded = source.load_many(chunk).instrument(load_span).await;
+                    if loaded.len() == chunk.len() {
+                        self.cache_loaded(chunk, loaded);
+                    } else {
+                        self.cache_loaded(
+                            chunk,
+                            chunk
+                                .iter()
+                                .map(|_| {
+                                    FactLoadResult::Error(FactLoadError::WrongResultCount {
+                                        fact_name: K::NAME,
+                                        expected: chunk.len(),
+                                        actual: loaded.len(),
+                                    })
+                                })
+                                .collect(),
+                        );
+                    }
+                    self.finish_in_flight::<K>(chunk);
+                }
+            } else {
+                self.cache_loaded(
+                    &load_plan.keys,
+                    load_plan
+                        .keys
+                        .iter()
+                        .map(|_| {
+                            FactLoadResult::Error(FactLoadError::SourceNotRegistered {
+                                fact_name: K::NAME,
+                            })
+                        })
+                        .collect(),
+                );
+                self.finish_in_flight::<K>(&load_plan.keys);
+            }
+        }
+
+        for waiter in load_plan.waiters {
+            let _ = waiter.await;
+        }
+
+        self.results_from_cache(keys)
+    }
+
+    fn source<K>(&self) -> Option<Arc<dyn FactSource<K>>>
+    where
+        K: FactKey,
+    {
+        self.inner
+            .sources
+            .lock()
+            .expect("fact source registry mutex should not be poisoned")
+            .get(&TypeId::of::<K>())
+            .and_then(|source| source.downcast_ref::<Arc<dyn FactSource<K>>>().cloned())
+    }
+
+    fn plan_loads<K>(&self, keys: &[K]) -> LoadPlan<K>
+    where
+        K: FactKey,
+    {
+        let mut seen = HashSet::new();
+        let mut missing = Vec::new();
+        let mut caches = self
+            .inner
+            .caches
+            .lock()
+            .expect("fact cache mutex should not be poisoned");
+        let cache = Self::cache_for::<K>(&mut caches);
+
+        let mut in_flight = self
+            .inner
+            .in_flight
+            .lock()
+            .expect("fact in-flight registry mutex should not be poisoned");
+        let in_flight = Self::in_flight_for::<K>(&mut in_flight);
+        let mut waiters = Vec::new();
+
+        for key in keys.iter().filter(|key| seen.insert((*key).clone())) {
+            if cache.contains_key(key) {
+                continue;
+            }
+
+            if let Some(existing_waiters) = in_flight.get_mut(key) {
+                let (sender, receiver) = oneshot::channel();
+                existing_waiters.push(sender);
+                waiters.push(receiver);
+            } else {
+                in_flight.insert(key.clone(), Vec::new());
+                missing.push(key.clone());
+            }
+        }
+
+        LoadPlan {
+            keys: missing,
+            waiters,
+        }
+    }
+
+    fn finish_in_flight<K>(&self, keys: &[K])
+    where
+        K: FactKey,
+    {
+        let mut in_flight = self
+            .inner
+            .in_flight
+            .lock()
+            .expect("fact in-flight registry mutex should not be poisoned");
+        let in_flight = Self::in_flight_for::<K>(&mut in_flight);
+
+        for key in keys {
+            if let Some(waiters) = in_flight.remove(key) {
+                for waiter in waiters {
+                    let _ = waiter.send(());
+                }
+            }
+        }
+    }
+
+    fn cache_loaded<K>(&self, keys: &[K], results: Vec<FactLoadResult<K::Value>>)
+    where
+        K: FactKey,
+    {
+        let mut caches = self
+            .inner
+            .caches
+            .lock()
+            .expect("fact cache mutex should not be poisoned");
+        let cache = Self::cache_for::<K>(&mut caches);
+
+        for (key, result) in keys.iter().cloned().zip(results) {
+            cache.insert(key, result);
+        }
+    }
+
+    fn results_from_cache<K>(&self, keys: &[K]) -> Vec<FactLoadResult<K::Value>>
+    where
+        K: FactKey,
+    {
+        let mut caches = self
+            .inner
+            .caches
+            .lock()
+            .expect("fact cache mutex should not be poisoned");
+        let cache = Self::cache_for::<K>(&mut caches);
+        keys.iter()
+            .map(|key| {
+                cache.get(key).cloned().unwrap_or_else(|| {
+                    FactLoadResult::Error(FactLoadError::SourceReturnedNoResult {
+                        fact_name: K::NAME,
+                    })
+                })
+            })
+            .collect()
+    }
+
+    fn cache_for<K>(
+        caches: &mut HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+    ) -> &mut HashMap<K, FactLoadResult<K::Value>>
+    where
+        K: FactKey,
+    {
+        caches
+            .entry(TypeId::of::<K>())
+            .or_insert_with(|| Box::new(HashMap::<K, FactLoadResult<K::Value>>::new()))
+            .downcast_mut::<HashMap<K, FactLoadResult<K::Value>>>()
+            .expect("fact cache type should match registry key")
+    }
+
+    fn in_flight_for<K>(
+        in_flight: &mut HashMap<TypeId, Box<dyn Any + Send>>,
+    ) -> &mut HashMap<K, Vec<oneshot::Sender<()>>>
+    where
+        K: FactKey,
+    {
+        in_flight
+            .entry(TypeId::of::<K>())
+            .or_insert_with(|| Box::new(HashMap::<K, Vec<oneshot::Sender<()>>>::new()))
+            .downcast_mut::<HashMap<K, Vec<oneshot::Sender<()>>>>()
+            .expect("fact in-flight type should match registry key")
+    }
+}
+
+struct LoadPlan<K> {
+    keys: Vec<K>,
+    waiters: Vec<oneshot::Receiver<()>>,
+}
+
+/// Per-item policy evaluation context.
+pub struct EvalCtx<'a, Subject, Resource, Action, Context> {
+    /// Request-scoped fact session.
+    pub session: &'a EvaluationSession,
+    /// Entity requesting access.
+    pub subject: &'a Subject,
+    /// Action being performed.
+    pub action: &'a Action,
+    /// Target resource.
+    pub resource: &'a Resource,
+    /// Additional evaluation context.
+    pub context: &'a Context,
+}
+
+/// Batch policy evaluation context.
+pub struct BatchEvalCtx<'a, Subject, Resource, Action, Context> {
+    /// Request-scoped fact session.
+    pub session: &'a EvaluationSession,
+    /// Entity requesting access.
+    pub subject: &'a Subject,
+    /// Action being performed.
+    pub action: &'a Action,
+    /// Borrowed resource/context pairs.
+    pub items: &'a [PolicyBatchItem<'a, Resource, Context>],
+}
+
+/// Canonical ReBAC fact key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RelationshipQuery<SubjectId, ResourceId, Relation> {
+    /// Subject identifier.
+    pub subject_id: SubjectId,
+    /// Resource identifier.
+    pub resource_id: ResourceId,
+    /// Relationship being checked.
+    pub relation: Relation,
+}
+
+impl<SubjectId, ResourceId, Relation> FactKey for RelationshipQuery<SubjectId, ResourceId, Relation>
+where
+    SubjectId: Eq + Hash + Clone + Send + Sync + 'static,
+    ResourceId: Eq + Hash + Clone + Send + Sync + 'static,
+    Relation: Eq + Hash + Clone + Send + Sync + 'static,
+{
+    type Value = bool;
+
+    const NAME: &'static str = "relationship";
+}
+
+/// Error returned by lookup-oriented relationship sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupError {
+    message: String,
+}
+
+impl LookupError {
+    /// Creates a lookup error with a human-readable message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Returns the error message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for LookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for LookupError {}
+
+/// One page of lookup-oriented relationship results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupPage<ResourceId, Cursor> {
+    /// Resources visible in this page.
+    pub resources: Vec<ResourceId>,
+    /// Cursor to request the next page, if more resources are available.
+    pub next_cursor: Option<Cursor>,
+}
+
+/// Optional graph-style relationship lookup source.
+#[async_trait]
+pub trait LookupSource<SubjectId, ResourceId, Relation>:
+    FactSource<RelationshipQuery<SubjectId, ResourceId, Relation>>
+where
+    SubjectId: Eq + Hash + Clone + Send + Sync + 'static,
+    ResourceId: Eq + Hash + Clone + Send + Sync + 'static,
+    Relation: Eq + Hash + Clone + Send + Sync + 'static,
+{
+    /// Opaque pagination cursor type used by this source.
+    type Cursor: Clone + Send + Sync + 'static;
+
+    /// Looks up one page of resources related to the subject by `relation`.
+    async fn lookup_resources(
+        &self,
+        subject: &SubjectId,
+        relation: &Relation,
+        cursor: Option<Self::Cursor>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<LookupPage<ResourceId, Self::Cursor>, LookupError>;
+}
+
 /// The complete result of a permission evaluation.
 /// Contains both the final decision and a detailed trace for debugging.
 ///
@@ -415,7 +930,8 @@ pub struct PolicyBatchItem<'a, Resource, Context> {
 /// #     let mut checker = PermissionChecker::<User, Document, ReadAction, EmptyContext>::new();
 /// #     let user = User { id: Uuid::new_v4() };
 /// #     let document = Document { id: Uuid::new_v4() };
-/// #     checker.evaluate_access(&user, &ReadAction, &document, &EmptyContext).await
+/// #     let session = EvaluationSession::empty();
+/// #     checker.evaluate_in_session(&session, &user, &ReadAction, &document, &EmptyContext).await
 /// # }
 /// #
 /// # tokio_test::block_on(async {
@@ -476,7 +992,8 @@ impl AccessEvaluation {
     /// # struct Ctx;
     /// # tokio_test::block_on(async {
     /// let checker = PermissionChecker::<User, Resource, Action, Ctx>::new();
-    /// let result = checker.evaluate_access(&User, &Action, &Resource, &Ctx).await;
+    /// let session = EvaluationSession::empty();
+    /// let result = checker.evaluate_in_session(&session, &User, &Action, &Resource, &Ctx).await;
     ///
     /// // Map a denial into a standard error:
     /// let outcome: Result<(), String> = result.to_result(|reason| reason.to_string());
@@ -676,23 +1193,9 @@ where
     Context: Sync,
 {
     /// Evaluates whether access should be granted.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The entity requesting access.
-    /// * `action` - The action being performed.
-    /// * `resource` - The target resource.
-    /// * `context` - Additional context that may affect the decision.
-    ///
-    /// # Returns
-    ///
-    /// A [`PolicyEvalResult`] indicating whether access is granted or denied.
-    async fn evaluate_access(
+    async fn evaluate(
         &self,
-        subject: &Subject,
-        action: &Action,
-        resource: &Resource,
-        context: &Context,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Context>,
     ) -> PolicyEvalResult;
 
     /// Evaluates access for a batch of resource/context pairs.
@@ -706,24 +1209,26 @@ where
     /// evaluation can differ from a naive item-outer loop when later policies
     /// have side effects or observe mutable external state. Prefer pure policy
     /// predicates and use traces to audit the policy-ordered batch behavior.
-    async fn evaluate_access_batch<'item>(
+    async fn evaluate_batch<'item>(
         &self,
-        subject: &'item Subject,
-        action: &'item Action,
-        items: &'item [PolicyBatchItem<'item, Resource, Context>],
+        ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Context>,
     ) -> Vec<PolicyEvalResult> {
-        let mut results = Vec::with_capacity(items.len());
-        for item in items {
-            results.push(
-                self.evaluate_access(subject, action, item.resource, item.context)
-                    .await,
-            );
+        let mut results = Vec::with_capacity(ctx.items.len());
+        for item in ctx.items {
+            let item_ctx = EvalCtx {
+                session: ctx.session,
+                subject: ctx.subject,
+                action: ctx.action,
+                resource: item.resource,
+                context: item.context,
+            };
+            results.push(self.evaluate(&item_ctx).await);
         }
         results
     }
 
     /// Policy name for debugging
-    fn policy_type(&self) -> String;
+    fn policy_type(&self) -> &str;
 
     /// Metadata describing the security rule that backs this policy.
     ///
@@ -791,13 +1296,15 @@ where
         self.policies.push(Arc::new(policy));
     }
 
-    /// Evaluates all policies against the given parameters.
+    /// Evaluates all policies against the given parameters using a caller-owned
+    /// request session.
     ///
     /// Policies are evaluated sequentially with OR semantics (short-circuiting on first success).
     /// Returns an [`AccessEvaluation`] with detailed tracing.
     #[tracing::instrument(skip_all)]
-    pub async fn evaluate_access(
+    pub async fn evaluate_in_session(
         &self,
+        session: &EvaluationSession,
         subject: &S,
         action: &A,
         resource: &R,
@@ -821,14 +1328,19 @@ where
 
         // Evaluate each policy
         for policy in &self.policies {
-            let result = policy
-                .evaluate_access(subject, action, resource, context)
-                .await;
+            let ctx = EvalCtx {
+                session,
+                subject,
+                action,
+                resource,
+                context,
+            };
+            let result = policy.evaluate(&ctx).await;
             let result_passes = result.is_granted();
 
             // Extract metadata for tracing (always needed for security audit)
             let policy_type = policy.policy_type();
-            let policy_type_str = policy_type.as_str();
+            let policy_type_str = policy_type;
             let metadata = policy.security_rule();
             let reason = result.reason();
             let reason_str = reason.as_deref();
@@ -871,7 +1383,7 @@ where
                 };
 
                 return AccessEvaluation::Granted {
-                    policy_type,
+                    policy_type: policy_type.to_string(),
                     reason,
                     trace: EvalTrace::with_root(combined),
                 };
@@ -893,15 +1405,15 @@ where
         }
     }
 
-    /// Evaluates a batch of caller-owned items.
+    /// Evaluates a batch of caller-owned items using a caller-owned session.
     ///
     /// The `parts` callback tells gatehouse how to borrow the resource and
     /// context from each caller-owned item. Returned results preserve input
     /// order, including duplicate resources. Policy evaluation still uses the
-    /// same OR semantics as [`Self::evaluate_access`], but the checker evaluates
+    /// same OR semantics as [`Self::evaluate_in_session`], but the checker evaluates
     /// each policy across the still-pending batch before moving to the next
     /// policy. This lets policies with set-oriented backends override
-    /// [`Policy::evaluate_access_batch`] and collapse many point lookups into
+    /// [`Policy::evaluate_batch`] and collapse many point lookups into
     /// one backend call.
     ///
     /// The loop is intentionally policy-outer/items-inner, not a naive
@@ -926,6 +1438,7 @@ where
     /// # tokio_test::block_on(async {
     /// let user = User { id: 7 };
     /// let context = RequestContext;
+    /// let session = EvaluationSession::empty();
     /// let documents = vec![
     ///     Document { owner_id: 7 },
     ///     Document { owner_id: 42 },
@@ -939,7 +1452,7 @@ where
     /// ));
     ///
     /// let visible = checker
-    ///     .filter_authorized_with_context_by(&user, &Read, documents, &context, |document| {
+    ///     .filter_authorized_with_context_in_session_by(&session, &user, &Read, documents, &context, |document| {
     ///         document
     ///     })
     ///     .await;
@@ -948,8 +1461,9 @@ where
     /// # });
     /// ```
     #[tracing::instrument(skip_all, fields(item_count, granted_count, denied_count, max_batch_size, policy_count = self.policies.len()))]
-    pub async fn evaluate_batch_by<I, F>(
+    pub async fn evaluate_batch_in_session_by<I, F>(
         &self,
+        session: &EvaluationSession,
         subject: &S,
         action: &A,
         items: I,
@@ -1011,7 +1525,7 @@ where
             let policy_type = policy.policy_type();
             let policy_span = tracing::debug_span!(
                 "gatehouse.batch_policy",
-                policy.type = policy_type.as_str(),
+                policy.type = policy_type,
                 policy.pending_count = pending.len(),
                 policy.granted_count = tracing::field::Empty,
                 policy.denied_count = tracing::field::Empty,
@@ -1034,8 +1548,14 @@ where
                     })
                     .collect();
 
+                let batch_ctx = BatchEvalCtx {
+                    session,
+                    subject,
+                    action,
+                    items: &batch_items,
+                };
                 let policy_results = policy
-                    .evaluate_access_batch(subject, action, &batch_items)
+                    .evaluate_batch(&batch_ctx)
                     .instrument(policy_span.clone())
                     .await;
 
@@ -1043,7 +1563,7 @@ where
                     for &index in pending_chunk {
                         policy_denied_count += 1;
                         let policy_result = PolicyEvalResult::Denied {
-                            policy_type: policy_type.clone(),
+                            policy_type: policy_type.to_string(),
                             reason: "Policy batch result count did not match input count"
                                 .to_string(),
                         };
@@ -1078,7 +1598,7 @@ where
                             outcome: true,
                         };
                         evaluations[index] = Some(AccessEvaluation::Granted {
-                            policy_type: policy_type.clone(),
+                            policy_type: policy_type.to_string(),
                             reason,
                             trace: EvalTrace::with_root(combined),
                         });
@@ -1135,9 +1655,10 @@ where
         results
     }
 
-    /// Returns only the items granted by [`Self::evaluate_batch_by`].
-    pub async fn filter_authorized_by<I, F>(
+    /// Returns only the items granted by [`Self::evaluate_batch_in_session_by`].
+    pub async fn filter_authorized_in_session_by<I, F>(
         &self,
+        session: &EvaluationSession,
         subject: &S,
         action: &A,
         items: I,
@@ -1147,20 +1668,18 @@ where
         I: IntoIterator,
         F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C),
     {
-        self.evaluate_batch_by(subject, action, items, parts)
+        self.evaluate_batch_in_session_by(session, subject, action, items, parts)
             .await
             .into_iter()
             .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
             .collect()
     }
 
-    /// Evaluates caller-owned items that all share one context value.
-    ///
-    /// This is a convenience wrapper around [`Self::evaluate_batch_by`] for the
-    /// common list-endpoint shape where every candidate resource is evaluated in
-    /// the same request context.
-    pub async fn evaluate_batch_with_context_by<I, F>(
+    /// Evaluates caller-owned items that all share one context value, using a
+    /// caller-owned session.
+    pub async fn evaluate_batch_with_context_in_session_by<I, F>(
         &self,
+        session: &EvaluationSession,
         subject: &S,
         action: &A,
         items: I,
@@ -1176,18 +1695,23 @@ where
             .map(|item| (item, context))
             .collect::<Vec<_>>();
 
-        self.evaluate_batch_by(subject, action, wrapped_items, |(item, context)| {
-            (resource(item), *context)
-        })
+        self.evaluate_batch_in_session_by(
+            session,
+            subject,
+            action,
+            wrapped_items,
+            |(item, context)| (resource(item), *context),
+        )
         .await
         .into_iter()
         .map(|((item, _context), evaluation)| (item, evaluation))
         .collect()
     }
 
-    /// Returns only authorized items when all items share one context value.
-    pub async fn filter_authorized_with_context_by<I, F>(
+    /// Returns only authorized items with a shared context and caller-owned session.
+    pub async fn filter_authorized_with_context_in_session_by<I, F>(
         &self,
+        session: &EvaluationSession,
         subject: &S,
         action: &A,
         items: I,
@@ -1198,11 +1722,13 @@ where
         I: IntoIterator,
         F: for<'item> Fn(&'item I::Item) -> &'item R,
     {
-        self.evaluate_batch_with_context_by(subject, action, items, context, resource)
-            .await
-            .into_iter()
-            .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
-            .collect()
+        self.evaluate_batch_with_context_in_session_by(
+            session, subject, action, items, context, resource,
+        )
+        .await
+        .into_iter()
+        .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
+        .collect()
     }
 }
 
@@ -1233,14 +1759,8 @@ where
     A: Send + Sync,
     C: Send + Sync,
 {
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
-        if (self.predicate)(subject, action, resource, context) {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        if (self.predicate)(ctx.subject, ctx.action, ctx.resource, ctx.context) {
             match self.effect {
                 Effect::Allow => PolicyEvalResult::Granted {
                     policy_type: self.name.clone(),
@@ -1259,8 +1779,8 @@ where
             }
         }
     }
-    fn policy_type(&self) -> String {
-        self.name.clone()
+    fn policy_type(&self) -> &str {
+        &self.name
     }
 }
 
@@ -1274,28 +1794,18 @@ where
     A: Send + Sync,
     C: Send + Sync,
 {
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
-        (**self)
-            .evaluate_access(subject, action, resource, context)
-            .await
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        (**self).evaluate(ctx).await
     }
 
-    async fn evaluate_access_batch<'item>(
+    async fn evaluate_batch<'item>(
         &self,
-        subject: &'item S,
-        action: &'item A,
-        items: &'item [PolicyBatchItem<'item, R, C>],
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
-        (**self).evaluate_access_batch(subject, action, items).await
+        (**self).evaluate_batch(ctx).await
     }
 
-    fn policy_type(&self) -> String {
+    fn policy_type(&self) -> &str {
         (**self).policy_type()
     }
 
@@ -1342,12 +1852,13 @@ where
 /// let user_id = Uuid::new_v4();
 /// let user = User { id: user_id, roles: vec!["editor".into()] };
 /// let doc = Document { owner_id: user_id, classification: "internal".into() };
+/// let session = EvaluationSession::empty();
 ///
 /// // User is an editor, action is "edit", doc is not top-secret, and user owns it:
-/// assert!(checker.evaluate_access(&user, &Action("edit".into()), &doc, &Ctx).await.is_granted());
+/// assert!(checker.evaluate_in_session(&session, &user, &Action("edit".into()), &doc, &Ctx).await.is_granted());
 ///
 /// // Wrong action — predicate fails:
-/// assert!(!checker.evaluate_access(&user, &Action("delete".into()), &doc, &Ctx).await.is_granted());
+/// assert!(!checker.evaluate_in_session(&session, &user, &Action("delete".into()), &doc, &Ctx).await.is_granted());
 /// # });
 /// ```
 pub struct PolicyBuilder<S, R, A, C>
@@ -1363,7 +1874,7 @@ where
     action_pred: Option<Box<dyn Fn(&A) -> bool + Send + Sync>>,
     resource_pred: Option<Box<dyn Fn(&R) -> bool + Send + Sync>>,
     context_pred: Option<Box<dyn Fn(&C) -> bool + Send + Sync>>,
-    // Note the order here matches the evaluate_access signature
+    // Note the order here matches the EvalCtx fields used by Policy::evaluate.
     extra_condition: Option<Box<dyn Fn(&S, &A, &R, &C) -> bool + Send + Sync>>,
 }
 
@@ -1500,11 +2011,12 @@ where
 /// checker.add_policy(rbac);
 ///
 /// # tokio_test::block_on(async {
+/// let session = EvaluationSession::empty();
 /// let authorised = User { role_ids: vec![editor_role] };
-/// assert!(checker.evaluate_access(&authorised, &Action, &Resource, &Ctx).await.is_granted());
+/// assert!(checker.evaluate_in_session(&session, &authorised, &Action, &Resource, &Ctx).await.is_granted());
 ///
 /// let unauthorised = User { role_ids: vec![Uuid::new_v4()] };
-/// assert!(!checker.evaluate_access(&unauthorised, &Action, &Resource, &Ctx).await.is_granted());
+/// assert!(!checker.evaluate_in_session(&session, &unauthorised, &Action, &Resource, &Ctx).await.is_granted());
 /// # });
 /// ```
 pub struct RbacPolicy<S, F1, F2> {
@@ -1534,32 +2046,26 @@ where
     F1: Fn(&R, &A) -> Vec<uuid::Uuid> + Sync + Send,
     F2: Fn(&S) -> Vec<uuid::Uuid> + Sync + Send,
 {
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        _context: &C,
-    ) -> PolicyEvalResult {
-        let required_roles = (self.required_roles_resolver)(resource, action);
-        let user_roles = (self.user_roles_resolver)(subject);
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        let required_roles = (self.required_roles_resolver)(ctx.resource, ctx.action);
+        let user_roles = (self.user_roles_resolver)(ctx.subject);
         let has_role = required_roles.iter().any(|role| user_roles.contains(role));
 
         if has_role {
             PolicyEvalResult::Granted {
-                policy_type: Policy::<S, R, A, C>::policy_type(self),
+                policy_type: Policy::<S, R, A, C>::policy_type(self).to_string(),
                 reason: Some("User has required role".to_string()),
             }
         } else {
             PolicyEvalResult::Denied {
-                policy_type: Policy::<S, R, A, C>::policy_type(self),
+                policy_type: Policy::<S, R, A, C>::policy_type(self).to_string(),
                 reason: "User doesn't have required role".to_string(),
             }
         }
     }
 
-    fn policy_type(&self) -> String {
-        "RbacPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "RbacPolicy"
     }
 }
 
@@ -1618,13 +2124,14 @@ where
 /// let owned_resource = Resource { owner_id: user.id };
 /// let other_resource = Resource { owner_id: Uuid::new_v4() };
 /// let context = EmptyContext;
+/// let session = EvaluationSession::empty();
 ///
 /// # tokio_test::block_on(async {
 /// // This check should succeed because the user is the owner:
-/// assert!(checker.evaluate_access(&user, &Action, &owned_resource, &context).await.is_granted());
+/// assert!(checker.evaluate_in_session(&session, &user, &Action, &owned_resource, &context).await.is_granted());
 ///
 /// // This check should fail because the user is not the owner:
-/// assert!(!checker.evaluate_access(&user, &Action, &other_resource, &context).await.is_granted());
+/// assert!(!checker.evaluate_in_session(&session, &user, &Action, &other_resource, &context).await.is_granted());
 /// # });
 /// ```
 ///
@@ -1652,99 +2159,45 @@ where
     C: Sync + Send,
     F: Fn(&S, &R, &A, &C) -> bool + Sync + Send,
 {
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
-        let condition_met = (self.condition)(subject, resource, action, context);
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        let condition_met = (self.condition)(ctx.subject, ctx.resource, ctx.action, ctx.context);
 
         if condition_met {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some("Condition evaluated to true".to_string()),
             }
         } else {
             PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: "Condition evaluated to false".to_string(),
             }
         }
     }
 
-    fn policy_type(&self) -> String {
-        "AbacPolicy".to_string()
-    }
-}
-
-/// A trait that abstracts a relationship resolver.
-/// Given a subject and a resource, the resolver answers whether the
-/// specified relationship e.g. "creator", "manager" exists between them.
-///
-/// The relationship type `Re` is generic, so you can use strings, enums, or
-/// other domain-specific types.
-#[async_trait]
-pub trait RelationshipResolver<S, R, Re>: Send + Sync
-where
-    S: Sync,
-    R: Sync,
-    Re: Sync,
-{
-    /// Returns `true` if `relationship` exists between `subject` and `resource`.
-    async fn has_relationship(&self, subject: &S, resource: &R, relationship: &Re) -> bool;
-
-    /// Maximum number of resources this resolver wants in one batch call.
-    ///
-    /// The default leaves batches unconstrained. Backend resolvers can override
-    /// this when query planner behavior, parameter limits, or service limits
-    /// make smaller chunks safer.
-    fn max_batch_size(&self) -> Option<NonZeroUsize> {
-        None
-    }
-
-    /// Returns one relationship decision per resource, in input order.
-    ///
-    /// The default implementation loops over [`Self::has_relationship`].
-    /// Resolvers backed by SQL, graph stores, or remote authorization services
-    /// can override this method to perform one set-oriented lookup for the
-    /// whole batch.
-    async fn has_relationship_batch<'item>(
-        &self,
-        subject: &'item S,
-        resources: &'item [&'item R],
-        relationship: &'item Re,
-    ) -> Vec<bool> {
-        let mut results = Vec::with_capacity(resources.len());
-        for resource in resources {
-            results.push(self.has_relationship(subject, resource, relationship).await);
-        }
-        results
+    fn policy_type(&self) -> &str {
+        "AbacPolicy"
     }
 }
 
 /// ### ReBAC Policy
 ///
-/// In this example, we show how to use a built-in relationship-based (ReBAC) policy. We define
-/// a dummy relationship resolver that checks if a user is the manager of a project.
+/// ReBAC is backed by [`FactSource`] in v0.3. A policy extracts flat,
+/// hashable IDs from the subject and resource, builds a [`RelationshipQuery`],
+/// then loads relationship facts through the request-scoped
+/// [`EvaluationSession`].
 ///
 /// ```rust
 /// use async_trait::async_trait;
-/// use std::sync::Arc;
+/// use std::collections::HashSet;
 /// use uuid::Uuid;
 /// use gatehouse::*;
 ///
 /// #[derive(Debug, Clone)]
-/// pub struct Employee {
-///     pub id: Uuid,
-/// }
+/// pub struct Employee { pub id: Uuid }
 ///
 /// #[derive(Debug, Clone)]
-/// pub struct Project {
-///     pub id: Uuid,
-///     pub manager_id: Uuid,
-/// }
+/// pub struct Project { pub id: Uuid }
 ///
 /// #[derive(Debug, Clone)]
 /// pub struct AccessAction;
@@ -1752,172 +2205,168 @@ where
 /// #[derive(Debug, Clone)]
 /// pub struct EmptyContext;
 ///
-/// // Define a dummy relationship resolver that considers an employee to be a manager
-/// // of a project if their id matches the project's manager_id.
-/// struct DummyRelationshipResolver;
+/// struct ProjectRelationships {
+///     grants: HashSet<RelationshipQuery<Uuid, Uuid, String>>,
+/// }
 ///
 /// #[async_trait]
-/// impl RelationshipResolver<Employee, Project, String> for DummyRelationshipResolver {
-///     async fn has_relationship(
+/// impl FactSource<RelationshipQuery<Uuid, Uuid, String>> for ProjectRelationships {
+///     async fn load_many(
 ///         &self,
-///         employee: &Employee,
-///         project: &Project,
-///         relationship: &String,
-///     ) -> bool {
-///         relationship == "manager" && employee.id == project.manager_id
+///         keys: &[RelationshipQuery<Uuid, Uuid, String>],
+///     ) -> Vec<FactLoadResult<bool>> {
+///         keys.iter()
+///             .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+///             .collect()
 ///     }
 /// }
 ///
-/// // Create a ReBAC policy that checks for the "manager" relationship.
-/// let rebac_policy = RebacPolicy::<Employee, Project, AccessAction, EmptyContext, _, _>::new(
-///     "manager".to_string(),
-///     DummyRelationshipResolver,
+/// let manager = Employee { id: Uuid::new_v4() };
+/// let project = Project { id: Uuid::new_v4() };
+/// let relationship = "manager".to_string();
+/// let grants = HashSet::from([RelationshipQuery {
+///     subject_id: manager.id,
+///     resource_id: project.id,
+///     relation: relationship.clone(),
+/// }]);
+///
+/// let session = EvaluationSession::new();
+/// session.register::<RelationshipQuery<Uuid, Uuid, String>, _>(ProjectRelationships { grants });
+///
+/// let rebac_policy = RebacPolicy::new(
+///     |employee: &Employee| employee.id,
+///     |project: &Project| project.id,
+///     relationship,
 /// );
 ///
-/// // Create a PermissionChecker and add the ReBAC policy.
 /// let mut checker = PermissionChecker::<Employee, Project, AccessAction, EmptyContext>::new();
 /// checker.add_policy(rebac_policy);
 ///
-/// // Create a sample employee and project.
-/// let manager = Employee { id: Uuid::new_v4() };
-/// let project = Project {
-///     id: Uuid::new_v4(),
-///     manager_id: manager.id,
-/// };
-/// let context = EmptyContext;
-///
-/// // The manager should have access.
 /// # tokio_test::block_on(async {
-/// assert!(checker.evaluate_access(&manager, &AccessAction, &project, &context).await.is_granted());
-///
-/// // A different employee should be denied access.
-/// let other_employee = Employee { id: Uuid::new_v4() };
-/// assert!(!checker.evaluate_access(&other_employee, &AccessAction, &project, &context).await.is_granted());
+/// assert!(checker
+///     .evaluate_in_session(&session, &manager, &AccessAction, &project, &EmptyContext)
+///     .await
+///     .is_granted());
 /// # });
 /// ```
-///
-/// The relationship type `Re` must implement [`fmt::Display`] so that policy
-/// evaluation reasons can include the relationship value in log messages.
-pub struct RebacPolicy<S, R, A, C, Re, RG> {
-    /// The relationship to check (e.g. `"manager"`, or an enum variant).
-    pub relationship: Re,
-    /// The resolver that determines whether the relationship exists.
-    pub resolver: RG,
-    _marker: std::marker::PhantomData<(S, R, A, C)>,
+pub struct RebacPolicy<S, R, A, C, SubjectId, ResourceId, Relation> {
+    subject_id: Arc<dyn Fn(&S) -> SubjectId + Send + Sync>,
+    resource_id: Arc<dyn Fn(&R) -> ResourceId + Send + Sync>,
+    relation: Relation,
+    _marker: std::marker::PhantomData<(A, C)>,
 }
 
-impl<S, R, A, C, Re, RG> RebacPolicy<S, R, A, C, Re, RG> {
-    /// Creates a new `RebacPolicy` for a given relationship.
-    pub fn new(relationship: Re, resolver: RG) -> Self {
+impl<S, R, A, C, SubjectId, ResourceId, Relation>
+    RebacPolicy<S, R, A, C, SubjectId, ResourceId, Relation>
+{
+    /// Creates a ReBAC policy from subject/resource ID extractors and a relation.
+    pub fn new<SubjectIdFn, ResourceIdFn>(
+        subject_id: SubjectIdFn,
+        resource_id: ResourceIdFn,
+        relation: Relation,
+    ) -> Self
+    where
+        SubjectIdFn: Fn(&S) -> SubjectId + Send + Sync + 'static,
+        ResourceIdFn: Fn(&R) -> ResourceId + Send + Sync + 'static,
+    {
         Self {
-            relationship,
-            resolver,
+            subject_id: Arc::new(subject_id),
+            resource_id: Arc::new(resource_id),
+            relation,
             _marker: std::marker::PhantomData,
         }
     }
 }
 
 #[async_trait]
-impl<S, R, A, C, Re, RG> Policy<S, R, A, C> for RebacPolicy<S, R, A, C, Re, RG>
+impl<S, R, A, C, SubjectId, ResourceId, Relation> Policy<S, R, A, C>
+    for RebacPolicy<S, R, A, C, SubjectId, ResourceId, Relation>
 where
     S: Sync + Send,
     R: Sync + Send,
     A: Sync + Send,
     C: Sync + Send,
-    Re: Sync + Send + fmt::Display,
-    RG: RelationshipResolver<S, R, Re>,
+    SubjectId: Eq + Hash + Clone + Send + Sync + 'static,
+    ResourceId: Eq + Hash + Clone + Send + Sync + 'static,
+    Relation: Eq + Hash + Clone + Send + Sync + fmt::Display + 'static,
 {
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        _action: &A,
-        resource: &R,
-        _context: &C,
-    ) -> PolicyEvalResult {
-        let has_relationship = self
-            .resolver
-            .has_relationship(subject, resource, &self.relationship)
-            .await;
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        let key = RelationshipQuery {
+            subject_id: (self.subject_id)(ctx.subject),
+            resource_id: (self.resource_id)(ctx.resource),
+            relation: self.relation.clone(),
+        };
+        self.result_from_fact(ctx.session.get(key).await)
+    }
 
-        if has_relationship {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
+    ) -> Vec<PolicyEvalResult> {
+        let keys = ctx
+            .items
+            .iter()
+            .map(|item| RelationshipQuery {
+                subject_id: (self.subject_id)(ctx.subject),
+                resource_id: (self.resource_id)(item.resource),
+                relation: self.relation.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let facts = ctx.session.get_many(&keys).await;
+        if facts.len() != ctx.items.len() {
+            return ctx
+                .items
+                .iter()
+                .map(|_| PolicyEvalResult::Denied {
+                    policy_type: self.policy_type().to_string(),
+                    reason: "Relationship fact source returned the wrong number of results"
+                        .to_string(),
+                })
+                .collect();
+        }
+
+        facts
+            .into_iter()
+            .map(|fact| self.result_from_fact(fact))
+            .collect()
+    }
+
+    fn policy_type(&self) -> &str {
+        "RebacPolicy"
+    }
+}
+
+impl<S, R, A, C, SubjectId, ResourceId, Relation>
+    RebacPolicy<S, R, A, C, SubjectId, ResourceId, Relation>
+where
+    Relation: fmt::Display,
+{
+    fn result_from_fact(&self, fact: FactLoadResult<bool>) -> PolicyEvalResult {
+        match fact {
+            FactLoadResult::Found(true) => PolicyEvalResult::Granted {
+                policy_type: "RebacPolicy".to_string(),
                 reason: Some(format!(
                     "Subject has '{}' relationship with resource",
-                    self.relationship
+                    self.relation
                 )),
-            }
-        } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+            },
+            FactLoadResult::Found(false) => PolicyEvalResult::Denied {
+                policy_type: "RebacPolicy".to_string(),
                 reason: format!(
                     "Subject does not have '{}' relationship with resource",
-                    self.relationship
+                    self.relation
                 ),
-            }
+            },
+            FactLoadResult::Missing => PolicyEvalResult::Denied {
+                policy_type: "RebacPolicy".to_string(),
+                reason: format!("Relationship '{}' fact is missing", self.relation),
+            },
+            FactLoadResult::Error(error) => PolicyEvalResult::Denied {
+                policy_type: "RebacPolicy".to_string(),
+                reason: format!("Relationship '{}' fact load failed: {error}", self.relation),
+            },
         }
-    }
-
-    async fn evaluate_access_batch<'item>(
-        &self,
-        subject: &'item S,
-        _action: &'item A,
-        items: &'item [PolicyBatchItem<'item, R, C>],
-    ) -> Vec<PolicyEvalResult> {
-        let mut results = Vec::with_capacity(items.len());
-        let chunk_size = self
-            .resolver
-            .max_batch_size()
-            .map_or(items.len(), NonZeroUsize::get)
-            .max(1);
-
-        for item_chunk in items.chunks(chunk_size) {
-            let resources = item_chunk
-                .iter()
-                .map(|item| item.resource)
-                .collect::<Vec<_>>();
-            let relationship_results = self
-                .resolver
-                .has_relationship_batch(subject, &resources, &self.relationship)
-                .await;
-
-            if relationship_results.len() != item_chunk.len() {
-                results.extend(item_chunk.iter().map(|_| {
-                    PolicyEvalResult::Denied {
-                        policy_type: self.policy_type(),
-                        reason: "Relationship resolver returned the wrong number of batch results"
-                            .to_string(),
-                    }
-                }));
-                continue;
-            }
-
-            results.extend(relationship_results.into_iter().map(|has_relationship| {
-                if has_relationship {
-                    PolicyEvalResult::Granted {
-                        policy_type: self.policy_type(),
-                        reason: Some(format!(
-                            "Subject has '{}' relationship with resource",
-                            self.relationship
-                        )),
-                    }
-                } else {
-                    PolicyEvalResult::Denied {
-                        policy_type: self.policy_type(),
-                        reason: format!(
-                            "Subject does not have '{}' relationship with resource",
-                            self.relationship
-                        ),
-                    }
-                }
-            }));
-        }
-
-        results
-    }
-
-    fn policy_type(&self) -> String {
-        "RebacPolicy".to_string()
     }
 }
 
@@ -1961,30 +2410,22 @@ where
     C: Sync + Send,
 {
     // Override the default policy_type implementation
-    fn policy_type(&self) -> String {
-        "AndPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "AndPolicy"
     }
 
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
         let mut children_results = Vec::with_capacity(self.policies.len());
 
         for policy in &self.policies {
-            let result = policy
-                .evaluate_access(subject, action, resource, context)
-                .await;
+            let result = policy.evaluate(ctx).await;
             let is_granted = result.is_granted();
             children_results.push(result);
 
             // Short-circuit on first denial
             if !is_granted {
                 return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     operation: CombineOp::And,
                     children: children_results,
                     outcome: false,
@@ -1994,22 +2435,20 @@ where
 
         // All policies granted access
         PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
+            policy_type: self.policy_type().to_string(),
             operation: CombineOp::And,
             children: children_results,
             outcome: true,
         }
     }
 
-    async fn evaluate_access_batch<'item>(
+    async fn evaluate_batch<'item>(
         &self,
-        subject: &'item S,
-        action: &'item A,
-        items: &'item [PolicyBatchItem<'item, R, C>],
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
-        let mut children_by_item = vec![Vec::new(); items.len()];
-        let mut results = vec![None; items.len()];
-        let mut pending = (0..items.len()).collect::<Vec<_>>();
+        let mut children_by_item = vec![Vec::new(); ctx.items.len()];
+        let mut results = vec![None; ctx.items.len()];
+        let mut pending = (0..ctx.items.len()).collect::<Vec<_>>();
 
         for policy in &self.policies {
             if pending.is_empty() {
@@ -2019,22 +2458,26 @@ where
             let batch_items = pending
                 .iter()
                 .map(|&index| PolicyBatchItem {
-                    resource: items[index].resource,
-                    context: items[index].context,
+                    resource: ctx.items[index].resource,
+                    context: ctx.items[index].context,
                 })
                 .collect::<Vec<_>>();
-            let child_results = policy
-                .evaluate_access_batch(subject, action, &batch_items)
-                .await;
+            let batch_ctx = BatchEvalCtx {
+                session: ctx.session,
+                subject: ctx.subject,
+                action: ctx.action,
+                items: &batch_items,
+            };
+            let child_results = policy.evaluate_batch(&batch_ctx).await;
 
             if child_results.len() != pending.len() {
                 for index in pending.drain(..) {
                     children_by_item[index].push(PolicyEvalResult::Denied {
-                        policy_type: policy.policy_type(),
+                        policy_type: policy.policy_type().to_string(),
                         reason: "Policy batch result count did not match input count".to_string(),
                     });
                     results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         operation: CombineOp::And,
                         children: std::mem::take(&mut children_by_item[index]),
                         outcome: false,
@@ -2052,7 +2495,7 @@ where
                     still_pending.push(index);
                 } else {
                     results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         operation: CombineOp::And,
                         children: std::mem::take(&mut children_by_item[index]),
                         outcome: false,
@@ -2064,7 +2507,7 @@ where
 
         for index in pending {
             results[index] = Some(PolicyEvalResult::Combined {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 operation: CombineOp::And,
                 children: std::mem::take(&mut children_by_item[index]),
                 outcome: true,
@@ -2075,7 +2518,7 @@ where
             .into_iter()
             .map(|result| {
                 result.unwrap_or_else(|| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: "Batch item was not evaluated".to_string(),
                 })
             })
@@ -2113,29 +2556,21 @@ where
     C: Sync + Send,
 {
     // Override the default policy_type implementation
-    fn policy_type(&self) -> String {
-        "OrPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "OrPolicy"
     }
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
         let mut children_results = Vec::with_capacity(self.policies.len());
 
         for policy in &self.policies {
-            let result = policy
-                .evaluate_access(subject, action, resource, context)
-                .await;
+            let result = policy.evaluate(ctx).await;
             let is_granted = result.is_granted();
             children_results.push(result);
 
             // Short-circuit on first success
             if is_granted {
                 return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     operation: CombineOp::Or,
                     children: children_results,
                     outcome: true,
@@ -2145,22 +2580,20 @@ where
 
         // All policies denied access
         PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
+            policy_type: self.policy_type().to_string(),
             operation: CombineOp::Or,
             children: children_results,
             outcome: false,
         }
     }
 
-    async fn evaluate_access_batch<'item>(
+    async fn evaluate_batch<'item>(
         &self,
-        subject: &'item S,
-        action: &'item A,
-        items: &'item [PolicyBatchItem<'item, R, C>],
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
-        let mut children_by_item = vec![Vec::new(); items.len()];
-        let mut results = vec![None; items.len()];
-        let mut pending = (0..items.len()).collect::<Vec<_>>();
+        let mut children_by_item = vec![Vec::new(); ctx.items.len()];
+        let mut results = vec![None; ctx.items.len()];
+        let mut pending = (0..ctx.items.len()).collect::<Vec<_>>();
 
         for policy in &self.policies {
             if pending.is_empty() {
@@ -2170,22 +2603,26 @@ where
             let batch_items = pending
                 .iter()
                 .map(|&index| PolicyBatchItem {
-                    resource: items[index].resource,
-                    context: items[index].context,
+                    resource: ctx.items[index].resource,
+                    context: ctx.items[index].context,
                 })
                 .collect::<Vec<_>>();
-            let child_results = policy
-                .evaluate_access_batch(subject, action, &batch_items)
-                .await;
+            let batch_ctx = BatchEvalCtx {
+                session: ctx.session,
+                subject: ctx.subject,
+                action: ctx.action,
+                items: &batch_items,
+            };
+            let child_results = policy.evaluate_batch(&batch_ctx).await;
 
             if child_results.len() != pending.len() {
                 for index in pending.drain(..) {
                     children_by_item[index].push(PolicyEvalResult::Denied {
-                        policy_type: policy.policy_type(),
+                        policy_type: policy.policy_type().to_string(),
                         reason: "Policy batch result count did not match input count".to_string(),
                     });
                     results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         operation: CombineOp::Or,
                         children: std::mem::take(&mut children_by_item[index]),
                         outcome: false,
@@ -2201,7 +2638,7 @@ where
 
                 if is_granted {
                     results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         operation: CombineOp::Or,
                         children: std::mem::take(&mut children_by_item[index]),
                         outcome: true,
@@ -2215,7 +2652,7 @@ where
 
         for index in pending {
             results[index] = Some(PolicyEvalResult::Combined {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 operation: CombineOp::Or,
                 children: std::mem::take(&mut children_by_item[index]),
                 outcome: false,
@@ -2226,7 +2663,7 @@ where
             .into_iter()
             .map(|result| {
                 result.unwrap_or_else(|| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: "Batch item was not evaluated".to_string(),
                 })
             })
@@ -2266,47 +2703,34 @@ where
     C: Sync + Send,
 {
     // Override the default policy_type implementation
-    fn policy_type(&self) -> String {
-        "NotPolicy".to_string()
+    fn policy_type(&self) -> &str {
+        "NotPolicy"
     }
 
-    async fn evaluate_access(
-        &self,
-        subject: &S,
-        action: &A,
-        resource: &R,
-        context: &C,
-    ) -> PolicyEvalResult {
-        let inner_result = self
-            .policy
-            .evaluate_access(subject, action, resource, context)
-            .await;
+    async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        let inner_result = self.policy.evaluate(ctx).await;
         let is_granted = inner_result.is_granted();
 
         PolicyEvalResult::Combined {
-            policy_type: Policy::<S, R, A, C>::policy_type(self),
+            policy_type: Policy::<S, R, A, C>::policy_type(self).to_string(),
             operation: CombineOp::Not,
             children: vec![inner_result],
             outcome: !is_granted,
         }
     }
 
-    async fn evaluate_access_batch<'item>(
+    async fn evaluate_batch<'item>(
         &self,
-        subject: &'item S,
-        action: &'item A,
-        items: &'item [PolicyBatchItem<'item, R, C>],
+        ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
-        let inner_results = self
-            .policy
-            .evaluate_access_batch(subject, action, items)
-            .await;
+        let inner_results = self.policy.evaluate_batch(ctx).await;
 
-        if inner_results.len() != items.len() {
-            return items
+        if inner_results.len() != ctx.items.len() {
+            return ctx
+                .items
                 .iter()
                 .map(|_| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: "Policy batch result count did not match input count".to_string(),
                 })
                 .collect();
@@ -2317,7 +2741,7 @@ where
             .map(|inner_result| {
                 let is_granted = inner_result.is_granted();
                 PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     operation: CombineOp::Not,
                     children: vec![inner_result],
                     outcome: !is_granted,
@@ -2330,8 +2754,181 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
+
+    trait TestPolicyExt<S, R, A, C>: Policy<S, R, A, C>
+    where
+        S: Send + Sync,
+        R: Send + Sync,
+        A: Send + Sync,
+        C: Send + Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = PolicyEvalResult> + Send + 'a>>;
+
+        fn evaluate_access_batch<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: &'a [PolicyBatchItem<'a, R, C>],
+        ) -> Pin<Box<dyn Future<Output = Vec<PolicyEvalResult>> + Send + 'a>>;
+    }
+
+    impl<T, S, R, A, C> TestPolicyExt<S, R, A, C> for T
+    where
+        T: Policy<S, R, A, C>,
+        S: Send + Sync,
+        R: Send + Sync,
+        A: Send + Sync,
+        C: Send + Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = PolicyEvalResult> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::new();
+                let ctx = EvalCtx {
+                    session: &session,
+                    subject,
+                    action,
+                    resource,
+                    context,
+                };
+                self.evaluate(&ctx).await
+            })
+        }
+
+        fn evaluate_access_batch<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: &'a [PolicyBatchItem<'a, R, C>],
+        ) -> Pin<Box<dyn Future<Output = Vec<PolicyEvalResult>> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::new();
+                let ctx = BatchEvalCtx {
+                    session: &session,
+                    subject,
+                    action,
+                    items,
+                };
+                self.evaluate_batch(&ctx).await
+            })
+        }
+    }
+
+    trait TestCheckerExt<S, R, A, C>
+    where
+        S: Sync,
+        R: Sync,
+        A: Sync,
+        C: Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = AccessEvaluation> + Send + 'a>>;
+
+        fn evaluate_batch_by<'a, I, F>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: I,
+            parts: F,
+        ) -> Pin<Box<dyn Future<Output = Vec<(I::Item, AccessEvaluation)>> + Send + 'a>>
+        where
+            I: IntoIterator + Send + 'a,
+            I::Item: Send + 'a,
+            F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C) + Send + 'a;
+
+        fn filter_authorized_by<'a, I, F>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: I,
+            parts: F,
+        ) -> Pin<Box<dyn Future<Output = Vec<I::Item>> + Send + 'a>>
+        where
+            I: IntoIterator + Send + 'a,
+            I::Item: Send + 'a,
+            F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C) + Send + 'a;
+    }
+
+    impl<S, R, A, C> TestCheckerExt<S, R, A, C> for PermissionChecker<S, R, A, C>
+    where
+        S: Sync,
+        R: Sync,
+        A: Sync,
+        C: Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = AccessEvaluation> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::empty();
+                self.evaluate_in_session(&session, subject, action, resource, context)
+                    .await
+            })
+        }
+
+        fn evaluate_batch_by<'a, I, F>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: I,
+            parts: F,
+        ) -> Pin<Box<dyn Future<Output = Vec<(I::Item, AccessEvaluation)>> + Send + 'a>>
+        where
+            I: IntoIterator + Send + 'a,
+            I::Item: Send + 'a,
+            F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C) + Send + 'a,
+        {
+            Box::pin(async move {
+                let session = EvaluationSession::empty();
+                self.evaluate_batch_in_session_by(&session, subject, action, items, parts)
+                    .await
+            })
+        }
+
+        fn filter_authorized_by<'a, I, F>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            items: I,
+            parts: F,
+        ) -> Pin<Box<dyn Future<Output = Vec<I::Item>> + Send + 'a>>
+        where
+            I: IntoIterator + Send + 'a,
+            I::Item: Send + 'a,
+            F: for<'item> Fn(&'item I::Item) -> (&'item R, &'item C) + Send + 'a,
+        {
+            Box::pin(async move {
+                let session = EvaluationSession::empty();
+                self.filter_authorized_in_session_by(&session, subject, action, items, parts)
+                    .await
+            })
+        }
+    }
 
     // Dummy resource/action/context types for testing
     #[derive(Debug, Clone)]
@@ -2377,21 +2974,18 @@ mod tests {
 
     #[async_trait]
     impl Policy<TestSubject, TestResource, TestAction, TestContext> for AlwaysAllowPolicy {
-        async fn evaluate_access(
+        async fn evaluate(
             &self,
-            _subject: &TestSubject,
-            _action: &TestAction,
-            _resource: &TestResource,
-            _context: &TestContext,
+            _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some("Always allow policy".to_string()),
             }
         }
 
-        fn policy_type(&self) -> String {
-            "AlwaysAllowPolicy".to_string()
+        fn policy_type(&self) -> &str {
+            "AlwaysAllowPolicy"
         }
     }
 
@@ -2400,21 +2994,18 @@ mod tests {
 
     #[async_trait]
     impl Policy<TestSubject, TestResource, TestAction, TestContext> for AlwaysDenyPolicy {
-        async fn evaluate_access(
+        async fn evaluate(
             &self,
-            _subject: &TestSubject,
-            _action: &TestAction,
-            _resource: &TestResource,
-            _context: &TestContext,
+            _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
             PolicyEvalResult::Denied {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: self.0.to_string(),
             }
         }
 
-        fn policy_type(&self) -> String {
-            "AlwaysDenyPolicy".to_string()
+        fn policy_type(&self) -> &str {
+            "AlwaysDenyPolicy"
         }
     }
 
@@ -2425,46 +3016,45 @@ mod tests {
 
     #[async_trait]
     impl Policy<TestSubject, TestResource, TestAction, TestContext> for EvenResourceBatchPolicy {
-        async fn evaluate_access(
+        async fn evaluate(
             &self,
-            _subject: &TestSubject,
-            _action: &TestAction,
-            resource: &TestResource,
-            _context: &TestContext,
+            ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
             self.single_calls.fetch_add(1, Ordering::SeqCst);
-            if resource.id.as_u128().is_multiple_of(2) {
+            if ctx.resource.id.as_u128().is_multiple_of(2) {
                 PolicyEvalResult::Granted {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: Some("even resource".to_string()),
                 }
             } else {
                 PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: "odd resource".to_string(),
                 }
             }
         }
 
-        async fn evaluate_access_batch<'item>(
+        async fn evaluate_batch<'item>(
             &self,
-            subject: &'item TestSubject,
-            action: &'item TestAction,
-            items: &'item [PolicyBatchItem<'item, TestResource, TestContext>],
+            ctx: &BatchEvalCtx<'item, TestSubject, TestResource, TestAction, TestContext>,
         ) -> Vec<PolicyEvalResult> {
             self.batch_calls.fetch_add(1, Ordering::SeqCst);
-            let mut results = Vec::with_capacity(items.len());
-            for item in items {
-                results.push(
-                    self.evaluate_access(subject, action, item.resource, item.context)
-                        .await,
-                );
+            let mut results = Vec::with_capacity(ctx.items.len());
+            for item in ctx.items {
+                let item_ctx = EvalCtx {
+                    session: ctx.session,
+                    subject: ctx.subject,
+                    action: ctx.action,
+                    resource: item.resource,
+                    context: item.context,
+                };
+                results.push(self.evaluate(&item_ctx).await);
             }
             results
         }
 
-        fn policy_type(&self) -> String {
-            "EvenResourceBatchPolicy".to_string()
+        fn policy_type(&self) -> &str {
+            "EvenResourceBatchPolicy"
         }
     }
 
@@ -2472,37 +3062,32 @@ mod tests {
 
     #[async_trait]
     impl Policy<TestSubject, TestResource, TestAction, TestContext> for MismatchedBatchPolicy {
-        async fn evaluate_access(
+        async fn evaluate(
             &self,
-            _subject: &TestSubject,
-            _action: &TestAction,
-            _resource: &TestResource,
-            _context: &TestContext,
+            _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
             PolicyEvalResult::Granted {
-                policy_type: self.policy_type(),
+                policy_type: self.policy_type().to_string(),
                 reason: Some("single item fallback".to_string()),
             }
         }
 
-        async fn evaluate_access_batch<'item>(
+        async fn evaluate_batch<'item>(
             &self,
-            _subject: &'item TestSubject,
-            _action: &'item TestAction,
-            items: &'item [PolicyBatchItem<'item, TestResource, TestContext>],
+            ctx: &BatchEvalCtx<'item, TestSubject, TestResource, TestAction, TestContext>,
         ) -> Vec<PolicyEvalResult> {
-            items
+            ctx.items
                 .iter()
                 .skip(1)
                 .map(|_| PolicyEvalResult::Granted {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: Some("wrong batch length".to_string()),
                 })
                 .collect()
         }
 
-        fn policy_type(&self) -> String {
-            "MismatchedBatchPolicy".to_string()
+        fn policy_type(&self) -> &str {
+            "MismatchedBatchPolicy"
         }
     }
 
@@ -3062,89 +3647,112 @@ mod tests {
         }
     }
 
-    // RebacPolicy tests with a dummy resolver.
+    // RebacPolicy tests with fact-backed relationship sources.
 
-    /// In-memory relationship resolver for testing.
-    /// It holds a vector of tuples (subject_id, resource_id, relationship)
-    /// to represent existing relationships.
-    pub struct DummyRelationshipResolver {
-        relationships: Vec<(uuid::Uuid, uuid::Uuid, String)>,
-    }
-
-    impl DummyRelationshipResolver {
-        pub fn new(relationships: Vec<(uuid::Uuid, uuid::Uuid, String)>) -> Self {
-            Self { relationships }
-        }
-    }
-
-    #[async_trait]
-    impl RelationshipResolver<TestSubject, TestResource, String> for DummyRelationshipResolver {
-        async fn has_relationship(
-            &self,
-            subject: &TestSubject,
-            resource: &TestResource,
-            relationship: &String,
-        ) -> bool {
-            self.relationships
-                .iter()
-                .any(|(s, r, rel)| s == &subject.id && r == &resource.id && rel == relationship)
-        }
-    }
-
-    struct ChunkedRelationshipResolver {
+    struct TestRelationshipSource {
+        grants: HashSet<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>>,
         batch_sizes: Arc<Mutex<Vec<usize>>>,
+        max_batch_size: Option<NonZeroUsize>,
     }
 
     #[async_trait]
-    impl RelationshipResolver<TestSubject, TestResource, String> for ChunkedRelationshipResolver {
-        async fn has_relationship(
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>> for TestRelationshipSource {
+        async fn load_many(
             &self,
-            _subject: &TestSubject,
-            resource: &TestResource,
-            _relationship: &String,
-        ) -> bool {
-            resource.id.as_u128().is_multiple_of(2)
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, String>],
+        ) -> Vec<FactLoadResult<bool>> {
+            self.batch_sizes.lock().unwrap().push(keys.len());
+            keys.iter()
+                .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+                .collect()
         }
 
         fn max_batch_size(&self) -> Option<NonZeroUsize> {
-            NonZeroUsize::new(2)
+            self.max_batch_size
         }
+    }
 
-        async fn has_relationship_batch<'item>(
+    struct MismatchedRelationshipSource;
+
+    #[async_trait]
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>>
+        for MismatchedRelationshipSource
+    {
+        async fn load_many(
             &self,
-            _subject: &'item TestSubject,
-            resources: &'item [&'item TestResource],
-            _relationship: &'item String,
-        ) -> Vec<bool> {
-            self.batch_sizes.lock().unwrap().push(resources.len());
-            resources
-                .iter()
-                .map(|resource| resource.id.as_u128().is_multiple_of(2))
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, String>],
+        ) -> Vec<FactLoadResult<bool>> {
+            keys.iter()
+                .skip(1)
+                .map(|_| FactLoadResult::Found(true))
                 .collect()
         }
     }
 
-    struct MismatchedRelationshipResolver;
+    struct MissingRelationshipSource;
 
     #[async_trait]
-    impl RelationshipResolver<TestSubject, TestResource, String> for MismatchedRelationshipResolver {
-        async fn has_relationship(
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>> for MissingRelationshipSource {
+        async fn load_many(
             &self,
-            _subject: &TestSubject,
-            _resource: &TestResource,
-            _relationship: &String,
-        ) -> bool {
-            true
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, String>],
+        ) -> Vec<FactLoadResult<bool>> {
+            keys.iter().map(|_| FactLoadResult::Missing).collect()
         }
+    }
 
-        async fn has_relationship_batch<'item>(
+    struct ErrorRelationshipSource;
+
+    #[async_trait]
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>> for ErrorRelationshipSource {
+        async fn load_many(
             &self,
-            _subject: &'item TestSubject,
-            resources: &'item [&'item TestResource],
-            _relationship: &'item String,
-        ) -> Vec<bool> {
-            resources.iter().skip(1).map(|_| true).collect()
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, String>],
+        ) -> Vec<FactLoadResult<bool>> {
+            keys.iter()
+                .map(|_| {
+                    FactLoadResult::Error(FactLoadError::backend_message("database unavailable"))
+                })
+                .collect()
         }
+    }
+
+    struct BlockingRelationshipSource {
+        calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>> for BlockingRelationshipSource {
+        async fn load_many(
+            &self,
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, String>],
+        ) -> Vec<FactLoadResult<bool>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(keys.len(), 1);
+            self.started.notify_one();
+            self.release.notified().await;
+            keys.iter().map(|_| FactLoadResult::Found(true)).collect()
+        }
+    }
+
+    fn relationship_policy(
+        relationship: String,
+    ) -> RebacPolicy<
+        TestSubject,
+        TestResource,
+        TestAction,
+        TestContext,
+        uuid::Uuid,
+        uuid::Uuid,
+        String,
+    > {
+        RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
+            relationship,
+        )
     }
 
     #[tokio::test]
@@ -3152,140 +3760,213 @@ mod tests {
         let subject_id = uuid::Uuid::new_v4();
         let resource_id = uuid::Uuid::new_v4();
         let relationship = "manager".to_string();
-
         let subject = TestSubject { id: subject_id };
         let resource = TestResource { id: resource_id };
-
-        // Create a dummy resolver that knows the subject is a manager of the resource.
-        let resolver =
-            DummyRelationshipResolver::new(vec![(subject_id, resource_id, relationship.clone())]);
-
-        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
-            relationship,
-            resolver,
+        let session = EvaluationSession::new();
+        session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+            TestRelationshipSource {
+                grants: HashSet::from([RelationshipQuery {
+                    subject_id,
+                    resource_id,
+                    relation: relationship.clone(),
+                }]),
+                batch_sizes: Arc::new(Mutex::new(Vec::new())),
+                max_batch_size: None,
+            },
         );
+        let policy = relationship_policy(relationship);
 
-        // Action and context are not used by RebacPolicy, so we pass dummy values.
-        let result = policy
-            .evaluate_access(&subject, &TestAction, &resource, &TestContext)
-            .await;
+        let ctx = EvalCtx {
+            session: &session,
+            subject: &subject,
+            action: &TestAction,
+            resource: &resource,
+            context: &TestContext,
+        };
+        let result = policy.evaluate(&ctx).await;
 
-        assert!(
-            result.is_granted(),
-            "Access should be allowed if relationship exists"
-        );
+        assert!(result.is_granted());
     }
 
     #[tokio::test]
-    async fn test_rebac_policy_denies_when_relationship_missing() {
-        let subject_id = uuid::Uuid::new_v4();
-        let resource_id = uuid::Uuid::new_v4();
-        let relationship = "manager".to_string();
+    async fn test_rebac_policy_denies_without_registered_source() {
+        let policy = relationship_policy("manager".to_string());
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resource = TestResource {
+            id: uuid::Uuid::new_v4(),
+        };
+        let session = EvaluationSession::new();
+        let ctx = EvalCtx {
+            session: &session,
+            subject: &subject,
+            action: &TestAction,
+            resource: &resource,
+            context: &TestContext,
+        };
 
-        let subject = TestSubject { id: subject_id };
-        let resource = TestResource { id: resource_id };
+        let result = policy.evaluate(&ctx).await;
 
-        // Create a dummy resolver with no relationships.
-        let resolver = DummyRelationshipResolver::new(vec![]);
-
-        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
-            relationship,
-            resolver,
-        );
-
-        let result = policy
-            .evaluate_access(&subject, &TestAction, &resource, &TestContext)
-            .await;
-        // Check access is denied
-        assert!(
-            !result.is_granted(),
-            "Access should be denied if relationship does not exist"
-        );
+        assert!(!result.is_granted());
+        assert!(result
+            .reason()
+            .as_deref()
+            .is_some_and(|reason| reason.contains("No fact source registered")));
     }
 
     #[tokio::test]
-    async fn test_rebac_policy_batch_respects_resolver_max_batch_size() {
+    async fn test_rebac_policy_batch_uses_session_dedup_and_source_chunking() {
         let subject = TestSubject {
             id: uuid::Uuid::new_v4(),
         };
         let relationship = "viewer".to_string();
         let batch_sizes = Arc::new(Mutex::new(Vec::new()));
-        let resolver = ChunkedRelationshipResolver {
-            batch_sizes: Arc::clone(&batch_sizes),
-        };
-        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
-            relationship,
-            resolver,
-        );
-        let owned_items = (0..5)
-            .map(|value| {
-                (
-                    TestResource {
-                        id: uuid::Uuid::from_u128(value),
-                    },
-                    TestContext,
-                )
+        let resources = (0..5)
+            .map(|value| TestResource {
+                id: uuid::Uuid::from_u128(value),
             })
             .collect::<Vec<_>>();
+        let grants = resources
+            .iter()
+            .filter(|resource| resource.id.as_u128().is_multiple_of(2))
+            .map(|resource| RelationshipQuery {
+                subject_id: subject.id,
+                resource_id: resource.id,
+                relation: relationship.clone(),
+            })
+            .collect::<HashSet<_>>();
+        let session = EvaluationSession::new();
+        session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+            TestRelationshipSource {
+                grants,
+                batch_sizes: Arc::clone(&batch_sizes),
+                max_batch_size: NonZeroUsize::new(2),
+            },
+        );
+        let owned_items = [
+            (resources[0].clone(), TestContext),
+            (resources[1].clone(), TestContext),
+            (resources[0].clone(), TestContext),
+            (resources[2].clone(), TestContext),
+            (resources[3].clone(), TestContext),
+        ];
         let batch_items = owned_items
             .iter()
             .map(|(resource, context)| PolicyBatchItem { resource, context })
             .collect::<Vec<_>>();
+        let policy = relationship_policy(relationship);
+        let ctx = BatchEvalCtx {
+            session: &session,
+            subject: &subject,
+            action: &TestAction,
+            items: &batch_items,
+        };
 
-        let results = policy
-            .evaluate_access_batch(&subject, &TestAction, &batch_items)
-            .await;
+        let results = policy.evaluate_batch(&ctx).await;
 
-        assert_eq!(*batch_sizes.lock().unwrap(), vec![2, 2, 1]);
+        assert_eq!(*batch_sizes.lock().unwrap(), vec![2, 2]);
         assert_eq!(
             results
                 .iter()
                 .map(PolicyEvalResult::is_granted)
                 .collect::<Vec<_>>(),
-            vec![true, false, true, false, true]
+            vec![true, false, true, true, false]
         );
+
+        let _ = policy.evaluate_batch(&ctx).await;
+        assert_eq!(*batch_sizes.lock().unwrap(), vec![2, 2]);
     }
 
     #[tokio::test]
-    async fn test_rebac_policy_batch_fails_closed_on_resolver_length_mismatch() {
+    async fn test_session_joins_concurrent_get_for_in_flight_key() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let session = EvaluationSession::new();
+        session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+            BlockingRelationshipSource {
+                calls: Arc::clone(&calls),
+                started: Arc::clone(&started),
+                release: Arc::clone(&release),
+            },
+        );
+        let key = RelationshipQuery {
+            subject_id: uuid::Uuid::new_v4(),
+            resource_id: uuid::Uuid::new_v4(),
+            relation: "viewer".to_string(),
+        };
+
+        let first_session = session.clone();
+        let first_key = key.clone();
+        let first = tokio::spawn(async move { first_session.get(first_key).await });
+
+        started.notified().await;
+
+        let second_session = session.clone();
+        let second = tokio::spawn(async move { second_session.get(key).await });
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        release.notify_one();
+        for result in [first.await.unwrap(), second.await.unwrap()] {
+            assert!(matches!(result, FactLoadResult::Found(true)));
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_rebac_policy_fails_closed_on_missing_error_and_mismatch() {
         let subject = TestSubject {
             id: uuid::Uuid::new_v4(),
         };
-        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
-            "viewer".to_string(),
-            MismatchedRelationshipResolver,
-        );
-        let owned_items = (0..3)
-            .map(|value| {
-                (
-                    TestResource {
-                        id: uuid::Uuid::from_u128(value),
-                    },
-                    TestContext,
-                )
-            })
-            .collect::<Vec<_>>();
-        let batch_items = owned_items
-            .iter()
-            .map(|(resource, context)| PolicyBatchItem { resource, context })
-            .collect::<Vec<_>>();
+        let resource = TestResource {
+            id: uuid::Uuid::new_v4(),
+        };
+        let policy = relationship_policy("viewer".to_string());
 
-        let results = policy
-            .evaluate_access_batch(&subject, &TestAction, &batch_items)
-            .await;
-
-        assert_eq!(results.len(), 3);
-        assert!(results.iter().all(|result| !result.is_granted()));
-        assert!(results.iter().all(|result| {
-            result.reason().as_deref().is_some_and(|reason| {
-                reason.contains("Relationship resolver returned the wrong number")
-            })
-        }));
+        for (session, expected_reason) in [
+            {
+                let session = EvaluationSession::new();
+                session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+                    MissingRelationshipSource,
+                );
+                (session, "fact is missing")
+            },
+            {
+                let session = EvaluationSession::new();
+                session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+                    ErrorRelationshipSource,
+                );
+                (session, "database unavailable")
+            },
+            {
+                let session = EvaluationSession::new();
+                session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+                    MismatchedRelationshipSource,
+                );
+                (session, "returned")
+            },
+        ] {
+            let ctx = EvalCtx {
+                session: &session,
+                subject: &subject,
+                action: &TestAction,
+                resource: &resource,
+                context: &TestContext,
+            };
+            let result = policy.evaluate(&ctx).await;
+            assert!(!result.is_granted());
+            assert!(result
+                .reason()
+                .as_deref()
+                .is_some_and(|reason| reason.contains(expected_reason)));
+        }
     }
 
     // RebacPolicy test with enum relationship type.
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     enum TestRelation {
         Manager,
         Viewer,
@@ -3300,21 +3981,21 @@ mod tests {
         }
     }
 
-    struct EnumRelationshipResolver {
-        relationships: Vec<(uuid::Uuid, uuid::Uuid, TestRelation)>,
+    struct EnumRelationshipSource {
+        grants: HashSet<RelationshipQuery<uuid::Uuid, uuid::Uuid, TestRelation>>,
     }
 
     #[async_trait]
-    impl RelationshipResolver<TestSubject, TestResource, TestRelation> for EnumRelationshipResolver {
-        async fn has_relationship(
+    impl FactSource<RelationshipQuery<uuid::Uuid, uuid::Uuid, TestRelation>>
+        for EnumRelationshipSource
+    {
+        async fn load_many(
             &self,
-            subject: &TestSubject,
-            resource: &TestResource,
-            relationship: &TestRelation,
-        ) -> bool {
-            self.relationships
-                .iter()
-                .any(|(s, r, rel)| s == &subject.id && r == &resource.id && rel == relationship)
+            keys: &[RelationshipQuery<uuid::Uuid, uuid::Uuid, TestRelation>],
+        ) -> Vec<FactLoadResult<bool>> {
+            keys.iter()
+                .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+                .collect()
         }
     }
 
@@ -3326,37 +4007,43 @@ mod tests {
         let subject = TestSubject { id: subject_id };
         let resource = TestResource { id: resource_id };
 
-        let resolver = EnumRelationshipResolver {
-            relationships: vec![(subject_id, resource_id, TestRelation::Manager)],
-        };
+        let session = EvaluationSession::new();
+        session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, TestRelation>, _>(
+            EnumRelationshipSource {
+                grants: HashSet::from([RelationshipQuery {
+                    subject_id,
+                    resource_id,
+                    relation: TestRelation::Manager,
+                }]),
+            },
+        );
 
-        let policy = RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
+        let policy = RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
             TestRelation::Manager,
-            resolver,
         );
 
         // Manager relationship exists — should be granted.
-        let result = policy
-            .evaluate_access(&subject, &TestAction, &resource, &TestContext)
-            .await;
+        let ctx = EvalCtx {
+            session: &session,
+            subject: &subject,
+            action: &TestAction,
+            resource: &resource,
+            context: &TestContext,
+        };
+        let result = policy.evaluate(&ctx).await;
         assert!(
             result.is_granted(),
             "Access should be granted for matching enum relationship"
         );
 
-        // Viewer policy with same resolver (no viewer relationship) — should be denied.
-        let resolver = EnumRelationshipResolver {
-            relationships: vec![(subject_id, resource_id, TestRelation::Manager)],
-        };
-        let viewer_policy =
-            RebacPolicy::<TestSubject, TestResource, TestAction, TestContext, _, _>::new(
-                TestRelation::Viewer,
-                resolver,
-            );
-
-        let result = viewer_policy
-            .evaluate_access(&subject, &TestAction, &resource, &TestContext)
-            .await;
+        let viewer_policy = RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
+            TestRelation::Viewer,
+        );
+        let result = viewer_policy.evaluate(&ctx).await;
         assert!(
             !result.is_granted(),
             "Access should be denied when enum relationship does not match"
@@ -3578,28 +4265,25 @@ mod tests {
 
     #[async_trait]
     impl Policy<TestSubject, TestResource, TestAction, FeatureFlagContext> for FeatureFlagPolicy {
-        async fn evaluate_access(
+        async fn evaluate(
             &self,
-            _subject: &TestSubject,
-            _action: &TestAction,
-            _resource: &TestResource,
-            context: &FeatureFlagContext,
+            ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, FeatureFlagContext>,
         ) -> PolicyEvalResult {
-            if context.feature_enabled {
+            if ctx.context.feature_enabled {
                 PolicyEvalResult::Granted {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: Some("Feature flag enabled".to_string()),
                 }
             } else {
                 PolicyEvalResult::Denied {
-                    policy_type: self.policy_type(),
+                    policy_type: self.policy_type().to_string(),
                     reason: "Feature flag disabled".to_string(),
                 }
             }
         }
 
-        fn policy_type(&self) -> String {
-            "FeatureFlagPolicy".to_string()
+        fn policy_type(&self) -> &str {
+            "FeatureFlagPolicy"
         }
     }
 
@@ -3757,15 +4441,15 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult =
-            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-                &policy,
-                &admin_user,
-                &TestAction,
-                &resource,
-                &TestContext,
-            )
-            .await;
+        let result: PolicyEvalResult = TestPolicyExt::<
+            RbacUser,
+            TestResource,
+            TestAction,
+            TestContext,
+        >::evaluate_access(
+            &policy, &admin_user, &TestAction, &resource, &TestContext
+        )
+        .await;
 
         assert!(
             result.is_granted(),
@@ -3800,7 +4484,7 @@ mod tests {
         };
 
         let result: PolicyEvalResult =
-            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+            TestPolicyExt::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
                 &policy,
                 &regular_user,
                 &TestAction,
@@ -3850,15 +4534,15 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult =
-            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-                &policy,
-                &user,
-                &TestAction,
-                &resource,
-                &TestContext,
-            )
-            .await;
+        let result: PolicyEvalResult = TestPolicyExt::<
+            RbacUser,
+            TestResource,
+            TestAction,
+            TestContext,
+        >::evaluate_access(
+            &policy, &user, &TestAction, &resource, &TestContext
+        )
+        .await;
 
         assert!(
             result.is_granted(),
@@ -3886,7 +4570,7 @@ mod tests {
         };
 
         let result: PolicyEvalResult =
-            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
+            TestPolicyExt::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
                 &policy,
                 &user_no_roles,
                 &TestAction,
@@ -3920,15 +4604,15 @@ mod tests {
             id: uuid::Uuid::new_v4(),
         };
 
-        let result: PolicyEvalResult =
-            Policy::<RbacUser, TestResource, TestAction, TestContext>::evaluate_access(
-                &policy,
-                &user,
-                &TestAction,
-                &resource,
-                &TestContext,
-            )
-            .await;
+        let result: PolicyEvalResult = TestPolicyExt::<
+            RbacUser,
+            TestResource,
+            TestAction,
+            TestContext,
+        >::evaluate_access(
+            &policy, &user, &TestAction, &resource, &TestContext
+        )
+        .await;
 
         // With empty required roles, no role can match, so access is denied
         assert!(
@@ -3952,30 +4636,27 @@ mod tests {
 
         #[async_trait]
         impl Policy<TestSubject, TestResource, TestAction, TestContext> for CountingPolicy {
-            async fn evaluate_access(
+            async fn evaluate(
                 &self,
-                _subject: &TestSubject,
-                _action: &TestAction,
-                _resource: &TestResource,
-                _context: &TestContext,
+                _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
             ) -> PolicyEvalResult {
                 self.counter.fetch_add(1, Ordering::SeqCst);
 
                 if self.result {
                     PolicyEvalResult::Granted {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         reason: Some("Counting policy granted".to_string()),
                     }
                 } else {
                     PolicyEvalResult::Denied {
-                        policy_type: self.policy_type(),
+                        policy_type: self.policy_type().to_string(),
                         reason: "Counting policy denied".to_string(),
                     }
                 }
             }
 
-            fn policy_type(&self) -> String {
-                "CountingPolicy".to_string()
+            fn policy_type(&self) -> &str {
+                "CountingPolicy"
             }
         }
 
@@ -4411,7 +5092,53 @@ mod tests {
 #[cfg(test)]
 mod policy_builder_tests {
     use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
     use uuid::Uuid;
+
+    trait PolicyBoxExt<S, R, A, C>
+    where
+        S: Send + Sync,
+        R: Send + Sync,
+        A: Send + Sync,
+        C: Send + Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = PolicyEvalResult> + Send + 'a>>;
+    }
+
+    impl<S, R, A, C> PolicyBoxExt<S, R, A, C> for Box<dyn Policy<S, R, A, C>>
+    where
+        S: Send + Sync,
+        R: Send + Sync,
+        A: Send + Sync,
+        C: Send + Sync,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a S,
+            action: &'a A,
+            resource: &'a R,
+            context: &'a C,
+        ) -> Pin<Box<dyn Future<Output = PolicyEvalResult> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::new();
+                let ctx = EvalCtx {
+                    session: &session,
+                    subject,
+                    action,
+                    resource,
+                    context,
+                };
+                self.evaluate(&ctx).await
+            })
+        }
+    }
 
     // Define simple test types
     #[derive(Debug, Clone)]

--- a/tests/axum_example.rs
+++ b/tests/axum_example.rs
@@ -1,8 +1,8 @@
 use axum::{
-    body::Body,
+    body::{to_bytes, Body},
     http::{Request, StatusCode},
     routing::{get, post},
-    Extension, Router,
+    Router,
 };
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -13,9 +13,8 @@ mod axum_example {
 }
 
 fn axum_app() -> Router {
-    let checker = axum_example::build_permission_checker();
-
     Router::new()
+        .route("/invoices", get(axum_example::list_invoices_handler))
         .route(
             "/invoices/{invoice_id}",
             get(axum_example::view_invoice_handler),
@@ -28,7 +27,7 @@ fn axum_app() -> Router {
             "/payments/{payment_id}/approve",
             post(axum_example::approve_payment_handler),
         )
-        .layer(Extension(checker))
+        .with_state(axum_example::AppState::demo())
 }
 
 #[tokio::test]
@@ -82,6 +81,53 @@ async fn view_invoice_handles_invalid_user_header() {
 
 fn owner_id() -> Uuid {
     Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap()
+}
+
+fn viewer_id() -> Uuid {
+    Uuid::parse_str("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee").unwrap()
+}
+
+#[tokio::test]
+async fn list_invoices_uses_request_session_relationships() {
+    let app = axum_app();
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/invoices")
+        .header("x-user-id", viewer_id().to_string())
+        .header("x-roles", "viewer")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("22222222-2222-2222-2222-222222222222"));
+    assert!(body.contains("33333333-3333-3333-3333-333333333333"));
+    assert!(!body.contains("11111111-1111-1111-1111-111111111111"));
+}
+
+#[tokio::test]
+async fn list_invoices_allows_admin_all_candidates() {
+    let app = axum_app();
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/invoices")
+        .header("x-roles", "admin")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("11111111-1111-1111-1111-111111111111"));
+    assert!(body.contains("22222222-2222-2222-2222-222222222222"));
+    assert!(body.contains("33333333-3333-3333-3333-333333333333"));
 }
 
 #[tokio::test]

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use gatehouse::{
-    AccessEvaluation, BatchEvalCtx, EvalCtx, EvaluationSession, FactLoadResult, FactSource,
-    PermissionChecker, Policy, PolicyBatchItem, PolicyBuilder, PolicyEvalResult, RebacPolicy,
-    RelationshipQuery,
+    AccessEvaluation, BatchEvalCtx, DelegatingPolicy, EvalCtx, EvaluationSession, FactLoadResult,
+    FactSource, PermissionChecker, Policy, PolicyBatchItem, PolicyBuilder, PolicyEvalResult,
+    RebacPolicy, RelationshipQuery,
 };
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -207,6 +207,110 @@ async fn single_item_batch_matches_single_evaluation() {
         .collect::<Vec<_>>();
 
     assert_eq!(batch, vec![single]);
+}
+
+#[tokio::test]
+async fn resource_batch_shortcut_uses_unit_context() {
+    let mut checker = PermissionChecker::<Subject, Resource, Action, ()>::new();
+    checker.add_policy(
+        PolicyBuilder::<Subject, Resource, Action, ()>::new("even-resource")
+            .resources(|resource: &Resource| resource.id.is_multiple_of(2))
+            .build(),
+    );
+
+    let session = EvaluationSession::empty();
+    let results = checker
+        .evaluate_batch_resources_in_session(
+            &session,
+            &Subject,
+            &Action,
+            vec![Resource { id: 1 }, Resource { id: 2 }, Resource { id: 3 }],
+        )
+        .await;
+
+    let decisions = results
+        .iter()
+        .map(|(resource, evaluation)| (resource.id, evaluation.is_granted()))
+        .collect::<Vec<_>>();
+    assert_eq!(decisions, vec![(1, false), (2, true), (3, false)]);
+
+    let visible = checker
+        .filter_authorized_resources_in_session(
+            &session,
+            &Subject,
+            &Action,
+            vec![Resource { id: 1 }, Resource { id: 2 }, Resource { id: 3 }],
+        )
+        .await;
+    assert_eq!(
+        visible
+            .iter()
+            .map(|resource| resource.id)
+            .collect::<Vec<_>>(),
+        vec![2]
+    );
+}
+
+#[tokio::test]
+async fn delegating_policy_preserves_child_batch_evaluation() {
+    let child_batch_calls = Arc::new(AtomicUsize::new(0));
+    let child_single_calls = Arc::new(AtomicUsize::new(0));
+    let child_seen = Arc::new(Mutex::new(Vec::new()));
+
+    let mut child_checker = PermissionChecker::new();
+    child_checker.add_policy(BatchGrantPolicy {
+        name: "child-even",
+        batch_calls: Arc::clone(&child_batch_calls),
+        single_calls: Arc::clone(&child_single_calls),
+        seen_batches: Arc::clone(&child_seen),
+        grant: Arc::new(|resource_id| resource_id % 2 == 0),
+    });
+
+    let delegating_policy = DelegatingPolicy::new(
+        "DelegatedRead",
+        child_checker,
+        |_subject: &Subject| Subject,
+        |_action: &Action| Action,
+        |_subject: &Subject, resource: &Resource, _action: &Action, _context: &Ctx| Resource {
+            id: resource.id + 1,
+        },
+        |_subject: &Subject, _resource: &Resource, _action: &Action, _context: &Ctx| Ctx,
+    );
+
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(delegating_policy);
+
+    let session = EvaluationSession::empty();
+    let results = checker
+        .evaluate_batch_with_context_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            vec![Resource { id: 0 }, Resource { id: 1 }, Resource { id: 2 }],
+            &Ctx,
+            |resource| resource,
+        )
+        .await;
+
+    let decisions = results
+        .iter()
+        .map(|(resource, evaluation)| (resource.id, evaluation.is_granted()))
+        .collect::<Vec<_>>();
+    assert_eq!(decisions, vec![(0, false), (1, true), (2, false)]);
+    assert_eq!(child_batch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(child_single_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        *child_seen.lock().unwrap(),
+        vec![vec![1, 2, 3]],
+        "delegation should preserve one child batch call with mapped resources"
+    );
+
+    let delegated_node = match &results[1].1 {
+        AccessEvaluation::Granted { trace, .. } => trace.root().unwrap(),
+        AccessEvaluation::Denied { .. } => panic!("expected delegated decision to grant"),
+    };
+    assert!(delegated_node.format(0).contains("DelegatedRead"));
+    assert!(delegated_node.format(0).contains("child-even"));
 }
 
 #[tokio::test]

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -4,7 +4,9 @@ use gatehouse::{
     PermissionChecker, Policy, PolicyBatchItem, PolicyBuilder, PolicyEvalResult, RebacPolicy,
     RelationshipQuery,
 };
+use proptest::prelude::*;
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -72,6 +74,53 @@ impl BatchGrantPolicy {
         } else {
             PolicyEvalResult::Denied {
                 policy_type: self.name.to_string(),
+                reason: format!("{resource_id} denied"),
+            }
+        }
+    }
+}
+
+struct RandomStackPolicy {
+    name: String,
+    grant_percent: u8,
+    salt: u16,
+}
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for RandomStackPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        self.result_for(ctx.resource.id)
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Ctx>,
+    ) -> Vec<PolicyEvalResult> {
+        ctx.items
+            .iter()
+            .map(|item| self.result_for(item.resource.id))
+            .collect()
+    }
+
+    fn policy_type(&self) -> &str {
+        &self.name
+    }
+}
+
+impl RandomStackPolicy {
+    fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
+        let score = ((resource_id as u16 * 37) ^ self.salt).wrapping_add(self.salt / 3) % 100;
+        if score < self.grant_percent as u16 {
+            PolicyEvalResult::Granted {
+                policy_type: self.name.clone(),
+                reason: Some(format!("{resource_id} granted")),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: self.name.clone(),
                 reason: format!("{resource_id} denied"),
             }
         }
@@ -316,6 +365,67 @@ async fn batch_decisions_match_naive_loop_for_empty_and_mixed_items() {
         .await;
     assert_granted(&batch[0].1, true);
     assert_granted(&batch[1].1, false);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 1_000,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn batch_decisions_match_naive_loop_for_random_policy_stacks(
+        policy_specs in prop::collection::vec((0u8..=100, any::<u16>()), 1..=5),
+        resource_ids in prop::collection::vec(0u8..64, 0..50),
+        max_batch_size in prop::option::of(1usize..8),
+    ) {
+        let mut checker = if let Some(max_batch_size) = max_batch_size {
+            PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(max_batch_size).unwrap())
+        } else {
+            PermissionChecker::new()
+        };
+        for (index, (grant_percent, salt)) in policy_specs.into_iter().enumerate() {
+            checker.add_policy(RandomStackPolicy {
+                name: format!("random_{index}"),
+                grant_percent,
+                salt,
+            });
+        }
+
+        let subject = Subject;
+        let action = Action;
+        let items = resource_ids
+            .iter()
+            .copied()
+            .map(|id| (Resource { id }, Ctx))
+            .collect::<Vec<_>>();
+        let batch_session = EvaluationSession::empty();
+        let batch = tokio_test::block_on(checker.evaluate_batch_in_session_by(
+            &batch_session,
+            &subject,
+            &action,
+            items.clone(),
+            |item| (&item.0, &item.1),
+        ))
+        .into_iter()
+        .map(|(_item, evaluation)| evaluation.is_granted())
+        .collect::<Vec<_>>();
+
+        let mut naive = Vec::new();
+        for (resource, context) in &items {
+            let session = EvaluationSession::empty();
+            naive.push(tokio_test::block_on(checker.evaluate_in_session(
+                &session,
+                &subject,
+                &action,
+                resource,
+                context,
+            ))
+            .is_granted());
+        }
+
+        prop_assert_eq!(batch, naive);
+    }
 }
 
 #[derive(Clone)]

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -1,0 +1,426 @@
+use async_trait::async_trait;
+use gatehouse::{
+    AccessEvaluation, BatchEvalCtx, EvalCtx, EvaluationSession, FactLoadResult, FactSource,
+    PermissionChecker, Policy, PolicyBatchItem, PolicyBuilder, PolicyEvalResult, RebacPolicy,
+    RelationshipQuery,
+};
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+struct Subject;
+
+#[derive(Debug, Clone)]
+struct Action;
+
+#[derive(Debug, Clone)]
+struct Ctx;
+
+#[derive(Debug, Clone)]
+struct Resource {
+    id: u8,
+}
+
+struct BatchGrantPolicy {
+    name: &'static str,
+    batch_calls: Arc<AtomicUsize>,
+    single_calls: Arc<AtomicUsize>,
+    seen_batches: Arc<Mutex<Vec<Vec<u8>>>>,
+    grant: Arc<dyn Fn(u8) -> bool + Send + Sync>,
+}
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for BatchGrantPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        self.single_calls.fetch_add(1, Ordering::SeqCst);
+        self.result_for(ctx.resource.id)
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Ctx>,
+    ) -> Vec<PolicyEvalResult> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        self.seen_batches.lock().unwrap().push(
+            ctx.items
+                .iter()
+                .map(|item| item.resource.id)
+                .collect::<Vec<_>>(),
+        );
+        ctx.items
+            .iter()
+            .map(|item| self.result_for(item.resource.id))
+            .collect()
+    }
+
+    fn policy_type(&self) -> &str {
+        self.name
+    }
+}
+
+impl BatchGrantPolicy {
+    fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
+        if (self.grant)(resource_id) {
+            PolicyEvalResult::Granted {
+                policy_type: self.name.to_string(),
+                reason: Some(format!("{resource_id} granted")),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: self.name.to_string(),
+                reason: format!("{resource_id} denied"),
+            }
+        }
+    }
+}
+
+struct NeverConsultedPolicy {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for NeverConsultedPolicy {
+    async fn evaluate(
+        &self,
+        _ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        PolicyEvalResult::Denied {
+            policy_type: self.policy_type().to_string(),
+            reason: "single called".to_string(),
+        }
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        _ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Ctx>,
+    ) -> Vec<PolicyEvalResult> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Vec::new()
+    }
+
+    fn policy_type(&self) -> &str {
+        "NeverConsultedPolicy"
+    }
+}
+
+#[tokio::test]
+async fn empty_batch_returns_empty_and_does_not_consult_policies() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(NeverConsultedPolicy {
+        calls: Arc::clone(&calls),
+    });
+
+    let session = EvaluationSession::empty();
+    let results = checker
+        .evaluate_batch_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            Vec::<(Resource, Ctx)>::new(),
+            |item| (&item.0, &item.1),
+        )
+        .await;
+
+    assert!(results.is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn single_item_batch_matches_single_evaluation() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(BatchGrantPolicy {
+        name: "even",
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|resource_id| resource_id % 2 == 0),
+    });
+    let session = EvaluationSession::empty();
+    let item = (Resource { id: 4 }, Ctx);
+
+    let single = checker
+        .evaluate_in_session(&session, &Subject, &Action, &item.0, &item.1)
+        .await
+        .is_granted();
+    let batch = checker
+        .evaluate_batch_in_session_by(&session, &Subject, &Action, vec![item], |item| {
+            (&item.0, &item.1)
+        })
+        .await
+        .into_iter()
+        .map(|(_item, evaluation)| evaluation.is_granted())
+        .collect::<Vec<_>>();
+
+    assert_eq!(batch, vec![single]);
+}
+
+#[tokio::test]
+async fn or_batch_does_not_re_evaluate_items_granted_by_earlier_policy() {
+    let first_seen = Arc::new(Mutex::new(Vec::new()));
+    let second_seen = Arc::new(Mutex::new(Vec::new()));
+    let first_batch_calls = Arc::new(AtomicUsize::new(0));
+    let second_batch_calls = Arc::new(AtomicUsize::new(0));
+
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(BatchGrantPolicy {
+        name: "even",
+        batch_calls: Arc::clone(&first_batch_calls),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::clone(&first_seen),
+        grant: Arc::new(|resource_id| resource_id % 2 == 0),
+    });
+    checker.add_policy(BatchGrantPolicy {
+        name: "all",
+        batch_calls: Arc::clone(&second_batch_calls),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::clone(&second_seen),
+        grant: Arc::new(|_| true),
+    });
+
+    let items = (0..6).map(|id| (Resource { id }, Ctx)).collect::<Vec<_>>();
+    let session = EvaluationSession::empty();
+    let results = checker
+        .evaluate_batch_in_session_by(&session, &Subject, &Action, items, |item| {
+            (&item.0, &item.1)
+        })
+        .await;
+
+    assert!(results
+        .iter()
+        .all(|(_item, evaluation)| evaluation.is_granted()));
+    assert_eq!(first_batch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(second_batch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(*first_seen.lock().unwrap(), vec![vec![0, 1, 2, 3, 4, 5]]);
+    assert_eq!(*second_seen.lock().unwrap(), vec![vec![1, 3, 5]]);
+}
+
+#[tokio::test]
+async fn boxed_dyn_policy_dispatches_evaluate_batch_override() {
+    let batch_calls = Arc::new(AtomicUsize::new(0));
+    let single_calls = Arc::new(AtomicUsize::new(0));
+    let boxed: Box<dyn Policy<Subject, Resource, Action, Ctx>> = Box::new(BatchGrantPolicy {
+        name: "boxed",
+        batch_calls: Arc::clone(&batch_calls),
+        single_calls: Arc::clone(&single_calls),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|resource_id| resource_id == 1),
+    });
+    let session = EvaluationSession::empty();
+    let owned_items = [(Resource { id: 1 }, Ctx), (Resource { id: 2 }, Ctx)];
+    let batch_items = owned_items
+        .iter()
+        .map(|(resource, context)| PolicyBatchItem { resource, context })
+        .collect::<Vec<_>>();
+
+    let results = boxed
+        .evaluate_batch(&BatchEvalCtx {
+            session: &session,
+            subject: &Subject,
+            action: &Action,
+            items: &batch_items,
+        })
+        .await;
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].is_granted());
+    assert!(!results[1].is_granted());
+    assert_eq!(batch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        single_calls.load(Ordering::SeqCst),
+        0,
+        "boxed dyn Policy must forward evaluate_batch instead of using the default point loop"
+    );
+}
+
+#[tokio::test]
+async fn batch_decisions_match_naive_loop_for_simple_policy_stack() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(BatchGrantPolicy {
+        name: "divisible_by_three",
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|resource_id| resource_id % 3 == 0),
+    });
+    checker.add_policy(BatchGrantPolicy {
+        name: "greater_than_four",
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|resource_id| resource_id > 4),
+    });
+
+    let items = (0..10).map(|id| (Resource { id }, Ctx)).collect::<Vec<_>>();
+    let session = EvaluationSession::empty();
+    let batch = checker
+        .evaluate_batch_in_session_by(&session, &Subject, &Action, items.clone(), |item| {
+            (&item.0, &item.1)
+        })
+        .await
+        .into_iter()
+        .map(|(_item, evaluation)| evaluation.is_granted())
+        .collect::<Vec<_>>();
+
+    let mut naive = Vec::new();
+    for (resource, context) in &items {
+        let session = EvaluationSession::empty();
+        naive.push(
+            checker
+                .evaluate_in_session(&session, &Subject, &Action, resource, context)
+                .await
+                .is_granted(),
+        );
+    }
+
+    assert_eq!(batch, naive);
+}
+
+fn assert_granted(evaluation: &AccessEvaluation, expected: bool) {
+    assert_eq!(evaluation.is_granted(), expected);
+}
+
+#[tokio::test]
+async fn batch_decisions_match_naive_loop_for_empty_and_mixed_items() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(BatchGrantPolicy {
+        name: "odd",
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|resource_id| resource_id % 2 == 1),
+    });
+
+    let session = EvaluationSession::empty();
+    let empty = checker
+        .evaluate_batch_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            Vec::<(Resource, Ctx)>::new(),
+            |item| (&item.0, &item.1),
+        )
+        .await;
+    assert!(empty.is_empty());
+
+    let items = vec![(Resource { id: 1 }, Ctx), (Resource { id: 2 }, Ctx)];
+    let batch = checker
+        .evaluate_batch_in_session_by(&session, &Subject, &Action, items, |item| {
+            (&item.0, &item.1)
+        })
+        .await;
+    assert_granted(&batch[0].1, true);
+    assert_granted(&batch[1].1, false);
+}
+
+#[derive(Clone)]
+struct MixedSubject {
+    id: u8,
+}
+
+#[derive(Clone)]
+struct MixedResource {
+    id: u8,
+    public: bool,
+}
+
+struct MixedAction;
+struct MixedCtx;
+
+type MixedRelationshipQuery = RelationshipQuery<u8, u8, &'static str>;
+type MixedRelationshipCalls = Arc<Mutex<Vec<Vec<MixedRelationshipQuery>>>>;
+
+struct MixedRelationshipSource {
+    grants: HashSet<MixedRelationshipQuery>,
+    calls: MixedRelationshipCalls,
+}
+
+#[async_trait]
+impl FactSource<MixedRelationshipQuery> for MixedRelationshipSource {
+    async fn load_many(&self, keys: &[MixedRelationshipQuery]) -> Vec<FactLoadResult<bool>> {
+        self.calls.lock().unwrap().push(keys.to_vec());
+        keys.iter()
+            .map(|key| FactLoadResult::Found(self.grants.contains(key)))
+            .collect()
+    }
+}
+
+#[tokio::test]
+async fn mixed_policy_stack_uses_in_memory_policy_and_rebac_session() {
+    let subject = MixedSubject { id: 7 };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let session = EvaluationSession::new();
+    session.register::<RelationshipQuery<u8, u8, &'static str>, _>(MixedRelationshipSource {
+        grants: HashSet::from([RelationshipQuery {
+            subject_id: subject.id,
+            resource_id: 2,
+            relation: "viewer",
+        }]),
+        calls: Arc::clone(&calls),
+    });
+
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(
+        PolicyBuilder::<MixedSubject, MixedResource, MixedAction, MixedCtx>::new("PublicResource")
+            .resources(|resource| resource.public)
+            .build(),
+    );
+    checker.add_policy(RebacPolicy::new(
+        |subject: &MixedSubject| subject.id,
+        |resource: &MixedResource| resource.id,
+        "viewer",
+    ));
+
+    let items = vec![
+        (
+            MixedResource {
+                id: 1,
+                public: true,
+            },
+            MixedCtx,
+        ),
+        (
+            MixedResource {
+                id: 2,
+                public: false,
+            },
+            MixedCtx,
+        ),
+        (
+            MixedResource {
+                id: 3,
+                public: false,
+            },
+            MixedCtx,
+        ),
+    ];
+    let results = checker
+        .evaluate_batch_in_session_by(&session, &subject, &MixedAction, items, |item| {
+            (&item.0, &item.1)
+        })
+        .await;
+
+    assert_granted(&results[0].1, true);
+    assert_granted(&results[1].1, true);
+    assert_granted(&results[2].1, false);
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![vec![
+            RelationshipQuery {
+                subject_id: subject.id,
+                resource_id: 2,
+                relation: "viewer",
+            },
+            RelationshipQuery {
+                subject_id: subject.id,
+                resource_id: 3,
+                relation: "viewer",
+            },
+        ]]
+    );
+}

--- a/tests/session_contract.rs
+++ b/tests/session_contract.rs
@@ -288,6 +288,56 @@ async fn session_deduplicates_across_calls() {
 }
 
 #[tokio::test]
+async fn shared_source_serves_concurrent_sessions_with_separate_caches() {
+    let calls = new_calls();
+    let source: Arc<dyn FactSource<TestKey>> = Arc::new(RecordingSource::echo(Arc::clone(&calls)));
+    let keys = vec![TestKey(1), TestKey(2), TestKey(1)];
+
+    let sessions = (0..3)
+        .map(|_| {
+            EvaluationSession::builder()
+                .with_arc::<TestKey>(Arc::clone(&source))
+                .build()
+        })
+        .collect::<Vec<_>>();
+
+    let handles = sessions
+        .clone()
+        .into_iter()
+        .map(|session| {
+            let keys = keys.clone();
+            tokio::spawn(async move { session.get_many(&keys).await })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        let results = handle.await.unwrap();
+        assert_eq!(results.len(), 3);
+        assert_found(&results[0], 1);
+        assert_found(&results[1], 2);
+        assert_found(&results[2], 1);
+    }
+
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        3,
+        "in-flight coalescing is per session, not global across shared sources"
+    );
+
+    for session in &sessions {
+        let cached = session.get_many(&keys).await;
+        assert_found(&cached[0], 1);
+        assert_found(&cached[1], 2);
+        assert_found(&cached[2], 1);
+    }
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        3,
+        "each session should reuse only its own request-scoped cache"
+    );
+}
+
+#[tokio::test]
 async fn fact_load_result_variants_round_trip_and_cache() {
     let calls = new_calls();
     let mut responses = HashMap::new();
@@ -387,13 +437,16 @@ fn source_panics_propagate_but_clean_in_flight_state() {
 }
 
 #[tokio::test]
-async fn missing_sources_fail_closed_and_re_registering_is_last_wins() {
+async fn missing_sources_fail_closed_and_source_registration_is_explicit() {
     let empty = EvaluationSession::new();
     let missing = empty.get(TestKey(1)).await;
     assert_source_not_registered(&missing, TestKey::NAME);
 
     let session = EvaluationSession::new();
+    let cached_missing = session.get(TestKey(1)).await;
+    assert_source_not_registered(&cached_missing, TestKey::NAME);
     session.register::<TestKey, _>(RecordingSource::echo(new_calls()));
+    assert_found(&session.get(TestKey(1)).await, 1);
     let missing_other = session.get(OtherKey(1)).await;
     assert_source_not_registered(&missing_other, OtherKey::NAME);
 
@@ -406,7 +459,21 @@ async fn missing_sources_fail_closed_and_re_registering_is_last_wins() {
     ));
     assert_found(&session.get(TestKey(1)).await, 1);
 
-    session.register::<TestKey, _>(RecordingSource::new(
+    let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        session.register::<TestKey, _>(RecordingSource::new(
+            Arc::clone(&second_calls),
+            None,
+            |_keys| vec![FactLoadResult::Found(2)],
+        ));
+    }));
+    assert!(
+        duplicate.is_err(),
+        "duplicate registration should fail fast"
+    );
+    assert_found(&session.get(TestKey(1)).await, 1);
+    assert_eq!(second_calls.lock().unwrap().len(), 0);
+
+    session.replace::<TestKey, _>(RecordingSource::new(
         Arc::clone(&second_calls),
         None,
         |_keys| vec![FactLoadResult::Found(2)],
@@ -415,8 +482,9 @@ async fn missing_sources_fail_closed_and_re_registering_is_last_wins() {
     assert_eq!(first_calls.lock().unwrap().len(), 1);
     assert_eq!(second_calls.lock().unwrap().len(), 1);
 
-    let other_session = EvaluationSession::new();
-    other_session.register::<OtherKey, _>(OtherSource);
+    let other_session = EvaluationSession::builder()
+        .with::<OtherKey, _>(OtherSource)
+        .build();
     assert_found(&other_session.get(OtherKey(5)).await, 5);
 }
 

--- a/tests/session_contract.rs
+++ b/tests/session_contract.rs
@@ -1,0 +1,615 @@
+use async_trait::async_trait;
+use gatehouse::{EvaluationSession, FactKey, FactLoadError, FactLoadResult, FactSource};
+use proptest::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct TestKey(u16);
+
+impl FactKey for TestKey {
+    type Value = u16;
+
+    const NAME: &'static str = "test";
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OtherKey(u16);
+
+impl FactKey for OtherKey {
+    type Value = u16;
+
+    const NAME: &'static str = "other";
+}
+
+type TestCalls = Arc<Mutex<Vec<Vec<TestKey>>>>;
+type TestResponse = Arc<dyn Fn(&[TestKey]) -> Vec<FactLoadResult<u16>> + Send + Sync>;
+
+#[derive(Clone)]
+struct RecordingSource {
+    calls: TestCalls,
+    max_batch_size: Option<NonZeroUsize>,
+    response: TestResponse,
+}
+
+impl RecordingSource {
+    fn echo(calls: TestCalls) -> Self {
+        Self::new(calls, None, |keys| {
+            keys.iter()
+                .map(|key| FactLoadResult::Found(key.0))
+                .collect()
+        })
+    }
+
+    fn new(
+        calls: TestCalls,
+        max_batch_size: Option<NonZeroUsize>,
+        response: impl Fn(&[TestKey]) -> Vec<FactLoadResult<u16>> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            calls,
+            max_batch_size,
+            response: Arc::new(response),
+        }
+    }
+}
+
+#[async_trait]
+impl FactSource<TestKey> for RecordingSource {
+    async fn load_many(&self, keys: &[TestKey]) -> Vec<FactLoadResult<u16>> {
+        self.calls.lock().unwrap().push(keys.to_vec());
+        (self.response)(keys)
+    }
+
+    fn max_batch_size(&self) -> Option<NonZeroUsize> {
+        self.max_batch_size
+    }
+}
+
+struct OtherSource;
+
+#[async_trait]
+impl FactSource<OtherKey> for OtherSource {
+    async fn load_many(&self, keys: &[OtherKey]) -> Vec<FactLoadResult<u16>> {
+        keys.iter()
+            .map(|key| FactLoadResult::Found(key.0))
+            .collect()
+    }
+}
+
+struct NeverCompletesSource {
+    calls: Arc<AtomicUsize>,
+    started: Arc<Notify>,
+}
+
+#[async_trait]
+impl FactSource<TestKey> for NeverCompletesSource {
+    async fn load_many(&self, keys: &[TestKey]) -> Vec<FactLoadResult<u16>> {
+        assert_eq!(keys, &[TestKey(7)]);
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.started.notify_one();
+        std::future::pending().await
+    }
+}
+
+struct BlockingErrorSource {
+    calls: Arc<AtomicUsize>,
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl FactSource<TestKey> for BlockingErrorSource {
+    async fn load_many(&self, keys: &[TestKey]) -> Vec<FactLoadResult<u16>> {
+        assert_eq!(keys, &[TestKey(8)]);
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.started.notify_one();
+        self.release.notified().await;
+        vec![FactLoadResult::Error(FactLoadError::backend_message(
+            "down",
+        ))]
+    }
+}
+
+struct PanicSource {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl FactSource<TestKey> for PanicSource {
+    async fn load_many(&self, _keys: &[TestKey]) -> Vec<FactLoadResult<u16>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        panic!("source panic");
+    }
+}
+
+fn new_calls() -> TestCalls {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+fn session_with_source(source: impl FactSource<TestKey> + 'static) -> EvaluationSession {
+    let session = EvaluationSession::new();
+    session.register::<TestKey, _>(source);
+    session
+}
+
+fn assert_found(result: &FactLoadResult<u16>, expected: u16) {
+    match result {
+        FactLoadResult::Found(actual) => assert_eq!(*actual, expected),
+        other => panic!("expected Found({expected}), got {other:?}"),
+    }
+}
+
+fn assert_missing(result: &FactLoadResult<u16>) {
+    assert!(
+        matches!(result, FactLoadResult::Missing),
+        "expected Missing, got {result:?}"
+    );
+}
+
+fn assert_backend_error_contains(result: &FactLoadResult<u16>, expected: &str) {
+    match result {
+        FactLoadResult::Error(FactLoadError::Backend(error)) => {
+            assert!(
+                error.to_string().contains(expected),
+                "expected backend error to contain {expected:?}, got {error}"
+            );
+        }
+        other => panic!("expected backend Error, got {other:?}"),
+    }
+}
+
+fn assert_source_not_registered(result: &FactLoadResult<u16>, fact_name: &'static str) {
+    match result {
+        FactLoadResult::Error(FactLoadError::SourceNotRegistered { fact_name: actual }) => {
+            assert_eq!(*actual, fact_name);
+        }
+        other => panic!("expected SourceNotRegistered, got {other:?}"),
+    }
+}
+
+fn assert_contract_violation(result: &FactLoadResult<u16>, expected: usize, actual: usize) {
+    match result {
+        FactLoadResult::Error(FactLoadError::SourceContractViolation {
+            fact_name,
+            expected: got_expected,
+            actual: got_actual,
+        }) => {
+            assert_eq!(*fact_name, TestKey::NAME);
+            assert_eq!(*got_expected, expected);
+            assert_eq!(*got_actual, actual);
+        }
+        other => panic!("expected SourceContractViolation, got {other:?}"),
+    }
+}
+
+fn assert_load_cancelled(result: &FactLoadResult<u16>) {
+    match result {
+        FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name }) => {
+            assert_eq!(*fact_name, TestKey::NAME);
+        }
+        other => panic!("expected LoaderCancelled, got {other:?}"),
+    }
+}
+
+fn first_unique(keys: &[TestKey]) -> Vec<TestKey> {
+    let mut seen = HashSet::new();
+    keys.iter()
+        .copied()
+        .filter(|key| seen.insert(*key))
+        .collect()
+}
+
+#[tokio::test]
+async fn get_many_preserves_order_duplicates_and_empty_batches() {
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+
+    let empty = session.get_many::<TestKey>(&[]).await;
+    assert!(empty.is_empty());
+    assert!(calls.lock().unwrap().is_empty());
+
+    let single = session.get_many(&[TestKey(1)]).await;
+    assert_found(&single[0], 1);
+    assert_eq!(*calls.lock().unwrap(), vec![vec![TestKey(1)]]);
+
+    let ordered = session
+        .get_many(&[TestKey(1), TestKey(2), TestKey(3)])
+        .await;
+    assert_eq!(ordered.len(), 3);
+    assert_found(&ordered[0], 1);
+    assert_found(&ordered[1], 2);
+    assert_found(&ordered[2], 3);
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![vec![TestKey(1)], vec![TestKey(2), TestKey(3)]]
+    );
+
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+    let duplicated = session
+        .get_many(&[TestKey(1), TestKey(2), TestKey(1), TestKey(1)])
+        .await;
+    assert_eq!(duplicated.len(), 4);
+    for index in [0, 2, 3] {
+        assert_found(&duplicated[index], 1);
+    }
+    assert_found(&duplicated[1], 2);
+    assert_eq!(*calls.lock().unwrap(), vec![vec![TestKey(1), TestKey(2)]]);
+
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+    let thousand = vec![TestKey(9); 1_000];
+    let results = session.get_many(&thousand).await;
+    assert_eq!(results.len(), 1_000);
+    assert!(results
+        .iter()
+        .all(|result| { matches!(result, FactLoadResult::Found(value) if *value == 9) }));
+    assert_eq!(*calls.lock().unwrap(), vec![vec![TestKey(9)]]);
+}
+
+#[tokio::test]
+async fn session_deduplicates_across_calls() {
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+
+    let first = session.get_many(&[TestKey(1), TestKey(2)]).await;
+    assert_found(&first[0], 1);
+    assert_found(&first[1], 2);
+
+    let second = session.get_many(&[TestKey(2), TestKey(3)]).await;
+    assert_found(&second[0], 2);
+    assert_found(&second[1], 3);
+
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![vec![TestKey(1), TestKey(2)], vec![TestKey(3)]]
+    );
+
+    let _ = session.get(TestKey(1)).await;
+    let _ = session.get(TestKey(1)).await;
+    assert_eq!(calls.lock().unwrap().len(), 2);
+
+    let third = session.get_many(&[TestKey(1), TestKey(4)]).await;
+    assert_found(&third[0], 1);
+    assert_found(&third[1], 4);
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![
+            vec![TestKey(1), TestKey(2)],
+            vec![TestKey(3)],
+            vec![TestKey(4)]
+        ]
+    );
+}
+
+#[tokio::test]
+async fn fact_load_result_variants_round_trip_and_cache() {
+    let calls = new_calls();
+    let mut responses = HashMap::new();
+    responses.insert(TestKey(1), FactLoadResult::Found(11));
+    responses.insert(TestKey(2), FactLoadResult::Missing);
+    responses.insert(
+        TestKey(3),
+        FactLoadResult::Error(FactLoadError::backend_message("boom")),
+    );
+    responses.insert(TestKey(4), FactLoadResult::Found(44));
+
+    let session = session_with_source(RecordingSource::new(
+        Arc::clone(&calls),
+        None,
+        move |keys| {
+            keys.iter()
+                .map(|key| responses.get(key).cloned().unwrap())
+                .collect()
+        },
+    ));
+
+    let results = session
+        .get_many(&[TestKey(1), TestKey(2), TestKey(3), TestKey(4)])
+        .await;
+    assert_found(&results[0], 11);
+    assert_missing(&results[1]);
+    assert_backend_error_contains(&results[2], "boom");
+    assert_found(&results[3], 44);
+    assert_eq!(calls.lock().unwrap().len(), 1);
+
+    let cached = session.get_many(&[TestKey(2), TestKey(3)]).await;
+    assert_missing(&cached[0]);
+    assert_backend_error_contains(&cached[1], "boom");
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        1,
+        "Missing and Error should both be cached for the session"
+    );
+}
+
+#[tokio::test]
+async fn length_mismatch_fails_closed_and_is_cached() {
+    for (actual_count, response) in [
+        (2, vec![FactLoadResult::Found(1), FactLoadResult::Found(2)]),
+        (
+            4,
+            vec![
+                FactLoadResult::Found(1),
+                FactLoadResult::Found(2),
+                FactLoadResult::Found(3),
+                FactLoadResult::Found(4),
+            ],
+        ),
+    ] {
+        let calls = new_calls();
+        let response = response.clone();
+        let session = session_with_source(RecordingSource::new(
+            Arc::clone(&calls),
+            None,
+            move |_keys| response.clone(),
+        ));
+
+        let results = session
+            .get_many(&[TestKey(1), TestKey(2), TestKey(3)])
+            .await;
+        assert_eq!(results.len(), 3);
+        for result in &results {
+            assert_contract_violation(result, 3, actual_count);
+        }
+
+        let cached = session.get(TestKey(1)).await;
+        assert_contract_violation(&cached, 3, actual_count);
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "contract errors should be cached for every affected key"
+        );
+    }
+}
+
+#[test]
+fn source_panics_propagate_but_clean_in_flight_state() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let session = session_with_source(PanicSource {
+        calls: Arc::clone(&calls),
+    });
+    let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tokio_test::block_on(session.get(TestKey(1)));
+    }));
+
+    assert!(panic_result.is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let cached = tokio_test::block_on(session.get(TestKey(1)));
+    assert_load_cancelled(&cached);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn missing_sources_fail_closed_and_re_registering_is_last_wins() {
+    let empty = EvaluationSession::new();
+    let missing = empty.get(TestKey(1)).await;
+    assert_source_not_registered(&missing, TestKey::NAME);
+
+    let session = EvaluationSession::new();
+    session.register::<TestKey, _>(RecordingSource::echo(new_calls()));
+    let missing_other = session.get(OtherKey(1)).await;
+    assert_source_not_registered(&missing_other, OtherKey::NAME);
+
+    let first_calls = new_calls();
+    let second_calls = new_calls();
+    let session = session_with_source(RecordingSource::new(
+        Arc::clone(&first_calls),
+        None,
+        |_keys| vec![FactLoadResult::Found(1)],
+    ));
+    assert_found(&session.get(TestKey(1)).await, 1);
+
+    session.register::<TestKey, _>(RecordingSource::new(
+        Arc::clone(&second_calls),
+        None,
+        |_keys| vec![FactLoadResult::Found(2)],
+    ));
+    assert_found(&session.get(TestKey(1)).await, 2);
+    assert_eq!(first_calls.lock().unwrap().len(), 1);
+    assert_eq!(second_calls.lock().unwrap().len(), 1);
+
+    let other_session = EvaluationSession::new();
+    other_session.register::<OtherKey, _>(OtherSource);
+    assert_found(&other_session.get(OtherKey(5)).await, 5);
+}
+
+#[tokio::test]
+async fn source_max_batch_size_chunks_after_dedup_without_reordering() {
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::new(
+        Arc::clone(&calls),
+        NonZeroUsize::new(3),
+        |keys| {
+            keys.iter()
+                .map(|key| FactLoadResult::Found(key.0))
+                .collect()
+        },
+    ));
+    let keys = (0..10).map(TestKey).collect::<Vec<_>>();
+    let results = session.get_many(&keys).await;
+    for (result, key) in results.iter().zip(&keys) {
+        assert_found(result, key.0);
+    }
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![
+            vec![TestKey(0), TestKey(1), TestKey(2)],
+            vec![TestKey(3), TestKey(4), TestKey(5)],
+            vec![TestKey(6), TestKey(7), TestKey(8)],
+            vec![TestKey(9)]
+        ]
+    );
+
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::new(
+        Arc::clone(&calls),
+        NonZeroUsize::new(1),
+        |keys| {
+            keys.iter()
+                .map(|key| FactLoadResult::Found(key.0))
+                .collect()
+        },
+    ));
+    let keys = (0..5).map(TestKey).collect::<Vec<_>>();
+    let _ = session.get_many(&keys).await;
+    assert_eq!(calls.lock().unwrap().len(), 5);
+
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+    let keys = (0..1_000).map(TestKey).collect::<Vec<_>>();
+    let _ = session.get_many(&keys).await;
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn chunking_with_duplicates_expands_to_original_positions() {
+    let calls = new_calls();
+    let session = session_with_source(RecordingSource::new(
+        Arc::clone(&calls),
+        NonZeroUsize::new(2),
+        |keys| {
+            keys.iter()
+                .map(|key| FactLoadResult::Found(key.0))
+                .collect()
+        },
+    ));
+
+    let results = session
+        .get_many(&[TestKey(1), TestKey(2), TestKey(1), TestKey(3), TestKey(1)])
+        .await;
+    assert_eq!(
+        results
+            .iter()
+            .map(|result| match result {
+                FactLoadResult::Found(value) => *value,
+                other => panic!("expected Found, got {other:?}"),
+            })
+            .collect::<Vec<_>>(),
+        vec![1, 2, 1, 3, 1]
+    );
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![vec![TestKey(1), TestKey(2)], vec![TestKey(3)]]
+    );
+}
+
+#[tokio::test]
+async fn cancelling_leader_get_cleans_in_flight_entry() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(Notify::new());
+    let session = session_with_source(NeverCompletesSource {
+        calls: Arc::clone(&calls),
+        started: Arc::clone(&started),
+    });
+
+    let leader_session = session.clone();
+    let leader = tokio::spawn(async move { leader_session.get(TestKey(7)).await });
+    started.notified().await;
+    leader.abort();
+    assert!(leader.await.unwrap_err().is_cancelled());
+
+    let result = tokio::time::timeout(Duration::from_millis(100), session.get(TestKey(7)))
+        .await
+        .expect("follow-up get should not wait forever");
+    assert_load_cancelled(&result);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn concurrent_waiters_observe_same_source_error() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let session = session_with_source(BlockingErrorSource {
+        calls: Arc::clone(&calls),
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    });
+
+    let leader_session = session.clone();
+    let leader = tokio::spawn(async move { leader_session.get(TestKey(8)).await });
+    started.notified().await;
+
+    let waiter_session = session.clone();
+    let waiter = tokio::spawn(async move { waiter_session.get(TestKey(8)).await });
+    tokio::task::yield_now().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    release.notify_one();
+    let leader_result = leader.await.unwrap();
+    let waiter_result = waiter.await.unwrap();
+    assert_backend_error_contains(&leader_result, "down");
+    assert_backend_error_contains(&waiter_result, "down");
+
+    let cached = session.get(TestKey(8)).await;
+    assert_backend_error_contains(&cached, "down");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+proptest! {
+    #[test]
+    fn get_many_preserves_input_order_for_arbitrary_duplicate_keys(raw_keys in prop::collection::vec(0u16..32, 0..200)) {
+        let keys = raw_keys.iter().copied().map(TestKey).collect::<Vec<_>>();
+        let calls = new_calls();
+        let session = session_with_source(RecordingSource::echo(Arc::clone(&calls)));
+
+        let results = tokio_test::block_on(session.get_many(&keys));
+        prop_assert_eq!(results.len(), keys.len());
+        for (result, key) in results.iter().zip(&keys) {
+            match result {
+                FactLoadResult::Found(value) => prop_assert_eq!(*value, key.0),
+                other => prop_assert!(false, "expected Found for {key:?}, got {other:?}"),
+            }
+        }
+
+        let expected_unique = first_unique(&keys);
+        let recorded = calls.lock().unwrap().clone();
+        if expected_unique.is_empty() {
+            prop_assert!(recorded.is_empty());
+        } else {
+            prop_assert_eq!(recorded, vec![expected_unique]);
+        }
+    }
+
+    #[test]
+    fn chunking_preserves_input_order_for_arbitrary_duplicate_keys(
+        raw_keys in prop::collection::vec(0u16..64, 0..300),
+        max in prop::option::of(1usize..8),
+    ) {
+        let keys = raw_keys.iter().copied().map(TestKey).collect::<Vec<_>>();
+        let calls = new_calls();
+        let max_batch_size = max.and_then(NonZeroUsize::new);
+        let session = session_with_source(RecordingSource::new(
+            Arc::clone(&calls),
+            max_batch_size,
+            |keys| keys.iter().map(|key| FactLoadResult::Found(key.0)).collect(),
+        ));
+
+        let results = tokio_test::block_on(session.get_many(&keys));
+        prop_assert_eq!(results.len(), keys.len());
+        for (result, key) in results.iter().zip(&keys) {
+            match result {
+                FactLoadResult::Found(value) => prop_assert_eq!(*value, key.0),
+                other => prop_assert!(false, "expected Found for {key:?}, got {other:?}"),
+            }
+        }
+
+        let expected_unique = first_unique(&keys);
+        let expected_unique_is_empty = expected_unique.is_empty();
+        let recorded = calls.lock().unwrap().clone();
+        let flattened = recorded.iter().flatten().copied().collect::<Vec<_>>();
+        prop_assert_eq!(flattened, expected_unique);
+        if let Some(max) = max_batch_size {
+            prop_assert!(recorded.iter().all(|chunk| chunk.len() <= max.get()));
+        } else if !expected_unique_is_empty {
+            prop_assert_eq!(recorded.len(), 1);
+        }
+    }
+}

--- a/tests/session_contract.rs
+++ b/tests/session_contract.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use gatehouse::{EvaluationSession, FactKey, FactLoadError, FactLoadResult, FactSource};
+use gatehouse::{
+    EvaluationSession, FactKey, FactLoadError, FactLoadResult, FactSource,
+    FactSourceRegistrationError,
+};
 use proptest::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
@@ -193,6 +196,16 @@ fn assert_load_cancelled(result: &FactLoadResult<u16>) {
             assert_eq!(*fact_name, TestKey::NAME);
         }
         other => panic!("expected LoaderCancelled, got {other:?}"),
+    }
+}
+
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = panic.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = panic.downcast_ref::<&'static str>() {
+        message.to_string()
+    } else {
+        "<non-string panic>".to_string()
     }
 }
 
@@ -470,6 +483,16 @@ async fn missing_sources_fail_closed_and_source_registration_is_explicit() {
         duplicate.is_err(),
         "duplicate registration should fail fast"
     );
+    assert!(matches!(
+        session.try_register::<TestKey, _>(RecordingSource::new(
+            Arc::clone(&second_calls),
+            None,
+            |_keys| vec![FactLoadResult::Found(2)],
+        )),
+        Err(FactSourceRegistrationError::AlreadyRegistered {
+            fact_name: TestKey::NAME
+        })
+    ));
     assert_found(&session.get(TestKey(1)).await, 1);
     assert_eq!(second_calls.lock().unwrap().len(), 0);
 
@@ -488,6 +511,50 @@ async fn missing_sources_fail_closed_and_source_registration_is_explicit() {
     assert_found(&other_session.get(OtherKey(5)).await, 5);
 }
 
+#[tokio::test]
+async fn source_registration_and_replacement_reject_in_flight_loads() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let session = session_with_source(BlockingErrorSource {
+        calls: Arc::clone(&calls),
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    });
+
+    let leader_session = session.clone();
+    let leader = tokio::spawn(async move { leader_session.get(TestKey(8)).await });
+    started.notified().await;
+
+    let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        session.register::<TestKey, _>(RecordingSource::echo(new_calls()));
+    }))
+    .expect_err("duplicate registration should panic before inspecting in-flight loads");
+    assert!(
+        panic_message(duplicate).contains("already registered"),
+        "duplicate registration should keep the actionable duplicate-source message"
+    );
+
+    let replacement = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        session.replace::<TestKey, _>(RecordingSource::echo(new_calls()));
+    }))
+    .expect_err("replacement during in-flight load should panic");
+    assert!(
+        panic_message(replacement).contains("registered or replaced while loads"),
+        "replacement panic should describe both public source-registration verbs"
+    );
+    assert!(matches!(
+        session.try_replace::<TestKey, _>(RecordingSource::echo(new_calls())),
+        Err(FactSourceRegistrationError::InFlight {
+            fact_name: TestKey::NAME
+        })
+    ));
+
+    release.notify_one();
+    let leader_result = leader.await.unwrap();
+    assert_backend_error_contains(&leader_result, "down");
+}
+
 #[test]
 fn shared_empty_session_is_static_and_rejects_source_registration() {
     let first = EvaluationSession::shared_empty() as *const EvaluationSession;
@@ -502,6 +569,13 @@ fn shared_empty_session_is_static_and_rejects_source_registration() {
         duplicate.is_err(),
         "shared empty sessions must not become mutable source registries"
     );
+    assert!(matches!(
+        EvaluationSession::shared_empty()
+            .try_register::<TestKey, _>(RecordingSource::echo(new_calls())),
+        Err(FactSourceRegistrationError::SharedEmptySession {
+            fact_name: TestKey::NAME
+        })
+    ));
 }
 
 #[tokio::test]

--- a/tests/session_contract.rs
+++ b/tests/session_contract.rs
@@ -488,6 +488,22 @@ async fn missing_sources_fail_closed_and_source_registration_is_explicit() {
     assert_found(&other_session.get(OtherKey(5)).await, 5);
 }
 
+#[test]
+fn shared_empty_session_is_static_and_rejects_source_registration() {
+    let first = EvaluationSession::shared_empty() as *const EvaluationSession;
+    let second = EvaluationSession::shared_empty() as *const EvaluationSession;
+    assert_eq!(first, second);
+
+    let duplicate = std::panic::catch_unwind(|| {
+        EvaluationSession::shared_empty()
+            .register::<TestKey, _>(RecordingSource::echo(new_calls()));
+    });
+    assert!(
+        duplicate.is_err(),
+        "shared empty sessions must not become mutable source registries"
+    );
+}
+
 #[tokio::test]
 async fn source_max_batch_size_chunks_after_dedup_without_reordering() {
     let calls = new_calls();

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -1,0 +1,392 @@
+use async_trait::async_trait;
+use gatehouse::{
+    BatchEvalCtx, EvalCtx, EvaluationSession, PermissionChecker, Policy, PolicyEvalResult,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing::{Id, Subscriber};
+use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
+use tracing_subscriber::registry::{LookupSpan, Registry};
+use tracing_subscriber::Layer;
+
+#[derive(Clone)]
+struct Subject;
+
+#[derive(Clone)]
+struct Action;
+
+#[derive(Clone)]
+struct Ctx;
+
+#[derive(Clone)]
+struct Resource {
+    allowed: bool,
+}
+
+struct TracePolicy;
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for TracePolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        result_for(ctx.resource.allowed)
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Ctx>,
+    ) -> Vec<PolicyEvalResult> {
+        ctx.items
+            .iter()
+            .map(|item| result_for(item.resource.allowed))
+            .collect()
+    }
+
+    fn policy_type(&self) -> &str {
+        "TracePolicy"
+    }
+}
+
+fn result_for(allowed: bool) -> PolicyEvalResult {
+    if allowed {
+        PolicyEvalResult::Granted {
+            policy_type: "TracePolicy".to_string(),
+            reason: Some("allowed".to_string()),
+        }
+    } else {
+        PolicyEvalResult::Denied {
+            policy_type: "TracePolicy".to_string(),
+            reason: "denied".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CapturedSpan {
+    name: String,
+    fields: BTreeSet<String>,
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+struct CapturedSpans(Arc<Mutex<Vec<Arc<Mutex<CapturedSpan>>>>>);
+
+impl CapturedSpans {
+    fn snapshot(&self) -> Vec<CapturedSpan> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|span| span.lock().unwrap().clone())
+            .collect()
+    }
+}
+
+struct CaptureLayer {
+    spans: CapturedSpans,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: LayerContext<'_, S>) {
+        let mut visitor = FieldValues::default();
+        attrs.record(&mut visitor);
+        let span = Arc::new(Mutex::new(CapturedSpan {
+            name: attrs.metadata().name().to_string(),
+            fields: attrs
+                .metadata()
+                .fields()
+                .iter()
+                .map(|field| field.name().to_string())
+                .collect(),
+            values: visitor.values,
+        }));
+
+        if let Some(ctx_span) = ctx.span(id) {
+            ctx_span.extensions_mut().insert(Arc::clone(&span));
+        }
+        self.spans.0.lock().unwrap().push(span);
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: LayerContext<'_, S>) {
+        let Some(ctx_span) = ctx.span(id) else {
+            return;
+        };
+        let Some(span) = ctx_span
+            .extensions()
+            .get::<Arc<Mutex<CapturedSpan>>>()
+            .cloned()
+        else {
+            return;
+        };
+
+        let mut visitor = FieldValues::default();
+        values.record(&mut visitor);
+        span.lock().unwrap().values.extend(visitor.values);
+    }
+}
+
+#[derive(Default)]
+struct FieldValues {
+    values: BTreeMap<String, String>,
+}
+
+impl FieldValues {
+    fn insert(&mut self, field: &Field, value: impl Into<String>) {
+        self.values.insert(field.name().to_string(), value.into());
+    }
+}
+
+impl Visit for FieldValues {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert(field, value);
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.insert(field, format!("{value:?}"));
+    }
+}
+
+fn capture_async<F, Fut, T>(f: F) -> (T, Vec<CapturedSpan>)
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let captured = CapturedSpans::default();
+    let subscriber = Registry::default().with(CaptureLayer {
+        spans: captured.clone(),
+    });
+    let output = tracing::subscriber::with_default(subscriber, || tokio_test::block_on(f()));
+    (output, captured.snapshot())
+}
+
+fn span<'a>(spans: &'a [CapturedSpan], name: &str) -> &'a CapturedSpan {
+    spans
+        .iter()
+        .find(|span| span.name == name)
+        .unwrap_or_else(|| panic!("missing span {name}; captured spans: {spans:#?}"))
+}
+
+fn assert_fields(span: &CapturedSpan, expected: &[&str]) {
+    for field in expected {
+        assert!(
+            span.fields.contains(*field),
+            "span {} missing field {field}; fields: {:?}",
+            span.name,
+            span.fields
+        );
+    }
+}
+
+fn assert_value(span: &CapturedSpan, field: &str, expected: &str) {
+    assert_eq!(
+        span.values.get(field).map(String::as_str),
+        Some(expected),
+        "span {} field {field}; values: {:?}",
+        span.name,
+        span.values
+    );
+}
+
+fn checker_with_policy() -> PermissionChecker<Subject, Resource, Action, Ctx> {
+    let mut checker = PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(2).unwrap());
+    checker.add_policy(TracePolicy);
+    checker
+}
+
+#[test]
+fn tracing_fields_are_recorded_for_granted_decisions() {
+    let checker = checker_with_policy();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_in_session(
+                &session,
+                &Subject,
+                &Action,
+                &Resource { allowed: true },
+                &Ctx,
+            )
+            .await
+    });
+
+    let single = span(&spans, "evaluate_in_session");
+    assert_fields(single, &["policy_count", "outcome", "policy.type"]);
+    assert_value(single, "policy_count", "1");
+    assert_value(single, "outcome", "granted");
+    assert_value(single, "policy.type", "TracePolicy");
+
+    let checker = checker_with_policy();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![(Resource { allowed: true }, Ctx)],
+                |item| (&item.0, &item.1),
+            )
+            .await
+    });
+
+    let batch = span(&spans, "evaluate_batch_in_session_by");
+    assert_fields(
+        batch,
+        &[
+            "item_count",
+            "granted_count",
+            "denied_count",
+            "max_batch_size",
+            "policy_count",
+        ],
+    );
+    assert_value(batch, "policy_count", "1");
+    assert_value(batch, "item_count", "1");
+    assert_value(batch, "granted_count", "1");
+    assert_value(batch, "denied_count", "0");
+    assert_value(batch, "max_batch_size", "2");
+
+    let policy = span(&spans, "gatehouse.batch_policy");
+    assert_fields(
+        policy,
+        &[
+            "policy.type",
+            "policy.pending_count",
+            "policy.granted_count",
+            "policy.denied_count",
+        ],
+    );
+    assert_value(policy, "policy.type", "TracePolicy");
+    assert_value(policy, "policy.pending_count", "1");
+    assert_value(policy, "policy.granted_count", "1");
+    assert_value(policy, "policy.denied_count", "0");
+}
+
+#[test]
+fn tracing_fields_are_recorded_for_denied_decisions() {
+    let checker = checker_with_policy();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_in_session(
+                &session,
+                &Subject,
+                &Action,
+                &Resource { allowed: false },
+                &Ctx,
+            )
+            .await
+    });
+
+    let single = span(&spans, "evaluate_in_session");
+    assert_fields(single, &["policy_count", "outcome", "policy.type"]);
+    assert_value(single, "policy_count", "1");
+    assert_value(single, "outcome", "denied");
+
+    let checker = checker_with_policy();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![(Resource { allowed: false }, Ctx)],
+                |item| (&item.0, &item.1),
+            )
+            .await
+    });
+
+    let batch = span(&spans, "evaluate_batch_in_session_by");
+    assert_fields(
+        batch,
+        &[
+            "item_count",
+            "granted_count",
+            "denied_count",
+            "max_batch_size",
+            "policy_count",
+        ],
+    );
+    assert_value(batch, "policy_count", "1");
+    assert_value(batch, "item_count", "1");
+    assert_value(batch, "granted_count", "0");
+    assert_value(batch, "denied_count", "1");
+    assert_value(batch, "max_batch_size", "2");
+}
+
+#[test]
+fn tracing_fields_are_recorded_for_empty_policy_decisions() {
+    let checker = PermissionChecker::<Subject, Resource, Action, Ctx>::new();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_in_session(
+                &session,
+                &Subject,
+                &Action,
+                &Resource { allowed: true },
+                &Ctx,
+            )
+            .await
+    });
+
+    let single = span(&spans, "evaluate_in_session");
+    assert_fields(single, &["policy_count", "outcome", "policy.type"]);
+    assert_value(single, "policy_count", "0");
+    assert_value(single, "outcome", "denied");
+
+    let checker = PermissionChecker::<Subject, Resource, Action, Ctx>::new()
+        .with_max_batch_size(NonZeroUsize::new(2).unwrap());
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![(Resource { allowed: true }, Ctx)],
+                |item| (&item.0, &item.1),
+            )
+            .await
+    });
+
+    let batch = span(&spans, "evaluate_batch_in_session_by");
+    assert_fields(
+        batch,
+        &[
+            "item_count",
+            "granted_count",
+            "denied_count",
+            "max_batch_size",
+            "policy_count",
+        ],
+    );
+    assert_value(batch, "policy_count", "0");
+    assert_value(batch, "item_count", "1");
+    assert_value(batch, "granted_count", "0");
+    assert_value(batch, "denied_count", "1");
+    assert_value(batch, "max_batch_size", "2");
+}

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -274,14 +274,57 @@ fn tracing_fields_are_recorded_for_granted_decisions() {
         &[
             "policy.type",
             "policy.pending_count",
+            "policy.chunk_index",
+            "policy.chunk_count",
             "policy.granted_count",
             "policy.denied_count",
         ],
     );
     assert_value(policy, "policy.type", "TracePolicy");
     assert_value(policy, "policy.pending_count", "1");
+    assert_value(policy, "policy.chunk_index", "0");
+    assert_value(policy, "policy.chunk_count", "1");
     assert_value(policy, "policy.granted_count", "1");
     assert_value(policy, "policy.denied_count", "0");
+}
+
+#[test]
+fn tracing_records_one_batch_policy_span_per_chunk() {
+    let checker = checker_with_policy();
+    let session = EvaluationSession::empty();
+    let (_result, spans) = capture_async(|| async {
+        checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![
+                    (Resource { allowed: true }, Ctx),
+                    (Resource { allowed: false }, Ctx),
+                    (Resource { allowed: true }, Ctx),
+                ],
+                |item| (&item.0, &item.1),
+            )
+            .await
+    });
+
+    let policy_spans = spans
+        .iter()
+        .filter(|span| span.name == "gatehouse.batch_policy")
+        .collect::<Vec<_>>();
+    assert_eq!(policy_spans.len(), 2, "expected one span per policy chunk");
+
+    assert_value(policy_spans[0], "policy.pending_count", "2");
+    assert_value(policy_spans[0], "policy.chunk_index", "0");
+    assert_value(policy_spans[0], "policy.chunk_count", "2");
+    assert_value(policy_spans[0], "policy.granted_count", "1");
+    assert_value(policy_spans[0], "policy.denied_count", "1");
+
+    assert_value(policy_spans[1], "policy.pending_count", "1");
+    assert_value(policy_spans[1], "policy.chunk_index", "1");
+    assert_value(policy_spans[1], "policy.chunk_count", "2");
+    assert_value(policy_spans[1], "policy.granted_count", "1");
+    assert_value(policy_spans[1], "policy.denied_count", "0");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Reshapes the batch-auth work into the v0.3 `FactSource` design from #20:

- collapses the public `Policy` trait to `evaluate(&EvalCtx)` plus `evaluate_batch(&BatchEvalCtx)`
- requires checker evaluation to receive an explicit request-scoped `EvaluationSession`; RBAC/ABAC-only callers use `EvaluationSession::empty()` or `EvaluationSession::shared_empty()` for hot no-fact loops
- adds `FactKey`, typed `FactLoadError`, `FactLoadResult`, `FactSource`, `FactSourceRegistrationError`, `RelationshipQuery`, and a request-scoped session cache/registry keyed by `TypeId`
- adds in-flight load joining so concurrent requests for the same key share one backend load, with cancelled or panicking leaders waking waiters via `Error(LoaderCancelled)`
- makes `RelationshipQuery<SubjectId, ResourceId, Relation>` the canonical ReBAC fact key and removes `RelationshipResolver`
- adds `DelegatingPolicy` for cross-domain policy-layer delegation through a child `PermissionChecker`, preserving child batch evaluation and trace output
- adds `EvaluationSession::builder()`, `shared_empty()`, non-panicking `try_register*` / `try_replace*`, and explicit `replace*` helpers
- adds resource-only batch helpers for the `R = item, C = ()` case
- keeps checker-level `with_max_batch_size` as a defensive policy-batch cap, while `FactSource::max_batch_size` caps source loads after deduplication
- changes `policy_type` to return `&str` and documents the new `S/R/A/C: Sync` policy input bound
- adds hot in-RAM and latency-injected Criterion groups for session overhead, batching, and in-flight coalescing behavior
- updates README, rustdocs, examples, benches, changelog, and `MIGRATION.md` for the v0.3 direction

Closes #17.
Closes #20.
Closes #22.
Closes #23.

Module splitting is tracked separately in #21 / PR #26. Lookup-style enumeration remains deferred to #24. Sharded session internals for future parallel batch evaluation are tracked in #25 / PR #26.

## Review follow-up

- Fixed source registration/replacement so duplicate checks, in-flight checks, source install, and cache clearing happen in one registry critical section.
- Added non-panicking `try_register`, `try_register_arc`, `try_replace`, and `try_replace_arc`.
- Added `MIGRATION.md` with side-by-side v0.2 -> v0.3 guidance, including dynamic `policy_type` patterns.
- Documented that `LoaderCancelled` poisons affected keys for the rest of the request-scoped session.
- Toned down the hot in-RAM benchmark language and added `latency_fact_source`, which injects fixed async source delay to show N per-item sessions versus one batched session, plus independent repeated loads versus shared-session in-flight coalescing.
- Moved batch telemetry to per-chunk `gatehouse.batch_policy` spans with chunk fields.
- Avoided repeated ReBAC subject ID extraction inside batch evaluation.

## Test-plan coverage added

- Session contract tests for empty input, ordering, duplicate expansion, cross-call cache hits, `Found`/`Missing`/`Error` caching, source contract violations, missing sources, explicit source replacement, chunk stitching, cancellation, source panic cleanup, shared empty sessions, and shared sources across concurrent sessions.
- Proptest coverage for arbitrary duplicate-key ordering, chunking/dedup invariants, and batch-vs-naive equivalence across randomized policy stacks, grant probabilities, item counts, and checker max-batch sizes.
- Checker contract tests for empty batches, single-item batch equivalence, resource-only unit-context batch helpers, OR pending-set short-circuiting, boxed `dyn Policy` batch dispatch, delegating-policy batch preservation, batch-vs-naive decisions for simple stacks, and mixed in-memory + ReBAC stacks.
- Axum integration tests for the request-scoped session listing endpoint, including relationship-backed viewer visibility and admin short-circuit visibility.
- Structured tracing contract tests for `evaluate_in_session`, `evaluate_batch_in_session_by`, and nested `gatehouse.batch_policy` span fields.
- Benchmark test-mode coverage for `in_ram_fact_source` and `latency_fact_source`; `cargo bench --bench permission_checker --no-run` compiles the optimized harness.

Follow-up harnesses still better outside this PR: loom with a synchronization abstraction, testcontainers PG18 integration/failure-mode tests, and richer `EvalTrace` linkage for shared fact-load IDs.

## PostgreSQL 18 example results

Run against a local PostgreSQL 18.3 container via Docker/OrbStack using the updated `FactSource<RelationshipQuery<Uuid, Uuid, Relation>>` implementation. The example fail-closes DB errors into `FactLoadError::Backend`, asserts point SQL agrees with one-key bulk SQL for a sampled grant and non-grant, uses a typed `Relation`, and composes an in-memory `PublicPost` policy before the SQL-backed `viewer` relationship policy.

```text
PostgreSQL 18.3 on aarch64-unknown-linux-musl, compiled by gcc (Alpine 15.2.0) 15.2.0, 64-bit
size,relationship_checks,naive_ms,bulk_ms,allowed,improvement
10,8,1.321,0.326,6,x4.1
100,80,8.611,0.267,60,x32.3
1000,800,63.872,1.230,600,x51.9
5000,4000,314.844,5.585,3000,x56.4
10000,8000,635.528,12.185,6000,x52.2
```

## Validation

```text
cargo fmt --all --check
cargo check --all-targets --all-features
cargo clippy --all-targets --all-features -- -D warnings
cargo doc --all-features --no-deps
cargo test --doc
cargo test --all-targets --all-features
cargo bench --bench permission_checker --no-run
```
