### PR TITLE
Add lookup-style authorization for 'what can this subject see?'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `LookupSource` and `Hydrator` traits plus `PermissionChecker::lookup_authorized` and `lookup_authorized_page` for "what can this subject see?" list endpoints. The source enumerates a candidate superset; the hydrator resolves IDs to caller-owned resources (with explicit "no longer exists" via `Option<Resource>`); the full policy stack still authorizes each hydrated candidate. Cursor-progress is enforced (no infinite loops on stuck sources). See `examples/lookup_in_ram.rs`. (#24)
+
 ### Changed
 
 - Internal refactor: the per-stripe session state machine is now a private synchronous core (`FactStripeCore<K, W>`) with no async, no tracing, and a generic waiter type. `FactState<K>` remains the async adapter that owns locks, the source, and tracing. No public API change. (#28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Tests
 
-- Loom permutation-test harness for the session fact-load state machine. Six models cover leader-election uniqueness, waiter wake-up, fail-closed cancellation, cache-write visibility, replacement atomicity, and idle cache clearing. Run under `RUSTFLAGS="--cfg loom" cargo test --lib --release` and as a separate CI job. (#29)
+- Loom permutation-test harness for the session fact-load state machine. Seven models cover leader-election uniqueness, exactly-once waiter wake-up on finish, fail-closed cancellation, cache-write visibility, replacement atomicity w.r.t. planning, multi-stripe independence, and replacement rejection while a leader is in flight. Run under `RUSTFLAGS="--cfg loom" cargo test --lib --release` and as a separate CI job. (#29)
 
 ## [0.3.0-alpha.1] - 2026-05-27
 

--- a/examples/lookup_in_ram.rs
+++ b/examples/lookup_in_ram.rs
@@ -1,0 +1,328 @@
+//! Lookup-style authorization with an in-memory backend.
+//!
+//! Demonstrates `PermissionChecker::lookup_authorized*` against an in-RAM
+//! `LookupSource` and a `Hydrator`, composed with a non-lookup policy
+//! (admin override) — the production shape #24 was scoped to enable.
+//!
+//! Domain: a notebook app where a user can list "documents I can see."
+//! Visibility paths:
+//!   - the user is a registered viewer (a relationship, enumerable per user)
+//!   - the user is a global admin (a non-lookup grant axis)
+//!
+//! The `LookupSource` enumerates the viewer relationship only. Admin
+//! overrides are still authorized through the policy stack: an admin's
+//! lookup-driven listing returns the viewer-visible subset, while a point
+//! check on any document returns Granted by the admin axis. The example
+//! prints both so the difference is visible.
+
+use async_trait::async_trait;
+use gatehouse::{
+    EvalCtx, EvaluationSession, LookupPage, LookupSource, PermissionChecker, Policy,
+    PolicyEvalResult,
+};
+use std::collections::HashMap;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// --- Domain ------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct User {
+    id: Uuid,
+    is_admin: bool,
+}
+
+#[derive(Clone, Debug)]
+struct Document {
+    id: Uuid,
+    title: String,
+}
+
+#[derive(Clone, Debug)]
+struct View;
+
+#[derive(Clone, Debug)]
+struct RequestCtx;
+
+// --- Policies ----------------------------------------------------------
+
+/// Grants admins access to any document, regardless of relationships.
+struct AdminPolicy;
+
+#[async_trait]
+impl Policy<User, Document, View, RequestCtx> for AdminPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, User, Document, View, RequestCtx>,
+    ) -> PolicyEvalResult {
+        if ctx.subject.is_admin {
+            PolicyEvalResult::Granted {
+                policy_type: self.policy_type().to_string(),
+                reason: Some("admin override".into()),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: self.policy_type().to_string(),
+                reason: "not admin".into(),
+            }
+        }
+    }
+    fn policy_type(&self) -> &str {
+        "AdminPolicy"
+    }
+}
+
+/// Grants when the user is registered as a viewer of the document.
+/// Matched against the same relationships the lookup source enumerates.
+struct ViewerPolicy {
+    viewers: HashMap<Uuid, Vec<Uuid>>, // doc_id -> users with viewer relation
+}
+
+#[async_trait]
+impl Policy<User, Document, View, RequestCtx> for ViewerPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, User, Document, View, RequestCtx>,
+    ) -> PolicyEvalResult {
+        let granted = self
+            .viewers
+            .get(&ctx.resource.id)
+            .map(|users| users.contains(&ctx.subject.id))
+            .unwrap_or(false);
+        if granted {
+            PolicyEvalResult::Granted {
+                policy_type: self.policy_type().to_string(),
+                reason: Some("viewer relation".into()),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: self.policy_type().to_string(),
+                reason: "no viewer relation".into(),
+            }
+        }
+    }
+    fn policy_type(&self) -> &str {
+        "ViewerPolicy"
+    }
+}
+
+// --- LookupSource ------------------------------------------------------
+
+/// Enumerates the documents `user` is registered as a viewer of, in a
+/// stable per-subject order. Pages by offset; cursor is the next offset
+/// rendered as ASCII bytes.
+///
+/// In a real backend this would be `SELECT doc_id FROM viewers WHERE
+/// user_id = $1 ORDER BY doc_id LIMIT $2 OFFSET decode($3)`.
+struct InMemoryViewerLookup {
+    per_user: HashMap<Uuid, Vec<Uuid>>,
+}
+
+#[derive(Debug)]
+struct ViewerLookupError(String);
+impl fmt::Display for ViewerLookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for ViewerLookupError {}
+
+#[async_trait]
+impl LookupSource for InMemoryViewerLookup {
+    type Subject = User;
+    type Id = Uuid;
+    type Error = ViewerLookupError;
+
+    async fn lookup_page(
+        &self,
+        subject: &User,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+    ) -> Result<LookupPage<Uuid>, ViewerLookupError> {
+        let offset = cursor
+            .map(|c| {
+                std::str::from_utf8(c)
+                    .map_err(|_| ViewerLookupError("non-utf8 cursor".into()))
+                    .and_then(|s| {
+                        s.parse::<usize>()
+                            .map_err(|_| ViewerLookupError("cursor not a number".into()))
+                    })
+            })
+            .transpose()?
+            .unwrap_or(0);
+
+        let all = self.per_user.get(&subject.id).cloned().unwrap_or_default();
+
+        if offset >= all.len() {
+            return Ok(LookupPage {
+                ids: Vec::new(),
+                next_cursor: None,
+            });
+        }
+        let end = (offset + limit.get()).min(all.len());
+        let next_cursor = (end < all.len()).then(|| end.to_string().into_bytes());
+        Ok(LookupPage {
+            ids: all[offset..end].to_vec(),
+            next_cursor,
+        })
+    }
+}
+
+// --- Wiring + main -----------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    // Build a small population.
+    let alice = User {
+        id: Uuid::new_v4(),
+        is_admin: false,
+    };
+    let admin = User {
+        id: Uuid::new_v4(),
+        is_admin: true,
+    };
+    let docs: Vec<Document> = (0..7)
+        .map(|i| Document {
+            id: Uuid::new_v4(),
+            title: format!("doc-{i}"),
+        })
+        .collect();
+
+    // Alice is a viewer of docs[1], docs[3], docs[5].
+    let viewer_doc_ids: Vec<Uuid> = [&docs[1], &docs[3], &docs[5]]
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
+
+    let viewers: HashMap<Uuid, Vec<Uuid>> = viewer_doc_ids
+        .iter()
+        .map(|doc_id| (*doc_id, vec![alice.id]))
+        .collect();
+
+    let viewer_lookup_index: HashMap<Uuid, Vec<Uuid>> =
+        HashMap::from([(alice.id, viewer_doc_ids.clone())]);
+
+    // Document catalog used by the hydrator. In production this is a
+    // database call: `SELECT * FROM docs WHERE id = ANY($1)`.
+    let catalog: Arc<HashMap<Uuid, Document>> =
+        Arc::new(docs.iter().map(|d| (d.id, d.clone())).collect());
+
+    let lookup = InMemoryViewerLookup {
+        per_user: viewer_lookup_index,
+    };
+
+    // Hydrator closure: maps a slice of ids to `Vec<Option<Document>>`.
+    // `None` would represent an id deleted between enumeration and the
+    // catalog fetch; the in-memory catalog here always resolves.
+    let hydrator = {
+        let catalog = Arc::clone(&catalog);
+        move |ids: &[Uuid]| {
+            let catalog = Arc::clone(&catalog);
+            let ids = ids.to_vec();
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    ids.iter().map(|id| catalog.get(id).cloned()).collect(),
+                )
+            }
+        }
+    };
+
+    // Compose policies: admin override OR viewer relation. The lookup
+    // source only enumerates the viewer axis — admin overrides apply only
+    // to point checks.
+    let mut checker = PermissionChecker::<User, Document, View, RequestCtx>::new();
+    checker.add_policy(AdminPolicy);
+    checker.add_policy(ViewerPolicy { viewers });
+
+    let session = EvaluationSession::empty();
+    let page_size = NonZeroUsize::new(2).unwrap();
+
+    // (1) Alice lists her visible documents via lookup_authorized.
+    let alice_visible = checker
+        .lookup_authorized(
+            &session,
+            &alice,
+            &View,
+            &RequestCtx,
+            &lookup,
+            page_size,
+            &hydrator,
+        )
+        .await
+        .expect("lookup ok");
+    println!("Alice sees {} document(s):", alice_visible.len());
+    for doc in &alice_visible {
+        println!("  - {} ({})", doc.title, doc.id);
+    }
+
+    // (2) Admin lists "their visible documents" via the same lookup.
+    // The viewer lookup does not enumerate documents for the admin (no
+    // viewer relation), so this listing returns empty — correctly,
+    // because lookup is bounded by what it enumerates. To enumerate
+    // "everything an admin can see", the production code would either
+    // route admin requests to a different source or simply skip the
+    // lookup path and list directly.
+    let admin_via_lookup = checker
+        .lookup_authorized(
+            &session,
+            &admin,
+            &View,
+            &RequestCtx,
+            &lookup,
+            page_size,
+            &hydrator,
+        )
+        .await
+        .expect("lookup ok");
+    println!(
+        "\nAdmin via the viewer-lookup sees {} document(s) — this is bounded \
+         by what the source enumerates; admin grants still apply at point checks.",
+        admin_via_lookup.len()
+    );
+
+    // (3) Point check confirms the admin policy is alive: pick a document
+    // the admin has no viewer relation on.
+    let any_doc = &docs[0];
+    let admin_point = checker
+        .evaluate_in_session(&session, &admin, &View, any_doc, &RequestCtx)
+        .await;
+    println!(
+        "\nAdmin point check on '{}': {}",
+        any_doc.title,
+        if admin_point.is_granted() {
+            "Granted"
+        } else {
+            "Denied"
+        }
+    );
+
+    // (4) Page-oriented streaming. Drive the lookup one candidate page at
+    // a time — useful when you want to flush results to a response writer
+    // as they are confirmed.
+    println!("\nStreaming Alice's visible documents page-by-page:");
+    let mut cursor: Option<Vec<u8>> = None;
+    let mut page_index = 0;
+    loop {
+        let page = checker
+            .lookup_authorized_page(
+                &session,
+                &alice,
+                &View,
+                &RequestCtx,
+                &lookup,
+                cursor.as_deref(),
+                page_size,
+                &hydrator,
+            )
+            .await
+            .expect("lookup_authorized_page ok");
+        println!("  page {page_index}: {} authorized", page.resources.len());
+        page_index += 1;
+        match page.next_cursor {
+            None => break,
+            Some(next) => cursor = Some(next),
+        }
+    }
+}

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AccessEvaluation, BatchEvalCtx, CombineOp, EvalCtx, EvalTrace, EvaluationSession, Policy,
-    PolicyBatchItem, PolicyEvalResult, DEFAULT_SECURITY_RULE_CATEGORY,
-    PERMISSION_CHECKER_POLICY_TYPE,
+    AccessEvaluation, BatchEvalCtx, CombineOp, EvalCtx, EvalTrace, EvaluationSession, Hydrator,
+    LookupAuthorizedError, LookupAuthorizedPage, LookupSource, Policy, PolicyBatchItem,
+    PolicyEvalResult, DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE,
 };
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -510,6 +510,162 @@ where
         .into_iter()
         .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
         .collect()
+    }
+
+    /// Look up one page of candidate IDs from `lookup`, hydrate them via
+    /// `hydrator`, and return only the resources that the full policy
+    /// stack authorizes.
+    ///
+    /// This is the page-oriented primitive behind
+    /// [`Self::lookup_authorized`]. Use it directly when you need
+    /// candidate-page-grained streaming — for example, a list endpoint
+    /// that emits results as they are confirmed without buffering the
+    /// whole authorized population.
+    ///
+    /// `next_cursor` paginates the **candidate** stream from `lookup`,
+    /// not the authorized output. A `Some(cursor)` with an empty
+    /// `resources` vector is normal: every candidate in this page was
+    /// denied by the policy stack. Continue paging until `next_cursor`
+    /// is `None`.
+    ///
+    /// See [`LookupSource`] for the completeness contract: the source
+    /// must enumerate a superset of every resource that any policy in
+    /// this checker could grant; lookup narrows the candidate set but
+    /// does not replace policy evaluation.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orchestration entry point: session + subject + action + context + lookup + \
+                  cursor + limit + hydrator are all genuinely independent inputs; bundling \
+                  them would obscure the call site without saving anything."
+    )]
+    pub async fn lookup_authorized_page<L, H>(
+        &self,
+        session: &EvaluationSession,
+        subject: &S,
+        action: &A,
+        context: &C,
+        lookup: &L,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+        hydrator: &H,
+    ) -> Result<LookupAuthorizedPage<R>, LookupAuthorizedError<L::Error, H::Error>>
+    where
+        L: LookupSource<Subject = S>,
+        H: Hydrator<L::Id, Resource = R>,
+        R: Send,
+    {
+        let lookup_span = tracing::debug_span!(
+            "gatehouse.lookup",
+            lookup.limit = limit.get(),
+            lookup.has_cursor = cursor.is_some(),
+        );
+        let page = lookup
+            .lookup_page(subject, cursor, limit)
+            .instrument(lookup_span)
+            .await
+            .map_err(LookupAuthorizedError::Lookup)?;
+
+        if page.ids.is_empty() {
+            return Ok(LookupAuthorizedPage {
+                resources: Vec::new(),
+                next_cursor: page.next_cursor,
+            });
+        }
+
+        let hydrate_span = tracing::debug_span!(
+            "gatehouse.hydrate",
+            hydrate.candidate_count = page.ids.len()
+        );
+        let hydrated = hydrator
+            .hydrate(&page.ids)
+            .instrument(hydrate_span)
+            .await
+            .map_err(LookupAuthorizedError::Hydrate)?;
+
+        if hydrated.len() != page.ids.len() {
+            return Err(LookupAuthorizedError::HydratorContractViolation {
+                expected: page.ids.len(),
+                actual: hydrated.len(),
+            });
+        }
+
+        let resources: Vec<R> = hydrated.into_iter().flatten().collect();
+        let authorized = self
+            .filter_authorized_with_context_in_session_by(
+                session,
+                subject,
+                action,
+                resources,
+                context,
+                |resource| resource,
+            )
+            .await;
+
+        Ok(LookupAuthorizedPage {
+            resources: authorized,
+            next_cursor: page.next_cursor,
+        })
+    }
+
+    /// Drive [`Self::lookup_authorized_page`] until the source is
+    /// exhausted, collecting every authorized resource into a single
+    /// `Vec`.
+    ///
+    /// This is the all-or-error convenience: any backend error from the
+    /// lookup source or hydrator aborts the whole operation; the caller
+    /// does not see partial results. For very large authorized
+    /// populations, prefer [`Self::lookup_authorized_page`] and stream
+    /// results page by page.
+    ///
+    /// Cursor-progress is enforced: if the source returns a `next_cursor`
+    /// equal to the cursor that was just consumed, gatehouse aborts with
+    /// [`LookupAuthorizedError::LookupCursorStuck`] rather than loop
+    /// forever.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "see lookup_authorized_page for the rationale."
+    )]
+    pub async fn lookup_authorized<L, H>(
+        &self,
+        session: &EvaluationSession,
+        subject: &S,
+        action: &A,
+        context: &C,
+        lookup: &L,
+        page_size: NonZeroUsize,
+        hydrator: &H,
+    ) -> Result<Vec<R>, LookupAuthorizedError<L::Error, H::Error>>
+    where
+        L: LookupSource<Subject = S>,
+        H: Hydrator<L::Id, Resource = R>,
+        R: Send,
+    {
+        let mut authorized = Vec::new();
+        let mut cursor: Option<Vec<u8>> = None;
+        loop {
+            let page = self
+                .lookup_authorized_page(
+                    session,
+                    subject,
+                    action,
+                    context,
+                    lookup,
+                    cursor.as_deref(),
+                    page_size,
+                    hydrator,
+                )
+                .await?;
+            authorized.extend(page.resources);
+            match page.next_cursor {
+                None => return Ok(authorized),
+                Some(next) => {
+                    if cursor.as_deref() == Some(next.as_slice()) {
+                        return Err(LookupAuthorizedError::LookupCursorStuck);
+                    }
+                    cursor = Some(next);
+                }
+            }
+        }
     }
 }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -528,6 +528,13 @@ where
     /// denied by the policy stack. Continue paging until `next_cursor`
     /// is `None`.
     ///
+    /// Cursor-progress is enforced here, not just in
+    /// [`Self::lookup_authorized`]: if the source returns a `next_cursor`
+    /// equal to the cursor that was just consumed, this method aborts
+    /// with [`LookupAuthorizedError::LookupCursorStuck`] rather than
+    /// returning a page that would lead a streaming caller into an
+    /// infinite loop.
+    ///
     /// See [`LookupSource`] for the completeness contract: the source
     /// must enumerate a superset of every resource that any policy in
     /// this checker could grant; lookup narrows the candidate set but
@@ -564,6 +571,15 @@ where
             .instrument(lookup_span)
             .await
             .map_err(LookupAuthorizedError::Lookup)?;
+
+        // Enforce the cursor-progress contract before anything else: if the
+        // source returned the same cursor that was just consumed, a caller
+        // following the "loop until next_cursor is None" guidance would
+        // spin. Catch it here (not just in the collecting loop) so the
+        // page-oriented streaming API is just as safe.
+        if cursor.is_some() && page.next_cursor.as_deref() == cursor {
+            return Err(LookupAuthorizedError::LookupCursorStuck);
+        }
 
         if page.ids.is_empty() {
             return Ok(LookupAuthorizedPage {
@@ -656,14 +672,11 @@ where
                 )
                 .await?;
             authorized.extend(page.resources);
+            // Cursor-progress is enforced inside `lookup_authorized_page`,
+            // so we just trust the returned `next_cursor` here.
             match page.next_cursor {
                 None => return Ok(authorized),
-                Some(next) => {
-                    if cursor.as_deref() == Some(next.as_slice()) {
-                        return Err(LookupAuthorizedError::LookupCursorStuck);
-                    }
-                    cursor = Some(next);
-                }
+                Some(next) => cursor = Some(next),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,7 @@ mod builder;
 mod checker;
 mod combinators;
 mod facts;
+mod lookup;
 mod metadata;
 mod policies;
 mod policy;
@@ -282,6 +283,7 @@ pub use facts::{
     FactKey, FactLoadError, FactLoadResult, FactSource, FactSourceRegistrationError,
     RelationshipQuery,
 };
+pub use lookup::{Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupPage, LookupSource};
 pub use metadata::SecurityRuleMetadata;
 pub(crate) use metadata::{DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE};
 pub use policies::{AbacPolicy, DelegatingPolicy, RbacPolicy, RebacPolicy};

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,0 +1,219 @@
+//! Lookup-style enumeration for "what can this subject see?" authorization.
+//!
+//! The point-check API (`evaluate_in_session`) and the batch filter
+//! (`filter_authorized_with_context_in_session_by`) both require the caller
+//! to already hold every candidate resource. That breaks down for list and
+//! scope endpoints where the candidate population may be millions of rows
+//! and the visible subset is tiny.
+//!
+//! [`LookupSource`] solves this by enumerating a *candidate superset* of
+//! resources the subject may have access to, page by page; the consuming
+//! [`PermissionChecker`] hydrates each page and routes the hydrated
+//! resources through the existing policy stack. The lookup step is strictly
+//! a **narrowing** of candidates — every policy in the checker still runs
+//! on the hydrated subset, so authorization is still centralized in
+//! gatehouse rather than smeared into the source's query.
+//!
+//! See [`LookupSource`] for the completeness contract.
+//!
+//! [`PermissionChecker`]: crate::PermissionChecker
+
+use async_trait::async_trait;
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroUsize;
+
+/// Enumerates a candidate superset of resources for a subject.
+///
+/// # Completeness contract
+///
+/// A `LookupSource` **must** enumerate a superset of every resource that any
+/// policy in the consuming [`PermissionChecker`] could grant for `subject`.
+/// Gatehouse uses lookup only to narrow the candidate set; it then runs the
+/// full policy stack on the hydrated subset. **If the source omits a grant
+/// path** — admin overrides, sharing relationships, global/public resources,
+/// secondary roles — **the result is incomplete, not denied.** There is no
+/// out-of-band signal that completeness was broken: the caller will simply
+/// see fewer resources than they should.
+///
+/// In particular, [`PermissionChecker`] uses OR semantics across policies.
+/// If you compose policies whose grant axes are independent (for example,
+/// "I own it" OR "it is public" OR "the admin override applies"), the
+/// `LookupSource` must enumerate the union of every axis. Lookup is the
+/// scaling story for the narrow case where one axis dominates; it is
+/// **not** a way to express policy logic inside the data layer.
+///
+/// # Cursor contract
+///
+/// `cursor` is opaque to gatehouse. Implementations may use any encoding
+/// (offset, last-seen ID, base64 of internal state). The contract:
+///
+/// * `None` cursor means "start from the beginning."
+/// * Return `next_cursor = None` to signal exhaustion.
+/// * `next_cursor` must strictly advance: returning the same cursor that
+///   was just consumed signals a stuck source and is reported by
+///   gatehouse as a cursor-progress contract violation.
+/// * `limit` is an upper bound on page size; pages may be shorter, but
+///   shorter does not mean "exhausted" unless `next_cursor` is `None`.
+///
+/// # Fail-closed behavior
+///
+/// Returning `Err` aborts the consuming pipeline; gatehouse does not yield
+/// partial results from the page.
+///
+/// [`PermissionChecker`]: crate::PermissionChecker
+#[async_trait]
+pub trait LookupSource: Send + Sync {
+    /// The subject domain type the source enumerates against.
+    type Subject: Sync + ?Sized;
+    /// The ID type the source enumerates. The caller-provided
+    /// [`Hydrator`] resolves these to resources.
+    type Id: Send + Sync + Clone;
+    /// Backend error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Return one page of candidate IDs.
+    async fn lookup_page(
+        &self,
+        subject: &Self::Subject,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+    ) -> Result<LookupPage<Self::Id>, Self::Error>;
+}
+
+/// One page of enumerated candidate IDs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupPage<Id> {
+    /// Candidate IDs in this page. Order is source-defined and preserved
+    /// through hydration and authorization.
+    pub ids: Vec<Id>,
+    /// Opaque cursor for the next page, or `None` if this page is the
+    /// last.
+    pub next_cursor: Option<Vec<u8>>,
+}
+
+/// Resolves enumerated IDs to caller-owned resources.
+///
+/// Hydration is separated from lookup so the same `LookupSource` can drive
+/// different resource shapes (summary vs. full row, with or without
+/// joins). The hydrator returns one `Option<Resource>` per input ID **in
+/// input order**:
+///
+/// * `Some(resource)` — the ID resolved.
+/// * `None` — the ID was enumerated by the source but no longer resolves
+///   (deleted between enumeration and hydration). Gatehouse skips
+///   `None` entries before running policies; this is not an error.
+///
+/// Returning a vector of length other than `ids.len()` is a contract
+/// violation and is reported by gatehouse as a hydrator contract error.
+/// Returning `Err` aborts the consuming pipeline.
+#[async_trait]
+pub trait Hydrator<Id>: Send + Sync {
+    /// The resource type produced by the hydrator.
+    type Resource: Send;
+    /// Backend error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Resolve `ids` to resources in input order. See trait docs for the
+    /// `Option` and length contract.
+    async fn hydrate(&self, ids: &[Id]) -> Result<Vec<Option<Self::Resource>>, Self::Error>;
+}
+
+/// Blanket implementation over closures, so callers can pass an `async`
+/// function or a `move |ids| async move { ... }` block directly.
+#[async_trait]
+impl<F, Fut, Id, R, E> Hydrator<Id> for F
+where
+    F: Fn(&[Id]) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Vec<Option<R>>, E>> + Send,
+    Id: Send + Sync,
+    R: Send,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type Resource = R;
+    type Error = E;
+
+    async fn hydrate(&self, ids: &[Id]) -> Result<Vec<Option<Self::Resource>>, Self::Error> {
+        self(ids).await
+    }
+}
+
+/// Failure modes for [`PermissionChecker::lookup_authorized`] and
+/// [`PermissionChecker::lookup_authorized_page`].
+///
+/// The generic parameters carry the source's and hydrator's own error
+/// types, so callers retain full backend context on the wrapped variants.
+///
+/// [`PermissionChecker::lookup_authorized`]: crate::PermissionChecker::lookup_authorized
+/// [`PermissionChecker::lookup_authorized_page`]: crate::PermissionChecker::lookup_authorized_page
+#[derive(Debug)]
+pub enum LookupAuthorizedError<LookupErr, HydrateErr> {
+    /// The [`LookupSource`] returned an error for the current page.
+    Lookup(LookupErr),
+    /// The [`Hydrator`] returned an error for the current page.
+    Hydrate(HydrateErr),
+    /// The hydrator returned a `Vec<Option<_>>` whose length did not match
+    /// the input ID slice length. Treated as fail-closed.
+    HydratorContractViolation {
+        /// Number of IDs that were passed to the hydrator.
+        expected: usize,
+        /// Number of `Option<Resource>` entries the hydrator returned.
+        actual: usize,
+    },
+    /// The lookup source returned a `next_cursor` equal to the cursor that
+    /// was just consumed, indicating zero progress. Gatehouse aborts
+    /// rather than loop forever.
+    LookupCursorStuck,
+}
+
+impl<L, H> fmt::Display for LookupAuthorizedError<L, H>
+where
+    L: fmt::Display,
+    H: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lookup(err) => write!(f, "lookup source error: {err}"),
+            Self::Hydrate(err) => write!(f, "hydrator error: {err}"),
+            Self::HydratorContractViolation { expected, actual } => write!(
+                f,
+                "hydrator returned {actual} entries for {expected} ids; \
+                 the result must match the input length"
+            ),
+            Self::LookupCursorStuck => f.write_str(
+                "lookup source returned the same cursor twice in a row; \
+                 cursors must strictly advance or be None to signal exhaustion",
+            ),
+        }
+    }
+}
+
+impl<L, H> std::error::Error for LookupAuthorizedError<L, H>
+where
+    L: std::error::Error + 'static,
+    H: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Lookup(err) => Some(err),
+            Self::Hydrate(err) => Some(err),
+            Self::HydratorContractViolation { .. } | Self::LookupCursorStuck => None,
+        }
+    }
+}
+
+/// One page of *authorized* resources, paired with the next candidate-page
+/// cursor.
+///
+/// Note that `next_cursor` paginates the **candidate** stream, not the
+/// authorized output. A `Some(cursor)` value with `resources.is_empty()`
+/// is normal: the source enumerated more IDs but the policy stack denied
+/// every one in that page. Continue paging until `next_cursor` is `None`.
+#[derive(Debug)]
+pub struct LookupAuthorizedPage<R> {
+    /// Resources from this page that the full policy stack authorized,
+    /// in source-defined order.
+    pub resources: Vec<R>,
+    /// Cursor for the next candidate page, or `None` if exhausted.
+    pub next_cursor: Option<Vec<u8>>,
+}

--- a/tests/lookup_contract.rs
+++ b/tests/lookup_contract.rs
@@ -1,0 +1,676 @@
+//! Contract tests for the [`LookupSource`] / [`Hydrator`] /
+//! `PermissionChecker::lookup_authorized*` pipeline.
+//!
+//! These tests pin down the protocol agreed in #24: the source enumerates
+//! a candidate superset, the hydrator resolves IDs to resources (with
+//! explicit "no longer exists" support), and the existing checker filter
+//! authorizes the hydrated subset.
+
+use async_trait::async_trait;
+use gatehouse::{
+    EvalCtx, EvaluationSession, Hydrator, LookupAuthorizedError, LookupPage, LookupSource,
+    PermissionChecker, Policy, PolicyEvalResult,
+};
+use std::collections::HashMap;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Cap for collecting calls; large enough not to clip any test but small
+/// enough to catch a runaway-loop bug quickly.
+const PAGE_SIZE: usize = 16;
+
+fn page_size() -> NonZeroUsize {
+    NonZeroUsize::new(PAGE_SIZE).unwrap()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct User {
+    id: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Doc {
+    id: u32,
+    public: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ReadAction;
+
+#[derive(Clone, Debug)]
+struct Ctx;
+
+// --- Policies ----------------------------------------------------------
+
+/// Grants when the user is a designated owner of the doc id. Models a
+/// per-resource grant the lookup source would also enumerate.
+struct OwnerPolicy {
+    owns: HashMap<u32, u32>, // doc_id -> user_id
+}
+
+#[async_trait]
+impl Policy<User, Doc, ReadAction, Ctx> for OwnerPolicy {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, User, Doc, ReadAction, Ctx>) -> PolicyEvalResult {
+        match self.owns.get(&ctx.resource.id) {
+            Some(owner) if *owner == ctx.subject.id => PolicyEvalResult::Granted {
+                policy_type: self.policy_type().to_string(),
+                reason: Some(format!("user {} owns doc {}", owner, ctx.resource.id)),
+            },
+            _ => PolicyEvalResult::Denied {
+                policy_type: self.policy_type().to_string(),
+                reason: format!(
+                    "user {} does not own doc {}",
+                    ctx.subject.id, ctx.resource.id
+                ),
+            },
+        }
+    }
+    fn policy_type(&self) -> &str {
+        "OwnerPolicy"
+    }
+}
+
+/// Grants every public doc to any user. Models the kind of non-lookup
+/// policy (admin override, public/global) that lookup-based callers must
+/// still let gatehouse evaluate.
+struct PublicDocPolicy;
+
+#[async_trait]
+impl Policy<User, Doc, ReadAction, Ctx> for PublicDocPolicy {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, User, Doc, ReadAction, Ctx>) -> PolicyEvalResult {
+        if ctx.resource.public {
+            PolicyEvalResult::Granted {
+                policy_type: self.policy_type().to_string(),
+                reason: Some("public doc".into()),
+            }
+        } else {
+            PolicyEvalResult::Denied {
+                policy_type: self.policy_type().to_string(),
+                reason: "doc is not public".into(),
+            }
+        }
+    }
+    fn policy_type(&self) -> &str {
+        "PublicDocPolicy"
+    }
+}
+
+// --- Lookup sources ----------------------------------------------------
+
+/// In-memory `LookupSource` that enumerates the IDs registered for each
+/// user. Pages by offset; cursor is the base-10 next-offset as ASCII bytes.
+struct OwnerLookup {
+    per_user: HashMap<u32, Vec<u32>>,
+    calls: AtomicUsize,
+}
+
+#[derive(Debug)]
+struct OwnerLookupError(&'static str);
+impl fmt::Display for OwnerLookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+impl std::error::Error for OwnerLookupError {}
+
+#[async_trait]
+impl LookupSource for OwnerLookup {
+    type Subject = User;
+    type Id = u32;
+    type Error = OwnerLookupError;
+
+    async fn lookup_page(
+        &self,
+        subject: &User,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+    ) -> Result<LookupPage<u32>, OwnerLookupError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let offset = parse_cursor(cursor);
+        let all = self.per_user.get(&subject.id).cloned().unwrap_or_default();
+        if offset >= all.len() {
+            return Ok(LookupPage {
+                ids: Vec::new(),
+                next_cursor: None,
+            });
+        }
+        let end = (offset + limit.get()).min(all.len());
+        let next_cursor = (end < all.len()).then(|| encode_cursor(end));
+        Ok(LookupPage {
+            ids: all[offset..end].to_vec(),
+            next_cursor,
+        })
+    }
+}
+
+fn parse_cursor(cursor: Option<&[u8]>) -> usize {
+    cursor
+        .and_then(|c| std::str::from_utf8(c).ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+fn encode_cursor(offset: usize) -> Vec<u8> {
+    offset.to_string().into_bytes()
+}
+
+// --- Hydrators ---------------------------------------------------------
+
+#[derive(Debug)]
+struct HydrateError(&'static str);
+impl fmt::Display for HydrateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+impl std::error::Error for HydrateError {}
+
+/// Resolves IDs against a fixed catalog. IDs absent from the catalog
+/// resolve to `None` (the "deleted between enumeration and hydration"
+/// case).
+struct CatalogHydrator {
+    catalog: Arc<HashMap<u32, Doc>>,
+}
+
+impl CatalogHydrator {
+    fn new(catalog: HashMap<u32, Doc>) -> Self {
+        Self {
+            catalog: Arc::new(catalog),
+        }
+    }
+}
+
+#[async_trait]
+impl Hydrator<u32> for CatalogHydrator {
+    type Resource = Doc;
+    type Error = HydrateError;
+    async fn hydrate(&self, ids: &[u32]) -> Result<Vec<Option<Doc>>, HydrateError> {
+        Ok(ids.iter().map(|id| self.catalog.get(id).cloned()).collect())
+    }
+}
+
+// --- Helpers -----------------------------------------------------------
+
+async fn run_collected(
+    checker: &PermissionChecker<User, Doc, ReadAction, Ctx>,
+    subject: &User,
+    lookup: &OwnerLookup,
+    hydrator: &impl Hydrator<u32, Resource = Doc, Error = HydrateError>,
+) -> Result<Vec<Doc>, LookupAuthorizedError<OwnerLookupError, HydrateError>> {
+    let session = EvaluationSession::empty();
+    checker
+        .lookup_authorized(
+            &session,
+            subject,
+            &ReadAction,
+            &Ctx,
+            lookup,
+            page_size(),
+            hydrator,
+        )
+        .await
+}
+
+// --- Tests -------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_page_yields_empty_authorized() {
+    let lookup = OwnerLookup {
+        per_user: HashMap::new(),
+        calls: AtomicUsize::new(0),
+    };
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: HashMap::new(),
+    });
+    let hydrate = CatalogHydrator::new(HashMap::new());
+
+    let out = run_collected(&checker, &User { id: 1 }, &lookup, &hydrate)
+        .await
+        .expect("ok");
+    assert!(out.is_empty());
+    assert_eq!(lookup.calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn paginates_until_exhausted() {
+    // 40 doc ids; page size 16 -> three calls (16, 16, 8).
+    let ids: Vec<u32> = (1..=40).collect();
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, ids.clone())]),
+        calls: AtomicUsize::new(0),
+    };
+    let catalog: HashMap<u32, Doc> = ids
+        .iter()
+        .map(|id| {
+            (
+                *id,
+                Doc {
+                    id: *id,
+                    public: false,
+                },
+            )
+        })
+        .collect();
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: ids.iter().map(|id| (*id, 1)).collect(),
+    });
+    let hydrate = CatalogHydrator::new(catalog);
+
+    let out = run_collected(&checker, &User { id: 1 }, &lookup, &hydrate)
+        .await
+        .expect("ok");
+    let out_ids: Vec<u32> = out.iter().map(|d| d.id).collect();
+    assert_eq!(out_ids, ids);
+    assert_eq!(lookup.calls.load(Ordering::Relaxed), 3);
+}
+
+#[tokio::test]
+async fn cursor_stuck_is_detected() {
+    struct Stuck;
+    #[async_trait]
+    impl LookupSource for Stuck {
+        type Subject = User;
+        type Id = u32;
+        type Error = OwnerLookupError;
+
+        async fn lookup_page(
+            &self,
+            _: &User,
+            _cursor: Option<&[u8]>,
+            _: NonZeroUsize,
+        ) -> Result<LookupPage<u32>, OwnerLookupError> {
+            // Always return the same cursor regardless of input.
+            Ok(LookupPage {
+                ids: vec![],
+                next_cursor: Some(b"forever".to_vec()),
+            })
+        }
+    }
+    let checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    let hydrate = CatalogHydrator::new(HashMap::new());
+    let session = EvaluationSession::empty();
+
+    let result = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &Stuck,
+            page_size(),
+            &hydrate,
+        )
+        .await;
+    match result {
+        Err(LookupAuthorizedError::LookupCursorStuck) => {}
+        other => panic!("expected LookupCursorStuck, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn duplicate_ids_across_pages_are_preserved() {
+    // Same id appears in two pages; the contract is "source-defined order",
+    // so duplicates pass through. Sources that want dedup should do it
+    // themselves.
+    let ids = vec![10u32, 10, 11, 12];
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, ids.clone())]),
+        calls: AtomicUsize::new(0),
+    };
+    // Force two pages of size 2 each.
+    let catalog: HashMap<u32, Doc> = HashMap::from([
+        (
+            10,
+            Doc {
+                id: 10,
+                public: false,
+            },
+        ),
+        (
+            11,
+            Doc {
+                id: 11,
+                public: false,
+            },
+        ),
+        (
+            12,
+            Doc {
+                id: 12,
+                public: false,
+            },
+        ),
+    ]);
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: HashMap::from([(10, 1), (11, 1), (12, 1)]),
+    });
+    let hydrate = CatalogHydrator::new(catalog);
+    let session = EvaluationSession::empty();
+
+    let small_page = NonZeroUsize::new(2).unwrap();
+    let out = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &lookup,
+            small_page,
+            &hydrate,
+        )
+        .await
+        .expect("ok");
+    let out_ids: Vec<u32> = out.iter().map(|d| d.id).collect();
+    assert_eq!(out_ids, vec![10, 10, 11, 12]);
+}
+
+#[tokio::test]
+async fn hydration_misses_are_silently_skipped() {
+    // Source enumerates 5 ids; only 3 still exist. Owner policy would
+    // grant all 5 if they existed.
+    let ids = vec![1u32, 2, 3, 4, 5];
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, ids.clone())]),
+        calls: AtomicUsize::new(0),
+    };
+    let catalog: HashMap<u32, Doc> = HashMap::from([
+        (
+            1,
+            Doc {
+                id: 1,
+                public: false,
+            },
+        ),
+        (
+            3,
+            Doc {
+                id: 3,
+                public: false,
+            },
+        ),
+        (
+            5,
+            Doc {
+                id: 5,
+                public: false,
+            },
+        ),
+    ]);
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: ids.iter().map(|id| (*id, 1)).collect(),
+    });
+    let hydrate = CatalogHydrator::new(catalog);
+
+    let out = run_collected(&checker, &User { id: 1 }, &lookup, &hydrate)
+        .await
+        .expect("ok");
+    let out_ids: Vec<u32> = out.iter().map(|d| d.id).collect();
+    assert_eq!(out_ids, vec![1, 3, 5]);
+}
+
+#[tokio::test]
+async fn lookup_error_propagates_as_lookup_variant() {
+    struct Boom;
+    #[async_trait]
+    impl LookupSource for Boom {
+        type Subject = User;
+        type Id = u32;
+        type Error = OwnerLookupError;
+        async fn lookup_page(
+            &self,
+            _: &User,
+            _: Option<&[u8]>,
+            _: NonZeroUsize,
+        ) -> Result<LookupPage<u32>, OwnerLookupError> {
+            Err(OwnerLookupError("backend down"))
+        }
+    }
+    let checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    let hydrate = CatalogHydrator::new(HashMap::new());
+    let session = EvaluationSession::empty();
+
+    let result = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &Boom,
+            page_size(),
+            &hydrate,
+        )
+        .await;
+    match result {
+        Err(LookupAuthorizedError::Lookup(err)) => assert_eq!(err.to_string(), "backend down"),
+        other => panic!("expected Lookup variant, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hydrator_error_propagates_as_hydrate_variant() {
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, vec![7u32])]),
+        calls: AtomicUsize::new(0),
+    };
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: HashMap::from([(7, 1)]),
+    });
+    let hydrate =
+        |_ids: &[u32]| async { Err::<Vec<Option<Doc>>, _>(HydrateError("hydrator unavailable")) };
+    let session = EvaluationSession::empty();
+
+    let result = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &lookup,
+            page_size(),
+            &hydrate,
+        )
+        .await;
+    match result {
+        Err(LookupAuthorizedError::Hydrate(err)) => {
+            assert_eq!(err.to_string(), "hydrator unavailable");
+        }
+        other => panic!("expected Hydrate variant, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hydrator_length_mismatch_is_contract_violation() {
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, vec![1u32, 2, 3])]),
+        calls: AtomicUsize::new(0),
+    };
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: HashMap::from([(1, 1), (2, 1), (3, 1)]),
+    });
+    let hydrate = |ids: &[u32]| {
+        let count = ids.len();
+        async move {
+            // Return one fewer entry than asked — contract violation.
+            Ok::<_, HydrateError>(
+                (0..count.saturating_sub(1))
+                    .map(|i| {
+                        Some(Doc {
+                            id: (i + 1) as u32,
+                            public: false,
+                        })
+                    })
+                    .collect(),
+            )
+        }
+    };
+    let session = EvaluationSession::empty();
+
+    let result = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &lookup,
+            page_size(),
+            &hydrate,
+        )
+        .await;
+    match result {
+        Err(LookupAuthorizedError::HydratorContractViolation { expected, actual }) => {
+            assert_eq!(expected, 3);
+            assert_eq!(actual, 2);
+        }
+        other => panic!("expected HydratorContractViolation, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn composition_with_non_lookup_policy_extends_authorized_set() {
+    // The lookup source only enumerates owned docs. The PublicDocPolicy in
+    // the checker grants every public doc to any user — including docs the
+    // source did *not* enumerate. That is exactly the "incomplete result"
+    // failure mode the trait docs warn about.
+    //
+    // We assert the *consumer-visible* behavior: lookup_authorized returns
+    // only what its source enumerated (correctly authorized through the
+    // full policy stack). A point check against a public doc the source
+    // omitted still grants — proving the policy is alive in the checker,
+    // and that the missing-from-lookup case is silent.
+    let owned_ids = vec![10u32, 11];
+    let public_doc_outside_lookup = Doc {
+        id: 99,
+        public: true,
+    };
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, owned_ids.clone())]),
+        calls: AtomicUsize::new(0),
+    };
+    let catalog: HashMap<u32, Doc> = HashMap::from([
+        (
+            10,
+            Doc {
+                id: 10,
+                public: false,
+            },
+        ),
+        (
+            11,
+            Doc {
+                id: 11,
+                public: true,
+            },
+        ), // also public; lookup also catches it
+        (99, public_doc_outside_lookup.clone()),
+    ]);
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: HashMap::from([(10, 1), (11, 1)]),
+    });
+    checker.add_policy(PublicDocPolicy);
+    let hydrate = CatalogHydrator::new(catalog);
+    let session = EvaluationSession::empty();
+
+    // Lookup-driven query: returns the docs the source enumerated, each
+    // authorized through the full policy stack.
+    let out = checker
+        .lookup_authorized(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &lookup,
+            page_size(),
+            &hydrate,
+        )
+        .await
+        .expect("ok");
+    let mut out_ids: Vec<u32> = out.iter().map(|d| d.id).collect();
+    out_ids.sort();
+    assert_eq!(out_ids, vec![10, 11]);
+
+    // The non-lookup policy is still alive in the checker: a point check
+    // grants the public doc that the source did NOT enumerate.
+    let direct = checker
+        .evaluate_in_session(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &public_doc_outside_lookup,
+            &Ctx,
+        )
+        .await;
+    assert!(
+        direct.is_granted(),
+        "PublicDocPolicy should grant the public doc directly"
+    );
+}
+
+#[tokio::test]
+async fn page_oriented_api_lets_caller_stream() {
+    // Demonstrates that callers can drive lookup_authorized_page in their
+    // own loop, observing per-candidate-page boundaries. Pre-empts a
+    // pager regression.
+    let ids: Vec<u32> = (1..=5).collect();
+    let lookup = OwnerLookup {
+        per_user: HashMap::from([(1, ids.clone())]),
+        calls: AtomicUsize::new(0),
+    };
+    let catalog: HashMap<u32, Doc> = ids
+        .iter()
+        .map(|id| {
+            (
+                *id,
+                Doc {
+                    id: *id,
+                    public: false,
+                },
+            )
+        })
+        .collect();
+    let mut checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    checker.add_policy(OwnerPolicy {
+        owns: ids.iter().map(|id| (*id, 1)).collect(),
+    });
+    let hydrate = CatalogHydrator::new(catalog);
+    let session = EvaluationSession::empty();
+    let page_size = NonZeroUsize::new(2).unwrap();
+
+    let mut cursor: Option<Vec<u8>> = None;
+    let pages = Arc::new(Mutex::new(Vec::new()));
+    loop {
+        let page = checker
+            .lookup_authorized_page(
+                &session,
+                &User { id: 1 },
+                &ReadAction,
+                &Ctx,
+                &lookup,
+                cursor.as_deref(),
+                page_size,
+                &hydrate,
+            )
+            .await
+            .expect("ok");
+        pages
+            .lock()
+            .await
+            .push(page.resources.iter().map(|d| d.id).collect::<Vec<_>>());
+        match page.next_cursor {
+            None => break,
+            Some(next) => cursor = Some(next),
+        }
+    }
+
+    let pages = Arc::try_unwrap(pages).unwrap().into_inner();
+    assert_eq!(pages, vec![vec![1, 2], vec![3, 4], vec![5]]);
+}

--- a/tests/lookup_contract.rs
+++ b/tests/lookup_contract.rs
@@ -313,6 +313,77 @@ async fn cursor_stuck_is_detected() {
 }
 
 #[tokio::test]
+async fn page_mode_cursor_stuck_is_detected() {
+    // A streaming caller drives `lookup_authorized_page` directly. The
+    // source echoes the input cursor back as `next_cursor`, so any
+    // "loop until next_cursor is None" caller would spin forever. The
+    // page primitive must catch this on the very first call after the
+    // initial advance, not leave detection to the collecting helper.
+    struct Echo;
+    #[async_trait]
+    impl LookupSource for Echo {
+        type Subject = User;
+        type Id = u32;
+        type Error = OwnerLookupError;
+
+        async fn lookup_page(
+            &self,
+            _: &User,
+            cursor: Option<&[u8]>,
+            _: NonZeroUsize,
+        ) -> Result<LookupPage<u32>, OwnerLookupError> {
+            // First call (cursor = None) advances; subsequent calls echo.
+            let next_cursor = Some(cursor.map(|c| c.to_vec()).unwrap_or_else(|| b"x".to_vec()));
+            Ok(LookupPage {
+                ids: vec![],
+                next_cursor,
+            })
+        }
+    }
+
+    let checker = PermissionChecker::<User, Doc, ReadAction, Ctx>::new();
+    let hydrate = CatalogHydrator::new(HashMap::new());
+    let session = EvaluationSession::empty();
+    let limit = page_size();
+
+    // First call: cursor None, source returns Some("x") -> legitimate advance.
+    let first = checker
+        .lookup_authorized_page(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &Echo,
+            None,
+            limit,
+            &hydrate,
+        )
+        .await
+        .expect("first page legitimately advances");
+    let cursor = first
+        .next_cursor
+        .expect("first call must yield next_cursor");
+
+    // Second call: cursor Some("x"), source echoes Some("x") -> stuck.
+    let second = checker
+        .lookup_authorized_page(
+            &session,
+            &User { id: 1 },
+            &ReadAction,
+            &Ctx,
+            &Echo,
+            Some(&cursor),
+            limit,
+            &hydrate,
+        )
+        .await;
+    match second {
+        Err(LookupAuthorizedError::LookupCursorStuck) => {}
+        other => panic!("expected LookupCursorStuck from page primitive, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn duplicate_ids_across_pages_are_preserved() {
     // Same id appears in two pages; the contract is "source-defined order",
     // so duplicates pass through. Sources that want dedup should do it


### PR DESCRIPTION
Closes #24.

## Summary

Implements the design-first lookup pipeline #24 was created to scope. `LookupSource` enumerates a candidate **superset** of resources for a subject; `Hydrator` resolves IDs to caller-owned resources with explicit "no longer exists" handling; `PermissionChecker::lookup_authorized` and `lookup_authorized_page` drive the loop and route hydrated candidates through the existing policy stack.

## Public surface added

| | |
|---|---|
| \`LookupSource\` | Paginated enumeration of candidate IDs for a subject. \`type Subject: Sync + ?Sized\`; \`type Id: Send + Sync + Clone\`; opaque \`Vec<u8>\` cursor. |
| \`LookupPage<Id>\` | \`{ ids, next_cursor }\` |
| \`Hydrator<Id>\` | Resolves IDs to \`Vec<Option<Resource>>\`. Blanket impl over closures returning the same shape. |
| \`LookupAuthorizedError<L, H>\` | \`Lookup(L)\` / \`Hydrate(H)\` / \`HydratorContractViolation\` / \`LookupCursorStuck\` |
| \`LookupAuthorizedPage<R>\` | One page of authorized resources + the next candidate-page cursor. |
| \`PermissionChecker::lookup_authorized_page\` | Page-oriented primitive — single page in, authorized page out. |
| \`PermissionChecker::lookup_authorized\` | All-or-error collecting convenience. |

The trait docs are loud about the completeness contract: the source must enumerate a superset of every resource any policy in the checker could grant. Omitting a path (admin override, sharing, public) produces *incomplete* results, not denied ones — and there is no out-of-band signal. Lookup narrows; it does not replace policy evaluation.

## Design notes per #24

- **Source vs. trait shape**: standalone trait, not coupled to \`FactSource\` or session registry. Lookup isn't keyed enumeration; it's paginated.
- **Cursor opacity**: \`Option<&[u8]>\`. Sources own their encoding (offset, last-id, base64 of internal state).
- **Cursor-progress enforcement**: a source returning the same cursor twice in a row is detected and reported as \`LookupCursorStuck\`. No infinite loops on stuck sources.
- **Hydration races**: \`Vec<Option<R>>\` means "ID still exists?". Whole-batch errors abort; missing entries are silently skipped.
- **Composition with non-lookup policies**: works by construction. The hydrated candidates go through \`filter_authorized_with_context_in_session_by\`; every policy still runs. A test exercises this with an additional \`PublicDocPolicy\` in the checker.
- **One source per call**: composition (union, intersection, multi-axis) is the caller's job. Building it into the checker would commit to merge semantics, dedup, fairness, and ordering across backends — a separate product surface.

## Tests

\`tests/lookup_contract.rs\` (10 tests, all pass):

1. empty page yields empty authorized
2. paginates until exhausted
3. cursor stuck detected
4. duplicate ids across pages preserved (no implicit dedup)
5. hydration misses silently skipped
6. lookup error propagates as \`LookupAuthorizedError::Lookup\`
7. hydrator error propagates as \`LookupAuthorizedError::Hydrate\`
8. hydrator length mismatch is contract violation
9. composition with non-lookup policy (asserts lookup is bounded by what the source enumerates AND the non-lookup policy is still alive at point checks)
10. page-oriented API streams page-by-page

## Example

\`examples/lookup_in_ram.rs\` — production-shape demo: admin-override + viewer-relation policies, a viewer-only \`LookupSource\`, hydrator over an in-memory catalog. Output shows alice (3 docs visible via viewer) vs. admin (0 visible via this lookup, but point check granted) so the design's bounded-by-what-it-enumerates property is visible.

## Validation

- \`cargo fmt --all --check\` ✅
- \`cargo clippy --all-targets --all-features -- -D warnings\` ✅
- \`cargo test --all-targets --all-features\` ✅ (162 + 10 new = 172)
- \`cargo doc --all-features --no-deps\` ✅
- \`RUSTFLAGS=\"--cfg loom\" cargo test --lib --release\` ✅ (16 unchanged)
- \`cargo run --example lookup_in_ram\` ✅