### PR TITLE
Extract Sans-I/O session core and add loom permutation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
       - name: Test
         run: cargo test --all-targets --all-features
 
+  loom-tests:
+    name: Loom permutation tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "loom-v1"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      # Loom-incompatible dev-deps are gated on `cfg(not(loom))` in Cargo.toml,
+      # so this build collapses to just the library + loom. The harness lives
+      # in `src/session/core.rs` (see #29).
+      - name: Run loom models
+        run: cargo test --lib --release
+        env:
+          RUSTFLAGS: "--cfg loom"
+
   release:
     name: Release
     needs: build-and-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Internal refactor: the per-stripe session state machine is now a private synchronous core (`FactStripeCore<K, W>`) with no async, no tracing, and a generic waiter type. `FactState<K>` remains the async adapter that owns locks, the source, and tracing. No public API change. (#28)
+
+### Tests
+
+- Loom permutation-test harness for the session fact-load state machine. Six models cover leader-election uniqueness, waiter wake-up, fail-closed cancellation, cache-write visibility, replacement atomicity, and idle cache clearing. Run under `RUSTFLAGS="--cfg loom" cargo test --lib --release` and as a separate CI job. (#29)
+
 ## [0.3.0-alpha.1] - 2026-05-27
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "dashmap",
  "futures-channel",
  "hyper",
+ "loom",
  "proptest",
  "serde",
  "tokio",
@@ -870,6 +871,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1314,6 +1330,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1398,15 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1798,6 +1845,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2248,6 +2301,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2256,9 +2321,16 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2341,6 +2413,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2547,6 +2625,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ uuid = {version="1", features = ["serde", "v4"]}
 async-trait = "0.1"
 futures-channel = "0.3"
 
-[dev-dependencies]
+# Regular dev-deps. Gated on `cfg(not(loom))` because several of them
+# (tokio's `net` module, anything that depends on it: actix-rt, axum, hyper,
+# tower, actix-web, tokio-test, tokio-postgres) are intentionally
+# loom-incompatible. Under `--cfg loom` the dependency graph collapses to
+# just the loom harness; under a normal build everything below is available.
+[target.'cfg(not(loom))'.dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 tokio-test = "0.4"
 tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
@@ -25,6 +30,12 @@ dashmap = "6"
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+
+# Loom is a permutation-testing model checker for concurrent Rust. Pulled in
+# only when the loom cfg is set (RUSTFLAGS="--cfg loom") so it does not affect
+# the default test build. See the loom_tests module in src/session/core.rs.
+[target.'cfg(loom)'.dev-dependencies]
+loom = "0.7"
 
 [[bench]]
 name = "permission_checker"
@@ -44,3 +55,9 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 # We want to document all features.
 all-features = true
+
+[lints.rust]
+# `cfg(loom)` is set by `RUSTFLAGS="--cfg loom"` for the loom permutation-test
+# harness. It is not a feature, so register it with `check-cfg` so default
+# builds do not warn about an unexpected cfg.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,5 +289,10 @@ pub use policy::{BatchEvalCtx, EvalCtx, Policy, PolicyBatchItem};
 pub use results::{AccessEvaluation, CombineOp, EvalTrace, PolicyEvalResult};
 pub use session::{EvaluationSession, EvaluationSessionBuilder};
 
-#[cfg(test)]
+// The shared unit-test module pulls in tokio-based async tests via dev-deps
+// that are intentionally loom-incompatible (`tokio::net`, axum, hyper, etc.).
+// Gate it out under `cfg(loom)` so the loom build's minimal dependency graph
+// stays clean. The synchronous core's deterministic tests and the loom
+// permutation tests both live in `src/session/core.rs` and are unaffected.
+#[cfg(all(test, not(loom)))]
 mod tests;

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -333,11 +333,15 @@ mod tests {
 // invariant explicitly, and prefer `loom::sync::Arc<loom::sync::Mutex<_>>`
 // around the core over building a richer adapter.
 // =============================================================================
-#[cfg(loom)]
+// Gated on `cfg(all(test, loom))` because `loom` is a `cfg(loom)`-only
+// dev-dependency. Without the `test` gate, `cargo check --lib --cfg loom`
+// would fail to resolve `loom::*` since dev-deps are only linked into the
+// test build.
+#[cfg(all(test, loom))]
 mod loom_tests {
     use super::*;
     use crate::FactLoadError;
-    use loom::sync::atomic::{AtomicBool, Ordering};
+    use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use loom::sync::{Arc, Mutex};
     use loom::thread;
 
@@ -350,23 +354,29 @@ mod loom_tests {
     }
 
     /// Loom-compatible waiter. The leader/canceller calls `signal` after the
-    /// cache is committed; waiters check `is_signaled` to observe wake-up.
+    /// cache is committed; waiters read `signal_count` to observe wake-up.
+    ///
+    /// Counts rather than flags so models can assert "exactly once" rather
+    /// than "at least once". A double-signal is detectable as count > 1.
     #[derive(Clone)]
     struct LoomWaiter {
-        flag: Arc<AtomicBool>,
+        count: Arc<AtomicUsize>,
     }
 
     impl LoomWaiter {
         fn new() -> Self {
             Self {
-                flag: Arc::new(AtomicBool::new(false)),
+                count: Arc::new(AtomicUsize::new(0)),
             }
         }
         fn signal(&self) {
-            self.flag.store(true, Ordering::Release);
+            self.count.fetch_add(1, Ordering::Release);
+        }
+        fn signal_count(&self) -> usize {
+            self.count.load(Ordering::Acquire)
         }
         fn is_signaled(&self) -> bool {
-            self.flag.load(Ordering::Acquire)
+            self.signal_count() > 0
         }
     }
 
@@ -421,13 +431,14 @@ mod loom_tests {
         });
     }
 
-    // Model 2: waiters are woken on finish.
+    // Model 2: waiters are woken exactly once on finish.
     // The main thread pre-claims leader so the waiter thread always sees
     // Joined or Cached (this isolates the wake-up invariant from leader
     // election, which model 1 covers). If the joiner registers before the
-    // finisher runs, finish must wake its waiter.
+    // finisher runs, finish must wake its waiter exactly once — counted
+    // via `LoomWaiter::signal_count` to detect both lost and double wakes.
     #[test]
-    fn loom_waiters_woken_on_finish() {
+    fn loom_waiters_woken_exactly_once_on_finish() {
         loom::model(|| {
             let stripe = new_stripe();
             {
@@ -466,11 +477,20 @@ mod loom_tests {
             t2.join().unwrap();
 
             if joined.load(Ordering::Acquire) {
-                assert!(
-                    waiter.is_signaled(),
-                    "a waiter that registered before finish must be signaled"
+                assert_eq!(
+                    waiter.signal_count(),
+                    1,
+                    "a waiter that registered before finish must be signaled exactly once \
+                     (lost wake -> 0, double wake -> >1)"
                 );
             } else {
+                // Joiner ran after finish: it saw Cached and was never
+                // stored as a waiter, so the signal count stays 0.
+                assert_eq!(
+                    waiter.signal_count(),
+                    0,
+                    "a joiner that saw Cached must never receive a signal"
+                );
                 // The joiner ran after finish: it saw Cached and was not
                 // stored as a waiter. The cache holds the value.
                 let cached = stripe
@@ -534,9 +554,16 @@ mod loom_tests {
             t2.join().unwrap();
 
             if joined.load(Ordering::Acquire) {
-                assert!(
-                    waiter.is_signaled(),
-                    "a waiter that joined before cancellation must be signaled"
+                assert_eq!(
+                    waiter.signal_count(),
+                    1,
+                    "a waiter that joined before cancellation must be signaled exactly once"
+                );
+            } else {
+                assert_eq!(
+                    waiter.signal_count(),
+                    0,
+                    "a joiner that saw Cached after cancellation must never receive a signal"
                 );
             }
             let cached = stripe

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -612,63 +612,102 @@ mod loom_tests {
     }
 
     /// Tiny adapter mirroring `FactState::insert_source` / `plan_loads` for
-    /// the source-vs-planner models below. One stripe is enough to exercise
-    /// the source-held-across-planning discipline; production has 64.
+    /// the source-vs-planner models below. Uses `LOOM_STRIPES = 2` so
+    /// multi-stripe interleavings are reachable; production has 64. The
+    /// keying is `K(n).0 % LOOM_STRIPES` so `K(0)` and `K(1)` land on
+    /// different stripes.
+    ///
+    /// Drift hazard: this adapter mirrors the production `FactState` lock
+    /// discipline. If `FactState::insert_source` or `plan_loads` change their
+    /// lock ordering, this mirror must follow.
+    const LOOM_STRIPES: usize = 2;
+
     struct LoomAdapter {
         source: Mutex<Option<u32>>,
-        stripe: Mutex<FactStripeCore<K, LoomWaiter>>,
+        stripes: [Mutex<FactStripeCore<K, LoomWaiter>>; LOOM_STRIPES],
     }
 
     impl LoomAdapter {
         fn new(initial_source: Option<u32>) -> Self {
             Self {
                 source: Mutex::new(initial_source),
-                stripe: Mutex::new(FactStripeCore::new()),
+                stripes: [
+                    Mutex::new(FactStripeCore::new()),
+                    Mutex::new(FactStripeCore::new()),
+                ],
             }
         }
 
+        fn stripe_index(key: &K) -> usize {
+            (key.0 as usize) % LOOM_STRIPES
+        }
+
         /// Plan-equivalent: snapshot source, peek cache. The source lock is
-        /// held while peeking — the same discipline as
+        /// held across the stripe peek — the same discipline as
         /// `FactState::plan_loads` — so replacement either fully precedes
         /// or fully follows the planning observation.
         fn plan(&self, key: &K) -> (Option<u32>, Option<FactLoadResult<u32>>) {
             let source_guard = self.source.lock().unwrap();
             let source = *source_guard;
-            let stripe = self.stripe.lock().unwrap();
+            let stripe = self.stripes[Self::stripe_index(key)].lock().unwrap();
             let cached = stripe.peek_cache(key);
             (source, cached)
         }
 
-        /// Replace-equivalent: acquire source, then stripe, check idle, swap,
-        /// clear cache, atomically.
+        /// Replace-equivalent: acquire source, then ALL stripes (in index
+        /// order), check idle, swap, clear caches, atomically.
         fn replace(&self, new_source: u32) -> bool {
             let mut source_guard = self.source.lock().unwrap();
-            let mut stripe_guard = self.stripe.lock().unwrap();
-            if !stripe_guard.is_idle() {
+            let mut s0 = self.stripes[0].lock().unwrap();
+            let mut s1 = self.stripes[1].lock().unwrap();
+            if !s0.is_idle() || !s1.is_idle() {
                 return false;
             }
             *source_guard = Some(new_source);
-            stripe_guard.clear_cache();
+            s0.clear_cache();
+            s1.clear_cache();
             true
         }
 
-        /// Single-threaded test setup helper. Not part of the modeled
-        /// protocol; runs before any thread is spawned.
+        /// Single-threaded helper: claim leader and finish in one call.
         fn seed_cache(&self, key: K, value: u32) {
-            let mut stripe = self.stripe.lock().unwrap();
+            let mut stripe = self.stripes[Self::stripe_index(&key)].lock().unwrap();
             let outcome = stripe.try_register::<_, LoomWaiter>(&key, || unreachable!());
             assert!(matches!(outcome, Registration::Leading));
             stripe.finish(key, FactLoadResult::Found(value));
+        }
+
+        /// Single-threaded helper: claim leader only. The caller is then
+        /// responsible for calling `finish_leader` later (possibly from
+        /// another thread).
+        fn lead(&self, key: &K) {
+            let mut stripe = self.stripes[Self::stripe_index(key)].lock().unwrap();
+            let outcome = stripe.try_register::<_, LoomWaiter>(key, || unreachable!());
+            assert!(matches!(outcome, Registration::Leading));
+        }
+
+        /// Finish a previously-claimed leader. Signals any joined waiters
+        /// outside the stripe lock.
+        fn finish_leader(&self, key: K, value: u32) {
+            let waiters = {
+                let mut stripe = self.stripes[Self::stripe_index(&key)].lock().unwrap();
+                stripe.finish(key, FactLoadResult::Found(value))
+            };
+            signal_all(waiters);
         }
     }
 
     // Model 5: replacement is atomic w.r.t. planning.
     // Setup: source = Some(1), cache has K(1) -> Found(100).
     // Thread A plans; thread B replaces source with 2 (clearing cache).
-    // The only legal observations from A are:
+    // Loom explores both orderings; the only legal observations are:
     //   * (Some(1), Some(Found(100))) — plan ran first
     //   * (Some(2), None)             — replace ran first
     // FORBIDDEN: (Some(2), Some(Found(100))) — new source + stale cache.
+    //
+    // (The reverse-order framing — thread B plans, thread A replaces — is
+    // the same loom model under thread-spawn renaming. Loom permutes
+    // schedules already; we don't need a second test to express it.)
     #[test]
     fn loom_replacement_is_atomic_with_respect_to_planning() {
         loom::model(|| {
@@ -679,12 +718,14 @@ mod loom_tests {
             let t1 = thread::spawn(move || a1.plan(&K(1)));
 
             let a2 = adapter.clone();
-            let t2 = thread::spawn(move || {
-                assert!(a2.replace(2));
-            });
+            let t2 = thread::spawn(move || a2.replace(2));
 
             let (source_seen, cached_seen) = t1.join().unwrap();
-            t2.join().unwrap();
+            let replaced = t2.join().unwrap();
+            assert!(
+                replaced,
+                "stripe is idle (seed_cache finished); replace must succeed under every schedule"
+            );
 
             match (source_seen, cached_seen) {
                 (Some(1), Some(FactLoadResult::Found(100))) => {}
@@ -697,32 +738,82 @@ mod loom_tests {
         });
     }
 
-    // Model 6: idle replacement clears cache atomically.
-    // Same shape as model 5 but spelled out as "the cache is never a stale
-    // hit under the new source." Kept distinct so a regression to the
-    // clear_cache step is immediately attributable.
+    // Model 6: unrelated keys on different stripes do not interfere.
+    // Setup: K(0) and K(1) route to stripe 0 and stripe 1 respectively.
+    // Two threads concurrently claim+finish their key. After both join,
+    // each stripe contains exactly its own cached value — no cross-stripe
+    // state leak under any schedule.
     #[test]
-    fn loom_idle_replacement_clears_cache() {
+    fn loom_unrelated_stripes_are_independent() {
         loom::model(|| {
-            let adapter = Arc::new(LoomAdapter::new(Some(1)));
-            adapter.seed_cache(K(1), 200);
+            let adapter = Arc::new(LoomAdapter::new(None));
+            assert_ne!(
+                LoomAdapter::stripe_index(&K(0)),
+                LoomAdapter::stripe_index(&K(1)),
+                "test setup requires K(0) and K(1) on different stripes"
+            );
 
             let a1 = adapter.clone();
             let t1 = thread::spawn(move || {
-                assert!(a1.replace(2));
+                a1.lead(&K(0));
+                a1.finish_leader(K(0), 10);
             });
 
             let a2 = adapter.clone();
-            let t2 = thread::spawn(move || a2.plan(&K(1)));
+            let t2 = thread::spawn(move || {
+                a2.lead(&K(1));
+                a2.finish_leader(K(1), 20);
+            });
 
             t1.join().unwrap();
-            let (source_seen, cached_seen) = t2.join().unwrap();
+            t2.join().unwrap();
 
-            match (source_seen, cached_seen) {
-                (Some(2), None) => {}
-                (Some(1), Some(FactLoadResult::Found(200))) => {}
-                (Some(1), None) => {}
-                other => panic!("idle replacement broke atomicity: observed {other:?}"),
+            match adapter.plan(&K(0)).1 {
+                Some(FactLoadResult::Found(10)) => {}
+                other => panic!("K(0) cache: expected Found(10), got {other:?}"),
+            }
+            match adapter.plan(&K(1)).1 {
+                Some(FactLoadResult::Found(20)) => {}
+                other => panic!("K(1) cache: expected Found(20), got {other:?}"),
+            }
+        });
+    }
+
+    // Model 7: replacement is rejected while a leader is in flight.
+    // Setup: source = Some(1), K(1)'s stripe has a claimed-but-unfinished
+    // leader. Thread A finishes the leader; thread B tries replace.
+    // Legal observations:
+    //   * B saw in-flight (ran before A's finish): returned false, source
+    //     stays Some(1), K(1) cached at the finish value.
+    //   * B saw idle (ran after A's finish): returned true, source becomes
+    //     Some(2), cache cleared.
+    // FORBIDDEN: replace returned true AND K(1) is still cached at the
+    // old value — that would mean clear_cache was skipped, or replace
+    // succeeded while the leader's finish hadn't yet committed.
+    #[test]
+    fn loom_replacement_rejected_while_in_flight() {
+        loom::model(|| {
+            let adapter = Arc::new(LoomAdapter::new(Some(1)));
+            adapter.lead(&K(1));
+
+            let a1 = adapter.clone();
+            let t_finish = thread::spawn(move || a1.finish_leader(K(1), 77));
+
+            let a2 = adapter.clone();
+            let t_replace = thread::spawn(move || a2.replace(2));
+
+            t_finish.join().unwrap();
+            let replaced = t_replace.join().unwrap();
+            let (source, cached) = adapter.plan(&K(1));
+
+            match (replaced, source, cached) {
+                // B rejected: A's finish stands.
+                (false, Some(1), Some(FactLoadResult::Found(77))) => {}
+                // B succeeded after A's finish: cache cleared.
+                (true, Some(2), None) => {}
+                other => panic!(
+                    "in-flight replacement invariant violated: (replaced, source, cached) = {other:?}"
+                ),
             }
         });
     }

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -1,0 +1,702 @@
+//! Synchronous core of the session fact-load state machine.
+//!
+//! This module owns the per-stripe cache and in-flight state and the state
+//! transitions that act on them. It is intentionally side-effect-light:
+//!
+//! * No `async`, no `.await`, no Tokio.
+//! * No `FactSource`, no I/O.
+//! * No concrete channel type. The waiter payload `W` is a fully abstract
+//!   storable that the adapter knows how to signal.
+//! * No tracing. The adapter wraps load I/O with spans.
+//!
+//! The async adapter (`super::FactState`) owns the locks that serialize these
+//! transitions, the source mutex, the runtime-specific waiter type
+//! (`oneshot::Sender<()>` in production), and the tracing spans around
+//! `FactSource::load_many(...).await`. This split keeps the protocol
+//! invariants (leader election, waiter wake-up, cancellation, replacement
+//! atomicity) deterministically testable without needing to induce precise
+//! Tokio timing.
+
+use crate::{FactKey, FactLoadResult};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+/// Per-stripe synchronous state for one fact key type.
+///
+/// `W` is the waiter payload type. The core stores `W` values and returns them
+/// from `finish` so the adapter can signal them outside the lock.
+pub(super) struct FactStripeCore<K, W>
+where
+    K: FactKey,
+{
+    cache: HashMap<K, FactLoadResult<K::Value>>,
+    in_flight: HashMap<K, Vec<W>>,
+}
+
+/// Outcome of [`FactStripeCore::try_register`].
+#[derive(Debug)]
+pub(super) enum Registration<V, R> {
+    /// The key was already cached. The cached value is returned.
+    Cached(FactLoadResult<V>),
+    /// No load was in flight for this key. The caller is now the leader and
+    /// owns an empty in-flight slot for the key.
+    Leading,
+    /// A load was already in flight. The `make_pair` closure was invoked to
+    /// create a (waiter, receiver) pair; the waiter is stored on the
+    /// in-flight entry and the receiver is returned to the caller.
+    Joined(R),
+}
+
+impl<K, W> FactStripeCore<K, W>
+where
+    K: FactKey,
+{
+    pub(super) fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+            in_flight: HashMap::new(),
+        }
+    }
+
+    /// Snapshot a cached entry, if any. Used by the all-cached fast path in
+    /// the planner.
+    pub(super) fn peek_cache(&self, key: &K) -> Option<FactLoadResult<K::Value>> {
+        self.cache.get(key).cloned()
+    }
+
+    /// Register interest in `key`.
+    ///
+    /// Returns [`Registration::Cached`] if the value is already cached;
+    /// [`Registration::Leading`] if no load was in flight and the caller is
+    /// now responsible for driving the load; [`Registration::Joined`] if a
+    /// load was already in flight and the caller is joining as a waiter.
+    ///
+    /// `make_pair` is invoked only on the `Joined` branch. The waiter is
+    /// stored on the in-flight entry; the receiver is returned in the
+    /// [`Registration::Joined`] variant.
+    pub(super) fn try_register<F, R>(&mut self, key: &K, make_pair: F) -> Registration<K::Value, R>
+    where
+        F: FnOnce() -> (W, R),
+    {
+        if let Some(cached) = self.cache.get(key) {
+            return Registration::Cached(cached.clone());
+        }
+        match self.in_flight.entry(key.clone()) {
+            Entry::Occupied(mut existing) => {
+                let (waiter, receiver) = make_pair();
+                existing.get_mut().push(waiter);
+                Registration::Joined(receiver)
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(Vec::new());
+                Registration::Leading
+            }
+        }
+    }
+
+    /// Cache `result` for `key` and return any registered waiters.
+    ///
+    /// The cache write and the waiter removal happen in one synchronous
+    /// transition; the caller signals the returned waiters after releasing
+    /// the surrounding lock. Used for successful loads, source contract
+    /// violations, missing-source errors, and loader cancellation.
+    pub(super) fn finish(&mut self, key: K, result: FactLoadResult<K::Value>) -> Vec<W> {
+        let waiters = self.in_flight.remove(&key).unwrap_or_default();
+        self.cache.insert(key, result);
+        waiters
+    }
+
+    /// True iff this stripe has no in-flight loads.
+    ///
+    /// Used by source registration/replacement to decide whether a swap is
+    /// safe.
+    pub(super) fn is_idle(&self) -> bool {
+        self.in_flight.is_empty()
+    }
+
+    /// Clear all cached results. Used by source replacement once every
+    /// stripe has been observed idle under the registry lock.
+    pub(super) fn clear_cache(&mut self) {
+        self.cache.clear();
+    }
+}
+
+impl<K, W> Default for FactStripeCore<K, W>
+where
+    K: FactKey,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FactLoadError;
+
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    struct K(u32);
+
+    impl FactKey for K {
+        type Value = u32;
+        const NAME: &'static str = "test";
+    }
+
+    // Simple opaque waiter ID for deterministic tests.
+    type Wid = u32;
+
+    fn assert_found(result: &FactLoadResult<u32>, expected: u32) {
+        match result {
+            FactLoadResult::Found(value) => assert_eq!(*value, expected),
+            other => panic!("expected Found({expected}), got {other:?}"),
+        }
+    }
+
+    fn assert_cancelled(result: &FactLoadResult<u32>) {
+        match result {
+            FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name }) => {
+                assert_eq!(*fact_name, K::NAME);
+            }
+            other => panic!("expected LoaderCancelled, got {other:?}"),
+        }
+    }
+
+    fn expect_leading<R: std::fmt::Debug>(reg: Registration<u32, R>) {
+        match reg {
+            Registration::Leading => {}
+            other => panic!("expected Leading, got {other:?}"),
+        }
+    }
+
+    fn expect_joined<R>(reg: Registration<u32, R>) -> R {
+        match reg {
+            Registration::Joined(r) => r,
+            Registration::Leading => panic!("expected Joined, got Leading"),
+            Registration::Cached(_) => panic!("expected Joined, got Cached"),
+        }
+    }
+
+    fn lead<W>(core: &mut FactStripeCore<K, W>, key: K) {
+        expect_leading(
+            core.try_register::<_, ()>(&key, || panic!("make_pair should not run on Leading")),
+        );
+    }
+
+    #[test]
+    fn peek_cache_empty_is_none() {
+        let core = FactStripeCore::<K, Wid>::new();
+        assert!(core.peek_cache(&K(1)).is_none());
+    }
+
+    #[test]
+    fn finish_caches_value_and_extracts_waiters_in_order() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(1));
+
+        let r0 = expect_joined(core.try_register(&K(1), || (10u32, "r0")));
+        let r1 = expect_joined(core.try_register(&K(1), || (11u32, "r1")));
+        assert_eq!(r0, "r0");
+        assert_eq!(r1, "r1");
+
+        let waiters = core.finish(K(1), FactLoadResult::Found(42));
+        assert_eq!(
+            waiters,
+            vec![10u32, 11u32],
+            "waiters returned in join order"
+        );
+        assert_found(&core.peek_cache(&K(1)).expect("cached"), 42);
+        assert!(core.is_idle(), "in-flight entry removed");
+    }
+
+    #[test]
+    fn second_finish_for_same_key_returns_no_waiters() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(7));
+        let _ = core.finish(K(7), FactLoadResult::Found(7));
+
+        let waiters = core.finish(K(7), FactLoadResult::Found(8));
+        assert!(waiters.is_empty(), "no waiters on a second finish");
+        assert_found(&core.peek_cache(&K(7)).expect("cached"), 8);
+    }
+
+    #[test]
+    fn try_register_returns_cached_when_present() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(3));
+        let _ = core.finish(K(3), FactLoadResult::Found(30));
+
+        match core.try_register::<_, ()>(&K(3), || panic!("closure must not fire on Cached")) {
+            Registration::Cached(value) => assert_found(&value, 30),
+            other => panic!("expected Cached, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancellation_caches_loader_cancelled_and_wakes_waiters() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(9));
+        expect_joined(core.try_register(&K(9), || (1u32, ())));
+        expect_joined(core.try_register(&K(9), || (2u32, ())));
+
+        // Adapter-side cancellation: finish with LoaderCancelled.
+        let waiters = core.finish(
+            K(9),
+            FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name: K::NAME }),
+        );
+        assert_eq!(waiters, vec![1u32, 2u32]);
+        assert_cancelled(&core.peek_cache(&K(9)).expect("cached"));
+        assert!(core.is_idle());
+    }
+
+    #[test]
+    fn unrelated_keys_are_independent() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(1));
+        lead(&mut core, K(2));
+        assert!(!core.is_idle(), "two in-flight entries");
+
+        let waiters_for_1 = core.finish(K(1), FactLoadResult::Found(100));
+        assert!(waiters_for_1.is_empty());
+        assert_found(&core.peek_cache(&K(1)).expect("cached"), 100);
+        assert!(core.peek_cache(&K(2)).is_none(), "K(2) still loading");
+        assert!(!core.is_idle(), "K(2) still in flight");
+
+        let _ = core.finish(K(2), FactLoadResult::Found(200));
+        assert!(core.is_idle());
+    }
+
+    #[test]
+    fn is_idle_reflects_in_flight_state() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        assert!(core.is_idle());
+        lead(&mut core, K(1));
+        assert!(!core.is_idle());
+        let _ = core.finish(K(1), FactLoadResult::Found(1));
+        assert!(core.is_idle());
+    }
+
+    #[test]
+    fn clear_cache_drops_cached_entries() {
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(1));
+        let _ = core.finish(K(1), FactLoadResult::Found(100));
+        assert_found(&core.peek_cache(&K(1)).expect("cached"), 100);
+
+        core.clear_cache();
+        assert!(core.peek_cache(&K(1)).is_none());
+        assert!(core.is_idle(), "clear_cache does not touch in-flight");
+    }
+
+    #[test]
+    fn clear_cache_with_active_in_flight_keeps_in_flight() {
+        // Defensive: clear_cache should never be called while in-flight exists
+        // (the adapter checks is_idle first). Verify the core does not corrupt
+        // state if it is misused.
+        let mut core = FactStripeCore::<K, Wid>::new();
+        lead(&mut core, K(1));
+        expect_joined(core.try_register(&K(1), || (5u32, ())));
+        core.clear_cache();
+        let waiters = core.finish(K(1), FactLoadResult::Found(11));
+        assert_eq!(waiters, vec![5u32]);
+        assert_found(&core.peek_cache(&K(1)).expect("cached"), 11);
+    }
+}
+
+// =============================================================================
+// Loom permutation-test harness.
+//
+// Enabled with `RUSTFLAGS="--cfg loom" cargo test --lib --release`. Loom runs
+// each `loom::model { ... }` block under a bounded model of every legal thread
+// interleaving and asserts the invariant holds for all of them.
+//
+// What loom covers here:
+// * Leader election uniqueness for one key under concurrent registrations.
+// * Waiter wake-up on `finish`, exactly once per waiter.
+// * Fail-closed cancellation: dropping the leader caches `LoaderCancelled`
+//   and wakes every registered waiter.
+// * Cache writes published by `finish` are visible to a concurrent
+//   `peek_cache` reader.
+// * Source replacement is atomic w.r.t. planning: a reader never observes a
+//   new source paired with the old cache.
+// * Idle replacement clears cache atomically.
+//
+// What loom does NOT cover here:
+// * The async adapter end-to-end. Loom cannot model `tokio::sync::oneshot`
+//   or the async runtime; the harness substitutes a loom-friendly waiter.
+// * Tracing spans, fact-load IDs, or chunking. Those are exercised by the
+//   normal async integration tests.
+// * Deep preemption sequences. Models bound thread count to 2 and run the
+//   smallest scenario that exercises each invariant.
+//
+// Adding a new model: keep it tight (2 threads, 1-2 keys), assert one
+// invariant explicitly, and prefer `loom::sync::Arc<loom::sync::Mutex<_>>`
+// around the core over building a richer adapter.
+// =============================================================================
+#[cfg(loom)]
+mod loom_tests {
+    use super::*;
+    use crate::FactLoadError;
+    use loom::sync::atomic::{AtomicBool, Ordering};
+    use loom::sync::{Arc, Mutex};
+    use loom::thread;
+
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    struct K(u32);
+
+    impl FactKey for K {
+        type Value = u32;
+        const NAME: &'static str = "loom";
+    }
+
+    /// Loom-compatible waiter. The leader/canceller calls `signal` after the
+    /// cache is committed; waiters check `is_signaled` to observe wake-up.
+    #[derive(Clone)]
+    struct LoomWaiter {
+        flag: Arc<AtomicBool>,
+    }
+
+    impl LoomWaiter {
+        fn new() -> Self {
+            Self {
+                flag: Arc::new(AtomicBool::new(false)),
+            }
+        }
+        fn signal(&self) {
+            self.flag.store(true, Ordering::Release);
+        }
+        fn is_signaled(&self) -> bool {
+            self.flag.load(Ordering::Acquire)
+        }
+    }
+
+    /// Drain `finish`-returned waiters and signal each. Always called after
+    /// releasing the surrounding stripe lock, matching the production
+    /// adapter's discipline.
+    fn signal_all(waiters: Vec<LoomWaiter>) {
+        for w in waiters {
+            w.signal();
+        }
+    }
+
+    type Stripe = Arc<Mutex<FactStripeCore<K, LoomWaiter>>>;
+
+    fn new_stripe() -> Stripe {
+        Arc::new(Mutex::new(FactStripeCore::<K, LoomWaiter>::new()))
+    }
+
+    // Model 1: leader election uniqueness.
+    // Two threads concurrently `try_register` the same key on an empty
+    // stripe. Exactly one must become Leading; the other becomes Joined.
+    #[test]
+    fn loom_leader_election_is_unique() {
+        loom::model(|| {
+            let stripe = new_stripe();
+
+            let s1 = stripe.clone();
+            let t1 = thread::spawn(move || {
+                let w = LoomWaiter::new();
+                let stored = w.clone();
+                let mut g = s1.lock().unwrap();
+                g.try_register::<_, LoomWaiter>(&K(1), || (stored, w))
+            });
+
+            let s2 = stripe.clone();
+            let t2 = thread::spawn(move || {
+                let w = LoomWaiter::new();
+                let stored = w.clone();
+                let mut g = s2.lock().unwrap();
+                g.try_register::<_, LoomWaiter>(&K(1), || (stored, w))
+            });
+
+            let r1 = t1.join().unwrap();
+            let r2 = t2.join().unwrap();
+
+            let leading = matches!(r1, Registration::Leading) as u8
+                + matches!(r2, Registration::Leading) as u8;
+            assert_eq!(
+                leading, 1,
+                "exactly one of the two registrations must become Leading"
+            );
+        });
+    }
+
+    // Model 2: waiters are woken on finish.
+    // The main thread pre-claims leader so the waiter thread always sees
+    // Joined or Cached (this isolates the wake-up invariant from leader
+    // election, which model 1 covers). If the joiner registers before the
+    // finisher runs, finish must wake its waiter.
+    #[test]
+    fn loom_waiters_woken_on_finish() {
+        loom::model(|| {
+            let stripe = new_stripe();
+            {
+                let mut g = stripe.lock().unwrap();
+                let outcome = g.try_register::<_, LoomWaiter>(&K(1), || {
+                    unreachable!("first try_register must be Leading")
+                });
+                assert!(matches!(outcome, Registration::Leading));
+            }
+
+            let s1 = stripe.clone();
+            let waiter = LoomWaiter::new();
+            let waiter_for_thread = waiter.clone();
+            let joined = Arc::new(AtomicBool::new(false));
+            let joined_for_thread = joined.clone();
+            let t1 = thread::spawn(move || {
+                let stored = waiter_for_thread.clone();
+                let receiver = waiter_for_thread.clone();
+                let mut g = s1.lock().unwrap();
+                let outcome = g.try_register::<_, LoomWaiter>(&K(1), || (stored, receiver));
+                if matches!(outcome, Registration::Joined(_)) {
+                    joined_for_thread.store(true, Ordering::Release);
+                }
+            });
+
+            let s2 = stripe.clone();
+            let t2 = thread::spawn(move || {
+                let waiters = {
+                    let mut g = s2.lock().unwrap();
+                    g.finish(K(1), FactLoadResult::Found(7))
+                };
+                signal_all(waiters);
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            if joined.load(Ordering::Acquire) {
+                assert!(
+                    waiter.is_signaled(),
+                    "a waiter that registered before finish must be signaled"
+                );
+            } else {
+                // The joiner ran after finish: it saw Cached and was not
+                // stored as a waiter. The cache holds the value.
+                let cached = stripe
+                    .lock()
+                    .unwrap()
+                    .peek_cache(&K(1))
+                    .expect("finish writes cache");
+                match cached {
+                    FactLoadResult::Found(v) => assert_eq!(v, 7),
+                    other => panic!("expected Found(7), got {other:?}"),
+                }
+            }
+        });
+    }
+
+    // Model 3: cancellation is fail-closed.
+    // Leader pre-claimed; one thread joins, another finishes with
+    // LoaderCancelled (simulating `InFlightGuard::drop`). If the joiner
+    // registered first, its waiter is signaled. The cache holds
+    // LoaderCancelled either way.
+    #[test]
+    fn loom_cancellation_is_fail_closed() {
+        loom::model(|| {
+            let stripe = new_stripe();
+            {
+                let mut g = stripe.lock().unwrap();
+                let outcome = g.try_register::<_, LoomWaiter>(&K(1), || unreachable!());
+                assert!(matches!(outcome, Registration::Leading));
+            }
+
+            let s1 = stripe.clone();
+            let waiter = LoomWaiter::new();
+            let waiter_for_thread = waiter.clone();
+            let joined = Arc::new(AtomicBool::new(false));
+            let joined_for_thread = joined.clone();
+            let t1 = thread::spawn(move || {
+                let stored = waiter_for_thread.clone();
+                let receiver = waiter_for_thread.clone();
+                let mut g = s1.lock().unwrap();
+                let outcome = g.try_register::<_, LoomWaiter>(&K(1), || (stored, receiver));
+                if matches!(outcome, Registration::Joined(_)) {
+                    joined_for_thread.store(true, Ordering::Release);
+                }
+            });
+
+            let s2 = stripe.clone();
+            let t2 = thread::spawn(move || {
+                let waiters = {
+                    let mut g = s2.lock().unwrap();
+                    g.finish(
+                        K(1),
+                        FactLoadResult::Error(FactLoadError::LoaderCancelled {
+                            fact_name: K::NAME,
+                        }),
+                    )
+                };
+                signal_all(waiters);
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            if joined.load(Ordering::Acquire) {
+                assert!(
+                    waiter.is_signaled(),
+                    "a waiter that joined before cancellation must be signaled"
+                );
+            }
+            let cached = stripe
+                .lock()
+                .unwrap()
+                .peek_cache(&K(1))
+                .expect("finish writes cache");
+            match cached {
+                FactLoadResult::Error(FactLoadError::LoaderCancelled { .. }) => {}
+                other => panic!("expected LoaderCancelled, got {other:?}"),
+            }
+        });
+    }
+
+    // Model 4: cache write is visible to a concurrent peek.
+    // One thread finishes (cache write under the mutex). Another peeks.
+    // Either order is legal; the observation is never a torn read.
+    #[test]
+    fn loom_cache_write_is_visible_to_concurrent_peek() {
+        loom::model(|| {
+            let stripe = new_stripe();
+
+            let s1 = stripe.clone();
+            let t1 = thread::spawn(move || {
+                let waiters = {
+                    let mut g = s1.lock().unwrap();
+                    g.finish(K(1), FactLoadResult::Found(99))
+                };
+                signal_all(waiters);
+            });
+
+            let s2 = stripe.clone();
+            let t2 = thread::spawn(move || -> Option<FactLoadResult<u32>> {
+                let g = s2.lock().unwrap();
+                g.peek_cache(&K(1))
+            });
+
+            t1.join().unwrap();
+            let observed = t2.join().unwrap();
+            match observed {
+                None => {}
+                Some(FactLoadResult::Found(v)) => assert_eq!(v, 99),
+                other => panic!("unexpected cache observation: {other:?}"),
+            }
+        });
+    }
+
+    /// Tiny adapter mirroring `FactState::insert_source` / `plan_loads` for
+    /// the source-vs-planner models below. One stripe is enough to exercise
+    /// the source-held-across-planning discipline; production has 64.
+    struct LoomAdapter {
+        source: Mutex<Option<u32>>,
+        stripe: Mutex<FactStripeCore<K, LoomWaiter>>,
+    }
+
+    impl LoomAdapter {
+        fn new(initial_source: Option<u32>) -> Self {
+            Self {
+                source: Mutex::new(initial_source),
+                stripe: Mutex::new(FactStripeCore::new()),
+            }
+        }
+
+        /// Plan-equivalent: snapshot source, peek cache. The source lock is
+        /// held while peeking — the same discipline as
+        /// `FactState::plan_loads` — so replacement either fully precedes
+        /// or fully follows the planning observation.
+        fn plan(&self, key: &K) -> (Option<u32>, Option<FactLoadResult<u32>>) {
+            let source_guard = self.source.lock().unwrap();
+            let source = *source_guard;
+            let stripe = self.stripe.lock().unwrap();
+            let cached = stripe.peek_cache(key);
+            (source, cached)
+        }
+
+        /// Replace-equivalent: acquire source, then stripe, check idle, swap,
+        /// clear cache, atomically.
+        fn replace(&self, new_source: u32) -> bool {
+            let mut source_guard = self.source.lock().unwrap();
+            let mut stripe_guard = self.stripe.lock().unwrap();
+            if !stripe_guard.is_idle() {
+                return false;
+            }
+            *source_guard = Some(new_source);
+            stripe_guard.clear_cache();
+            true
+        }
+
+        /// Single-threaded test setup helper. Not part of the modeled
+        /// protocol; runs before any thread is spawned.
+        fn seed_cache(&self, key: K, value: u32) {
+            let mut stripe = self.stripe.lock().unwrap();
+            let outcome = stripe.try_register::<_, LoomWaiter>(&key, || unreachable!());
+            assert!(matches!(outcome, Registration::Leading));
+            stripe.finish(key, FactLoadResult::Found(value));
+        }
+    }
+
+    // Model 5: replacement is atomic w.r.t. planning.
+    // Setup: source = Some(1), cache has K(1) -> Found(100).
+    // Thread A plans; thread B replaces source with 2 (clearing cache).
+    // The only legal observations from A are:
+    //   * (Some(1), Some(Found(100))) — plan ran first
+    //   * (Some(2), None)             — replace ran first
+    // FORBIDDEN: (Some(2), Some(Found(100))) — new source + stale cache.
+    #[test]
+    fn loom_replacement_is_atomic_with_respect_to_planning() {
+        loom::model(|| {
+            let adapter = Arc::new(LoomAdapter::new(Some(1)));
+            adapter.seed_cache(K(1), 100);
+
+            let a1 = adapter.clone();
+            let t1 = thread::spawn(move || a1.plan(&K(1)));
+
+            let a2 = adapter.clone();
+            let t2 = thread::spawn(move || {
+                assert!(a2.replace(2));
+            });
+
+            let (source_seen, cached_seen) = t1.join().unwrap();
+            t2.join().unwrap();
+
+            match (source_seen, cached_seen) {
+                (Some(1), Some(FactLoadResult::Found(100))) => {}
+                (Some(2), None) => {}
+                other => panic!(
+                    "atomicity violation: planner observed {other:?}; \
+                     new source must never be paired with stale cache"
+                ),
+            }
+        });
+    }
+
+    // Model 6: idle replacement clears cache atomically.
+    // Same shape as model 5 but spelled out as "the cache is never a stale
+    // hit under the new source." Kept distinct so a regression to the
+    // clear_cache step is immediately attributable.
+    #[test]
+    fn loom_idle_replacement_clears_cache() {
+        loom::model(|| {
+            let adapter = Arc::new(LoomAdapter::new(Some(1)));
+            adapter.seed_cache(K(1), 200);
+
+            let a1 = adapter.clone();
+            let t1 = thread::spawn(move || {
+                assert!(a1.replace(2));
+            });
+
+            let a2 = adapter.clone();
+            let t2 = thread::spawn(move || a2.plan(&K(1)));
+
+            t1.join().unwrap();
+            let (source_seen, cached_seen) = t2.join().unwrap();
+
+            match (source_seen, cached_seen) {
+                (Some(2), None) => {}
+                (Some(1), Some(FactLoadResult::Found(200))) => {}
+                (Some(1), None) => {}
+                other => panic!("idle replacement broke atomicity: observed {other:?}"),
+            }
+        });
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,8 +1,11 @@
+mod core;
+
+use self::core::{FactStripeCore, Registration};
 use crate::{FactKey, FactLoadError, FactLoadResult, FactSource, FactSourceRegistrationError};
 use futures_channel::oneshot;
 use std::any::{Any, TypeId};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::hash::Hasher;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -10,6 +13,15 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use tracing::Instrument;
 
 const FACT_STATE_STRIPES: usize = 64;
+
+/// Production waiter type. The core stores these and the adapter signals
+/// them by sending `()` after releasing the surrounding stripe lock.
+type StripeWaiter = oneshot::Sender<()>;
+/// Receiver type returned to the joining caller. The caller awaits it after
+/// all stripe locks are released.
+type StripeReceiver = oneshot::Receiver<()>;
+/// Concrete instantiation of [`FactStripeCore`] used by the async adapter.
+type StripeCore<K> = FactStripeCore<K, StripeWaiter>;
 
 #[derive(Default)]
 struct EvaluationSessionInner {
@@ -23,27 +35,7 @@ where
     K: FactKey,
 {
     source: Mutex<Option<Arc<dyn FactSource<K>>>>,
-    stripes: Box<[Mutex<FactStripe<K>>]>,
-}
-
-struct FactStripe<K>
-where
-    K: FactKey,
-{
-    cache: HashMap<K, FactLoadResult<K::Value>>,
-    in_flight: HashMap<K, Vec<oneshot::Sender<()>>>,
-}
-
-impl<K> Default for FactStripe<K>
-where
-    K: FactKey,
-{
-    fn default() -> Self {
-        Self {
-            cache: HashMap::new(),
-            in_flight: HashMap::new(),
-        }
-    }
+    stripes: Box<[Mutex<StripeCore<K>>]>,
 }
 
 impl<K> FactState<K>
@@ -52,7 +44,7 @@ where
 {
     fn new(source: Option<Arc<dyn FactSource<K>>>) -> Self {
         let stripes = (0..FACT_STATE_STRIPES)
-            .map(|_| Mutex::new(FactStripe::default()))
+            .map(|_| Mutex::new(StripeCore::<K>::new()))
             .collect();
 
         Self {
@@ -61,6 +53,20 @@ where
         }
     }
 
+    // LOCK ORDER: source -> stripes (in index order).
+    //
+    // Source registration and replacement acquire the source mutex first,
+    // then all stripe mutexes in index order, before checking in-flight
+    // state, swapping the source, and clearing per-stripe caches. The whole
+    // sequence is one critical section. This is the invariant from #18 / #26:
+    // a concurrent planner holding the source mutex cannot observe
+    // new-source-with-stale-cache, and a replacement is rejected while any
+    // stripe still has in-flight loaders.
+    //
+    // Readers (`plan_loads`) acquire the source mutex first, then one stripe
+    // at a time. Single-stripe operations (`finish_keys`, `results_from_cache`)
+    // take no source lock. The core itself holds no locks and contains no
+    // `.await`; signaling happens outside the stripe lock.
     fn insert_source(
         &self,
         source: Arc<dyn FactSource<K>>,
@@ -76,18 +82,18 @@ where
             return Err(FactSourceRegistrationError::AlreadyRegistered { fact_name: K::NAME });
         }
 
-        if stripes.iter().any(|stripe| !stripe.in_flight.is_empty()) {
+        if stripes.iter().any(|stripe| !stripe.is_idle()) {
             return Err(FactSourceRegistrationError::InFlight { fact_name: K::NAME });
         }
 
         *source_guard = Some(source);
         for stripe in &mut stripes {
-            stripe.cache.clear();
+            stripe.clear_cache();
         }
         Ok(())
     }
 
-    fn lock_stripes(&self) -> Vec<MutexGuard<'_, FactStripe<K>>> {
+    fn lock_stripes(&self) -> Vec<MutexGuard<'_, StripeCore<K>>> {
         self.stripes
             .iter()
             .map(|stripe| {
@@ -105,24 +111,25 @@ where
     }
 
     fn plan_loads(&self, keys: &[K]) -> LoadPlan<K> {
+        // Precompute stripe indices BEFORE acquiring any locks. `K::hash` may
+        // be user code with arbitrary cost; computing it outside the critical
+        // section preserves the invariant that an expensive or blocking hash
+        // for one key does not contend with planning for unrelated keys.
         let key_stripes = keys
             .iter()
             .map(|key| self.stripe_index(key))
             .collect::<Vec<_>>();
-        let mut seen = HashSet::new();
-        let unique_keys = keys
-            .iter()
-            .zip(key_stripes.iter().copied())
-            .filter(|(key, _)| seen.insert((*key).clone()))
-            .map(|(key, stripe_index)| (key.clone(), stripe_index))
-            .collect::<Vec<_>>();
 
+        // Source mutex is held across the whole planning step so that source
+        // resolution, cache lookup, and in-flight registration are atomic
+        // relative to a concurrent `insert_source` (see LOCK ORDER above).
         let source_guard = self
             .source
             .lock()
             .expect("fact source mutex should not be poisoned");
         let source = source_guard.clone();
 
+        // Fast path: every input key already cached.
         let cached_results = keys
             .iter()
             .zip(key_stripes.iter().copied())
@@ -130,7 +137,7 @@ where
                 let stripe = self.stripes[stripe_index]
                     .lock()
                     .expect("fact state stripe mutex should not be poisoned");
-                stripe.cache.get(key).cloned()
+                stripe.peek_cache(key)
             })
             .collect::<Option<Vec<_>>>();
 
@@ -143,61 +150,59 @@ where
             };
         }
 
-        let mut missing = Vec::new();
+        // Slow path: dedupe and register interest per unique key.
+        let mut seen = std::collections::HashSet::new();
+        let mut leader_keys = Vec::new();
         let mut waiters = Vec::new();
 
-        for (key, stripe_index) in unique_keys {
+        for (key, stripe_index) in keys.iter().zip(key_stripes.iter().copied()) {
+            if !seen.insert(key.clone()) {
+                continue;
+            }
             let mut stripe = self.stripes[stripe_index]
                 .lock()
                 .expect("fact state stripe mutex should not be poisoned");
-
-            if stripe.cache.contains_key(&key) {
-                continue;
-            }
-
-            if let Some(existing_waiters) = stripe.in_flight.get_mut(&key) {
+            match stripe.try_register::<_, StripeReceiver>(key, || {
                 let (sender, receiver) = oneshot::channel();
-                existing_waiters.push(sender);
-                waiters.push(receiver);
-            } else {
-                stripe.in_flight.insert(key.clone(), Vec::new());
-                missing.push(key.clone());
+                (sender, receiver)
+            }) {
+                Registration::Cached(_) => {
+                    // Already cached; `results_from_cache` will pick it up at
+                    // the end of `get_many`.
+                }
+                Registration::Leading => leader_keys.push(key.clone()),
+                Registration::Joined(receiver) => waiters.push(receiver),
             }
         }
 
         LoadPlan {
             source,
             cached_results: None,
-            keys: missing,
+            keys: leader_keys,
             waiters,
         }
     }
 
-    fn finish_in_flight(&self, keys: &[K]) {
-        let mut waiters = Vec::new();
-
-        for key in keys {
-            let stripe_index = self.stripe_index(key);
-            let mut stripe = self.stripes[stripe_index]
-                .lock()
-                .expect("fact state stripe mutex should not be poisoned");
-            if let Some(key_waiters) = stripe.in_flight.remove(key) {
-                waiters.extend(key_waiters);
-            }
-        }
-
-        for waiter in waiters {
-            let _ = waiter.send(());
-        }
-    }
-
-    fn cache_loaded(&self, keys: &[K], results: Vec<FactLoadResult<K::Value>>) {
-        for (key, result) in keys.iter().cloned().zip(results) {
+    /// Cache results for `keys` and signal any registered waiters.
+    ///
+    /// Cache writes and waiter removal happen under per-stripe locks; signals
+    /// fire after all stripe locks have been released, matching the prior
+    /// behavior of separate `cache_loaded` + `finish_in_flight` calls.
+    fn finish_keys(&self, keys: &[K], results: Vec<FactLoadResult<K::Value>>) {
+        debug_assert_eq!(keys.len(), results.len());
+        let mut all_waiters = Vec::new();
+        for (key, result) in keys.iter().cloned().zip(results.into_iter()) {
             let stripe_index = self.stripe_index(&key);
-            let mut stripe = self.stripes[stripe_index]
-                .lock()
-                .expect("fact state stripe mutex should not be poisoned");
-            stripe.cache.insert(key, result);
+            let waiters = {
+                let mut stripe = self.stripes[stripe_index]
+                    .lock()
+                    .expect("fact state stripe mutex should not be poisoned");
+                stripe.finish(key, result)
+            };
+            all_waiters.extend(waiters);
+        }
+        for waiter in all_waiters {
+            let _ = waiter.send(());
         }
     }
 
@@ -208,7 +213,7 @@ where
                 let stripe = self.stripes[stripe_index]
                     .lock()
                     .expect("fact state stripe mutex should not be poisoned");
-                stripe.cache.get(key).cloned().unwrap_or_else(|| {
+                stripe.peek_cache(key).unwrap_or_else(|| {
                     FactLoadResult::Error(FactLoadError::SourceContractViolation {
                         fact_name: K::NAME,
                         expected: 1,
@@ -227,6 +232,13 @@ where
 /// is deliberately not process-global. Cached facts and cached errors are
 /// dropped with the session, so permission revocations or backend changes are
 /// observed by the next request's session rather than being held process-wide.
+///
+/// There is intentionally no time-based (TTL) cache: freshness is governed by
+/// session lifetime — drop the session to drop its cache. If you need caching
+/// that outlives a single session (a process-wide cache with a TTL, say), layer
+/// it inside a [`FactSource`] implementation. A source can hold its own
+/// expiring cache and be shared across sessions via [`Self::register_arc`],
+/// which keeps the session a simple request-scoped layer on top.
 #[derive(Clone, Default)]
 pub struct EvaluationSession {
     inner: Arc<EvaluationSessionInner>,
@@ -252,10 +264,20 @@ impl EvaluationSession {
     /// sources.
     ///
     /// This avoids allocating a new empty session for RBAC/ABAC-only checks in
-    /// tight loops such as fanout or SSE frame authorization. It is only safe
-    /// when no fact-backed policies are expected. Calling [`Self::register`],
-    /// [`Self::register_arc`], [`Self::replace`], or [`Self::replace_arc`] on
-    /// this session will panic.
+    /// tight loops. It is only safe when no fact-backed policies are expected:
+    /// calling [`Self::register`], [`Self::register_arc`], [`Self::replace`], or
+    /// [`Self::replace_arc`] on this session panics.
+    ///
+    /// The panic is deliberate. Registering on the shared handle is a
+    /// programming error, not a runtime condition — code that registers sources
+    /// should own a [`Self::new`] session, and this handle exists only for
+    /// fact-free hot paths. The non-panicking [`Self::try_register`] /
+    /// [`Self::try_replace`] family still returns
+    /// [`FactSourceRegistrationError::SharedEmptySession`] here rather than
+    /// panicking, for callers that want to handle it. A type-state split (a
+    /// separate "registrable" type) was considered but would push that
+    /// distinction into every signature that accepts a `&EvaluationSession`,
+    /// defeating the drop-in substitutability that makes this handle useful.
     pub fn shared_empty() -> &'static Self {
         static SHARED_EMPTY: OnceLock<EvaluationSession> = OnceLock::new();
         SHARED_EMPTY.get_or_init(|| EvaluationSession {
@@ -278,6 +300,12 @@ impl EvaluationSession {
     /// when replacing a source is intentional. Register sources during session
     /// setup; registering while loads for the same key type are in flight is
     /// not a supported operation and will panic.
+    ///
+    /// This panicking form is meant for session setup, where a failed
+    /// registration (a duplicate source, or a load already in flight) is a
+    /// configuration bug that should fail loudly and immediately. Use
+    /// [`Self::try_register`] when registration is driven by runtime input and
+    /// you want to handle [`FactSourceRegistrationError`] rather than panic.
     pub fn register<K, S>(&self, source: S)
     where
         K: FactKey,
@@ -292,6 +320,15 @@ impl EvaluationSession {
     /// during session setup; use [`Self::replace_arc`] only when overwriting is
     /// deliberate. Registering while loads for the same key type are in flight
     /// is not a supported operation and will panic.
+    ///
+    /// Use this form to share one source instance across many sessions: build
+    /// the `Arc` once and `Arc::clone` it into each request's session (see
+    /// [`EvaluationSessionBuilder::with_arc`]). [`Self::register`] takes the
+    /// source by value and wraps it in a fresh `Arc` per call, so it cannot
+    /// share a single instance; reach for `register_arc` when the source holds
+    /// expensive shared state such as a connection pool or its own cache. Like
+    /// [`Self::register`], it panics on invalid registration; use
+    /// [`Self::try_register_arc`] to handle the error instead.
     ///
     /// The registry is keyed by the exact Rust fact key type. If two production
     /// backends serve the same logical shape, such as the same
@@ -468,41 +505,40 @@ impl EvaluationSession {
                         fact.unique_key_count = chunk.len(),
                     );
                     let loaded = source.load_many(chunk).instrument(load_span).await;
-                    if loaded.len() == chunk.len() {
-                        state.cache_loaded(chunk, loaded);
+                    let results = if loaded.len() == chunk.len() {
+                        loaded
                     } else {
-                        state.cache_loaded(
-                            chunk,
-                            chunk
-                                .iter()
-                                .map(|_| {
-                                    FactLoadResult::Error(FactLoadError::SourceContractViolation {
-                                        fact_name: K::NAME,
-                                        expected: chunk.len(),
-                                        actual: loaded.len(),
-                                    })
+                        chunk
+                            .iter()
+                            .map(|_| {
+                                FactLoadResult::Error(FactLoadError::SourceContractViolation {
+                                    fact_name: K::NAME,
+                                    expected: chunk.len(),
+                                    actual: loaded.len(),
                                 })
-                                .collect(),
-                        );
-                    }
-                    // Keep this immediately after the cache write, with no await in between.
-                    // The drop guard treats remaining keys as cancelled.
-                    in_flight_guard.finish(chunk);
+                            })
+                            .collect()
+                    };
+                    // Cache writes + waiter wake-ups happen synchronously under
+                    // per-stripe locks via `finish_keys`. There is no `.await`
+                    // between the cache write and the waiter signal, so the
+                    // drop guard's cancellation cleanup only fires for keys
+                    // that have not yet been finished.
+                    state.finish_keys(chunk, results);
+                    in_flight_guard.mark_finished(chunk);
                 }
             } else {
-                state.cache_loaded(
-                    &load_plan.keys,
-                    load_plan
-                        .keys
-                        .iter()
-                        .map(|_| {
-                            FactLoadResult::Error(FactLoadError::SourceNotRegistered {
-                                fact_name: K::NAME,
-                            })
+                let results = load_plan
+                    .keys
+                    .iter()
+                    .map(|_| {
+                        FactLoadResult::Error(FactLoadError::SourceNotRegistered {
+                            fact_name: K::NAME,
                         })
-                        .collect(),
-                );
-                in_flight_guard.finish(&load_plan.keys);
+                    })
+                    .collect();
+                state.finish_keys(&load_plan.keys, results);
+                in_flight_guard.mark_finished(&load_plan.keys);
             }
         }
 
@@ -602,13 +638,16 @@ where
         }
     }
 
-    fn finish(&mut self, keys: &[K]) {
-        self.state.finish_in_flight(keys);
+    /// Mark `keys` as finished by the leader so the drop guard does not
+    /// re-finish them with `LoaderCancelled` on cancellation.
+    fn mark_finished(&mut self, keys: &[K]) {
         if self.remaining.is_empty() {
             return;
         }
-
-        let finished = keys.iter().cloned().collect::<HashSet<_>>();
+        let finished = keys
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
         self.remaining.retain(|key| !finished.contains(key));
     }
 }
@@ -621,16 +660,11 @@ where
         if self.remaining.is_empty() {
             return;
         }
-
-        self.state.cache_loaded(
-            &self.remaining,
-            self.remaining
-                .iter()
-                .map(|_| {
-                    FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name: K::NAME })
-                })
-                .collect(),
-        );
-        self.state.finish_in_flight(&self.remaining);
+        let cancelled = std::mem::take(&mut self.remaining);
+        let results = cancelled
+            .iter()
+            .map(|_| FactLoadResult::Error(FactLoadError::LoaderCancelled { fact_name: K::NAME }))
+            .collect();
+        self.state.finish_keys(&cancelled, results);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -189,9 +189,19 @@ where
     /// fire after all stripe locks have been released, matching the prior
     /// behavior of separate `cache_loaded` + `finish_in_flight` calls.
     fn finish_keys(&self, keys: &[K], results: Vec<FactLoadResult<K::Value>>) {
-        debug_assert_eq!(keys.len(), results.len());
+        // assert (not debug_assert) so a release-mode mismatch can never
+        // strand waiters: if a caller passed unequal-length slices the
+        // shorter `zip` below would silently finish only the prefix while
+        // the caller's `InFlightGuard::mark_finished` cleared the whole
+        // chunk from `remaining`, leaving the unfinished tails as in-flight
+        // entries with no one to wake them.
+        assert_eq!(
+            keys.len(),
+            results.len(),
+            "finish_keys requires equal-length keys and results"
+        );
         let mut all_waiters = Vec::new();
-        for (key, result) in keys.iter().cloned().zip(results.into_iter()) {
+        for (key, result) in keys.iter().cloned().zip(results) {
             let stripe_index = self.stripe_index(&key);
             let waiters = {
                 let mut stripe = self.stripes[stripe_index]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -264,7 +264,41 @@ mod core_tests {
         }
     }
 
+    /// Permissive no-op global subscriber. Installed once on first use so the
+    /// process-wide tracing callsite cache locks in `Interest::sometimes` for
+    /// every callsite. Without this, a parallel test thread that hits a
+    /// tracing callsite before any subscriber is installed will poison the
+    /// cache with `Interest::never`, and later threads using
+    /// `with_default(...)` see zero events. This is the standard flake in
+    /// tracing tests under parallel execution.
+    struct PermissiveNoop;
+    impl Subscriber for PermissiveNoop {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, _: &Event<'_>) {}
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    fn install_permissive_global() {
+        use std::sync::Once;
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            // Ignore the result: another crate may have already installed a
+            // global. In that case the existing one is responsible for the
+            // callsite-cache behavior; if it is also permissive, all good.
+            let _ = tracing::subscriber::set_global_default(PermissiveNoop);
+        });
+    }
+
     fn with_recorded_events<T>(f: impl FnOnce() -> T) -> (T, Vec<RecordedEvent>) {
+        install_permissive_global();
         let recorder = EventRecorder::default();
         let events = recorder.events.clone();
         let subscriber = Registry::default().with(recorder);

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -168,11 +168,41 @@ impl Visit for FieldValues {
     }
 }
 
+/// Permissive no-op global subscriber. Installed once on first call to
+/// `capture_async` so the process-wide tracing callsite cache locks in
+/// `Interest::sometimes` for every callsite. Without this, a parallel test
+/// thread that hits a tracing callsite before any subscriber is installed
+/// will poison the cache with `Interest::never`, and later threads using
+/// `with_default(...)` see zero spans/events.
+struct PermissiveNoop;
+impl Subscriber for PermissiveNoop {
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+    fn record(&self, _: &Id, _: &Record<'_>) {}
+    fn record_follows_from(&self, _: &Id, _: &Id) {}
+    fn event(&self, _: &tracing::Event<'_>) {}
+    fn enter(&self, _: &Id) {}
+    fn exit(&self, _: &Id) {}
+}
+
+fn install_permissive_global() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = tracing::subscriber::set_global_default(PermissiveNoop);
+    });
+}
+
 fn capture_async<F, Fut, T>(f: F) -> (T, Vec<CapturedSpan>)
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = T>,
 {
+    install_permissive_global();
     let captured = CapturedSpans::default();
     let subscriber = Registry::default().with(CaptureLayer {
         spans: captured.clone(),


### PR DESCRIPTION
Closes #28. Closes #29.

## Summary

- **#28 (Sans-I/O extraction).** The per-stripe session state machine is now a private synchronous core, `FactStripeCore<K, W>`, with no async, no `.await`, no `FactSource`, no Tokio, no concrete channel type, and no tracing. `FactState<K>` remains the async adapter that owns the locks, the source, and tracing around `FactSource::load_many(...).await`. Public API is unchanged.
- **#29 (Loom harness).** Six `loom::model` permutation tests assert the named invariants under every legal thread interleaving. The harness lives in `src/session/core.rs` under `#[cfg(loom)] mod loom_tests`.

## What landed

| File | What |
|------|------|
| `src/session/core.rs` (new) | Sync core + 9 deterministic unit tests + 6 loom models |
| `src/session/mod.rs` (renamed from `src/session.rs`) | Async adapter, now layered over the core; `LOCK ORDER` comment added |
| `Cargo.toml` | Tokio-using dev-deps gated on `cfg(not(loom))`; `loom = \"0.7\"` under `cfg(loom)`; `check-cfg` for `cfg(loom)` |
| `src/lib.rs` | Gate the shared tests module on `cfg(all(test, not(loom)))` so the loom build's dep graph stays minimal |
| `.github/workflows/ci.yml` | New `loom-tests` job running `RUSTFLAGS=\"--cfg loom\" cargo test --lib --release` |
| `CHANGELOG.md` | New `[Unreleased]` entries for the refactor and the loom harness |

## Core API (`pub(super)`, private to the session module)

```rust
struct FactStripeCore<K: FactKey, W> { /* cache + in_flight */ }

enum Registration<V, R> { Cached(FactLoadResult<V>), Leading, Joined(R) }

fn peek_cache(&self, key: &K) -> Option<FactLoadResult<K::Value>>;
fn try_register<F, R>(&mut self, key: &K, make_pair: F) -> Registration<K::Value, R>
  where F: FnOnce() -> (W, R);
fn finish(&mut self, key: K, result: FactLoadResult<K::Value>) -> Vec<W>;
fn is_idle(&self) -> bool;
fn clear_cache(&mut self);
```

Six methods. `try_register`'s closure is invoked only on the `Joined` branch, so the channel/waiter pair is never allocated on `Cached` or `Leading`. The adapter signals the returned waiters outside the stripe lock.

## Adapter discipline preserved

- `LOCK ORDER: source -> stripes (in index order)` is documented inline at the top of `FactState`'s impl block.
- `insert_source` acquires source + all stripes in one critical section before checking in-flight, swapping, and clearing. The #18/#26 invariant — no new-source-with-stale-cache — holds unchanged.
- `plan_loads` precomputes stripe indices **before** acquiring any lock so a slow user-defined `Hash` implementation does not contend with planning for unrelated keys. (Caught early by the existing `unrelated_fact_keys_do_not_contend_on_one_session_lock` test, which uses a `Condvar` inside `Hash`.)
- No `.await` while holding the source mutex or any stripe mutex.

## Loom models

1. **Leader-election uniqueness** — two threads `try_register` the same uncached key; exactly one becomes `Leading`.
2. **Waiters woken on `finish`** — a registered waiter sees its signal flag set after the leader finishes; both interleavings (joiner before/after finish) are explored.
3. **Cancellation is fail-closed** — `finish(key, LoaderCancelled)` caches the error and wakes any joined waiter.
4. **Cache writes visible to concurrent `peek_cache`** — never observes a torn read; either `None` or the full `Found(v)`.
5. **Replacement atomic w.r.t. planning** — planner observes either `(old source, old cache)` or `(new source, empty cache)`, never `(new source, old cache)`.
6. **Idle replacement clears cache** — same atomicity restated for the cleared-cache observation.

Models 5 and 6 use a tiny adapter mirror (`LoomAdapter`) with one stripe to model the source-vs-stripe lock dance without depending on the production adapter's runtime types.

## Harness regression confirmation

During development I introduced a temporary bug in `FactStripeCore::finish` (skip the cache write). Loom + the deterministic tests caught it:

- **Loom models failed:** `loom_replacement_is_atomic_with_respect_to_planning`, `loom_cancellation_is_fail_closed`, `loom_waiters_woken_on_finish`
- **Deterministic tests failed:** 7 of 9

Reverted before commit. The model set is real, not symbolic.

## What loom does not cover

Explicit in the file's top-of-module doc comment, and worth restating here:

- The async adapter end-to-end. Loom cannot model `tokio::sync::oneshot` or the runtime; the harness substitutes a loom-friendly waiter.
- Tracing spans, fact-load IDs, or chunking. Those are exercised by the existing async integration tests.
- Deep preemption sequences. Models bound to 2 threads and 1-2 keys for tractability.

## Validation

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --all-targets --all-features` ✓ (162 tests, 9 of them new in the core)
- `cargo doc --all-features --no-deps` ✓
- `RUSTFLAGS=\"--cfg loom\" cargo test --lib --release` ✓ (15 tests: 9 deterministic + 6 loom models, ~0.01s)

## Notes for reviewers

- This PR is stacked over `main` post 0.3.0-alpha.1. It does not touch the v0.3 public API; the only `src/lib.rs` change is the `cfg(loom)` gate on the shared tests module.
- The provenance work being added in parallel (`chore/fact-provenance-and-authz-docs`) is intentionally not part of this PR.