### PR TITLE
Restore #31 fact provenance after botched alpha.2 release base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,21 @@
 
 ## [0.3.0-alpha.2] - 2026-06-01
 
+### Breaking
+
+- `PolicyEvalResult::Granted` and `PolicyEvalResult::Denied` gain a `provenance: Vec<FactProvenance>` field recording the facts a policy consulted to reach its decision. Construct results via the new `PolicyEvalResult::granted`/`denied` (or `granted_with_facts`/`denied_with_facts`) constructors instead of struct literals.
+- `RebacPolicy` now requires its subject and resource ID types to implement `Debug` so the consulted relationship can be rendered into decision provenance.
+
 ### Added
 
 - `LookupSource` and `Hydrator` traits plus `PermissionChecker::lookup_authorized` and `lookup_authorized_page` for "what can this subject see?" list endpoints. The source enumerates a candidate superset; the hydrator resolves IDs to caller-owned resources (with explicit "no longer exists" via `Option<Resource>`); the full policy stack still authorizes each hydrated candidate. Cursor-progress is enforced (no infinite loops on stuck sources). See `examples/lookup_in_ram.rs`. (#24)
+- `FactProvenance` and `FactOutcome`: per-decision fact provenance attached to `PolicyEvalResult` leaf nodes and rendered inline by `EvalTrace::format`. `RebacPolicy` records the relationship it consulted, the load outcome, and any backend error detail. Operational fact-load telemetry remains on the `gatehouse.fact_load` tracing span.
+- `PolicyEvalResult::granted`, `denied`, `granted_with_facts`, and `denied_with_facts` constructors and a `provenance()` accessor.
 
 ### Changed
 
 - Internal refactor: the per-stripe session state machine is now a private synchronous core (`FactStripeCore<K, W>`) with no async, no tracing, and a generic waiter type. `FactState<K>` remains the async adapter that owns locks, the source, and tracing. No public API change. (#28)
+- Expanded and clarified docs: `RelationshipQuery`, `FactLoadResult` (rationale vs `Result<Option<V>, FactLoadError>`), `BatchEvalCtx` single-action design and escape hatches, `EvaluationSession` (no TTL; layer longer-lived caching inside a `FactSource`), the `shared_empty`/`register` panic rationale, and the `LoaderCancelled` error.
 
 ### Tests
 

--- a/examples/combinator_policy.rs
+++ b/examples/combinator_policy.rs
@@ -59,15 +59,12 @@ impl Policy<User, Document, ViewAction, EmptyContext> for CountingPolicy {
         println!("Evaluating policy: {}", self.name);
 
         if self.allow {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some(format!("{} grants access", self.name)),
-            }
+            PolicyEvalResult::granted(
+                self.policy_type(),
+                Some(format!("{} grants access", self.name)),
+            )
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: format!("{} denies access", self.name),
-            }
+            PolicyEvalResult::denied(self.policy_type(), format!("{} denies access", self.name))
         }
     }
 

--- a/examples/groups_policy.rs
+++ b/examples/groups_policy.rs
@@ -41,15 +41,12 @@ impl Policy<SubjectV2, Group, GroupManagementAction, EmptyContext> for OrgAdminP
         ctx: &EvalCtx<'_, SubjectV2, Group, GroupManagementAction, EmptyContext>,
     ) -> PolicyEvalResult {
         if ctx.subject.authorization_details.is_org_admin {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("User is organization admin".to_string()),
-            }
+            PolicyEvalResult::granted(
+                self.policy_type(),
+                Some("User is organization admin".to_string()),
+            )
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "User is not organization admin".to_string(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "User is not organization admin")
         }
     }
 
@@ -74,15 +71,12 @@ impl Policy<SubjectV2, Group, GroupManagementAction, EmptyContext> for StaffPoli
             .iter()
             .any(|p| p.scope == "staff")
         {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("User has staff permission".to_string()),
-            }
+            PolicyEvalResult::granted(
+                self.policy_type(),
+                Some("User has staff permission".to_string()),
+            )
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "User lacks staff permission".to_string(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "User lacks staff permission")
         }
     }
 

--- a/examples/lookup_in_ram.rs
+++ b/examples/lookup_in_ram.rs
@@ -58,15 +58,9 @@ impl Policy<User, Document, View, RequestCtx> for AdminPolicy {
         ctx: &EvalCtx<'_, User, Document, View, RequestCtx>,
     ) -> PolicyEvalResult {
         if ctx.subject.is_admin {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("admin override".into()),
-            }
+            PolicyEvalResult::granted(self.policy_type(), Some("admin override".into()))
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "not admin".into(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "not admin")
         }
     }
     fn policy_type(&self) -> &str {
@@ -92,15 +86,9 @@ impl Policy<User, Document, View, RequestCtx> for ViewerPolicy {
             .map(|users| users.contains(&ctx.subject.id))
             .unwrap_or(false);
         if granted {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("viewer relation".into()),
-            }
+            PolicyEvalResult::granted(self.policy_type(), Some("viewer relation".into()))
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "no viewer relation".into(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "no viewer relation")
         }
     }
     fn policy_type(&self) -> &str {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -31,21 +31,15 @@ where
     async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
         if (self.predicate)(ctx.subject, ctx.action, ctx.resource, ctx.context) {
             match self.effect {
-                Effect::Allow => PolicyEvalResult::Granted {
-                    policy_type: self.name.clone(),
-                    reason: Some("Policy allowed access".into()),
-                },
-                Effect::Deny => PolicyEvalResult::Denied {
-                    policy_type: self.name.clone(),
-                    reason: "Policy denied access".into(),
-                },
+                Effect::Allow => PolicyEvalResult::granted(
+                    self.name.clone(),
+                    Some("Policy allowed access".into()),
+                ),
+                Effect::Deny => PolicyEvalResult::denied(self.name.clone(), "Policy denied access"),
             }
         } else {
             // Predicate didn't match – treat as non-applicable (denied).
-            PolicyEvalResult::Denied {
-                policy_type: self.name.clone(),
-                reason: "Policy predicate did not match".into(),
-            }
+            PolicyEvalResult::denied(self.name.clone(), "Policy predicate did not match")
         }
     }
     fn policy_type(&self) -> &str {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -86,10 +86,8 @@ where
         if self.policies.is_empty() {
             tracing::Span::current().record("outcome", "denied");
             tracing::debug!("No policies configured");
-            let result = PolicyEvalResult::Denied {
-                policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
-                reason: "No policies configured".to_string(),
-            };
+            let result =
+                PolicyEvalResult::denied(PERMISSION_CHECKER_POLICY_TYPE, "No policies configured");
 
             return AccessEvaluation::Denied {
                 trace: EvalTrace::with_root(result),
@@ -266,10 +264,10 @@ where
                 .into_iter()
                 .map(|item| {
                     denied_count += 1;
-                    let result = PolicyEvalResult::Denied {
-                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
-                        reason: "No policies configured".to_string(),
-                    };
+                    let result = PolicyEvalResult::denied(
+                        PERMISSION_CHECKER_POLICY_TYPE,
+                        "No policies configured",
+                    );
                     (
                         item,
                         AccessEvaluation::Denied {
@@ -341,11 +339,10 @@ where
                 if policy_results.len() != pending_chunk.len() {
                     for &index in pending_chunk {
                         policy_denied_count += 1;
-                        let policy_result = PolicyEvalResult::Denied {
-                            policy_type: policy_type.to_string(),
-                            reason: "Policy batch result count did not match input count"
-                                .to_string(),
-                        };
+                        let policy_result = PolicyEvalResult::denied(
+                            policy_type,
+                            "Policy batch result count did not match input count",
+                        );
                         traces[index].push(policy_result);
                         let combined = PolicyEvalResult::Combined {
                             policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
@@ -415,10 +412,10 @@ where
             .zip(evaluations.into_iter())
             .map(|(item, evaluation)| {
                 let evaluation = evaluation.unwrap_or_else(|| {
-                    let result = PolicyEvalResult::Denied {
-                        policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
-                        reason: "Batch item was not evaluated".to_string(),
-                    };
+                    let result = PolicyEvalResult::denied(
+                        PERMISSION_CHECKER_POLICY_TYPE,
+                        "Batch item was not evaluated",
+                    );
                     AccessEvaluation::Denied {
                         trace: EvalTrace::with_root(result),
                         reason: "Batch item was not evaluated".to_string(),

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -104,10 +104,10 @@ where
 
             if child_results.len() != pending.len() {
                 for index in pending.drain(..) {
-                    children_by_item[index].push(PolicyEvalResult::Denied {
-                        policy_type: policy.policy_type().to_string(),
-                        reason: "Policy batch result count did not match input count".to_string(),
-                    });
+                    children_by_item[index].push(PolicyEvalResult::denied(
+                        policy.policy_type(),
+                        "Policy batch result count did not match input count",
+                    ));
                     results[index] = Some(PolicyEvalResult::Combined {
                         policy_type: self.policy_type().to_string(),
                         operation: CombineOp::And,
@@ -149,9 +149,8 @@ where
         results
             .into_iter()
             .map(|result| {
-                result.unwrap_or_else(|| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "Batch item was not evaluated".to_string(),
+                result.unwrap_or_else(|| {
+                    PolicyEvalResult::denied(self.policy_type(), "Batch item was not evaluated")
                 })
             })
             .collect()
@@ -249,10 +248,10 @@ where
 
             if child_results.len() != pending.len() {
                 for index in pending.drain(..) {
-                    children_by_item[index].push(PolicyEvalResult::Denied {
-                        policy_type: policy.policy_type().to_string(),
-                        reason: "Policy batch result count did not match input count".to_string(),
-                    });
+                    children_by_item[index].push(PolicyEvalResult::denied(
+                        policy.policy_type(),
+                        "Policy batch result count did not match input count",
+                    ));
                     results[index] = Some(PolicyEvalResult::Combined {
                         policy_type: self.policy_type().to_string(),
                         operation: CombineOp::Or,
@@ -294,9 +293,8 @@ where
         results
             .into_iter()
             .map(|result| {
-                result.unwrap_or_else(|| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "Batch item was not evaluated".to_string(),
+                result.unwrap_or_else(|| {
+                    PolicyEvalResult::denied(self.policy_type(), "Batch item was not evaluated")
                 })
             })
             .collect()
@@ -361,9 +359,11 @@ where
             return ctx
                 .items
                 .iter()
-                .map(|_| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "Policy batch result count did not match input count".to_string(),
+                .map(|_| {
+                    PolicyEvalResult::denied(
+                        self.policy_type(),
+                        "Policy batch result count did not match input count",
+                    )
                 })
                 .collect();
         }

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -7,12 +7,15 @@ use std::sync::Arc;
 /// A typed fact key that can be loaded through an [`crate::EvaluationSession`].
 ///
 /// Keys are flat, cloneable, and hashable so the session can deduplicate and
-/// cache fact loads for the lifetime of one authorization request.
+/// cache fact loads for the lifetime of a single [`crate::EvaluationSession`].
 ///
-/// Session caching is deliberately request-scoped. Cached facts and cached
-/// errors are dropped with the [`crate::EvaluationSession`], so permission revocations
-/// or backend changes are observed by the next request's session rather than
-/// being held in a process-global cache.
+/// Caching is scoped to that session, not the process. Gatehouse has no
+/// built-in notion of a "request"; the caller decides how long a session lives
+/// and, by convention, scopes it to one authorization pass (for an HTTP
+/// service, typically one inbound request). Cached facts and cached errors are
+/// dropped when the session is dropped, so permission revocations or backend
+/// changes are observed by the next session rather than being held in a
+/// process-global cache.
 pub trait FactKey: Eq + Hash + Clone + Send + Sync + 'static {
     /// The value returned by a [`FactSource`] for this key.
     type Value: Clone + Send + Sync + 'static;
@@ -24,6 +27,8 @@ pub trait FactKey: Eq + Hash + Clone + Send + Sync + 'static {
     const NAME: &'static str;
 }
 
+/// Private error type backing [`FactLoadError::backend_message`], so callers
+/// can wrap a human-readable message without defining their own error type.
 #[derive(Debug)]
 struct MessageError(String);
 
@@ -52,13 +57,16 @@ pub enum FactLoadError {
         /// Number of results returned by the source.
         actual: usize,
     },
-    /// The leader task for a fact load was cancelled before it completed.
+    /// The future driving a fact load was dropped before the load completed.
     ///
-    /// The session caches this error for the affected keys and wakes any
-    /// waiters. This is correct for request-scoped sessions: the request fails
-    /// closed and the next request builds a fresh session. Do not share a
-    /// fact-loaded session across independent requests, because cancellation in
-    /// one request would cache this error for the others.
+    /// When several evaluations await the same key, one of them drives the load
+    /// and the others wait on its result. If that driving future is cancelled —
+    /// for example, the surrounding request times out and its future is
+    /// dropped — the load is reported as cancelled. The session caches this
+    /// error for the affected keys and wakes any waiters, so the evaluation
+    /// fails closed and the next session retries from scratch. For this reason a
+    /// fact-loaded session should not be shared across independent requests: a
+    /// cancellation in one would surface here for the others.
     LoaderCancelled {
         /// Diagnostic fact name from [`FactKey::NAME`].
         fact_name: &'static str,
@@ -108,6 +116,14 @@ impl fmt::Display for FactLoadError {
 impl std::error::Error for FactLoadError {}
 
 /// Result of loading one fact.
+///
+/// This is shaped like `Result<Option<V>, FactLoadError>` — `Found`, `Missing`,
+/// and `Error` map onto `Ok(Some)`, `Ok(None)`, and `Err`. A dedicated enum is
+/// used instead so the three outcomes read as domain concepts at policy call
+/// sites (`FactLoadResult::Missing` rather than `Ok(None)`), so "the fact does
+/// not exist" is never visually conflated with "the load failed" — a
+/// distinction that matters for fail-closed authorization — and so the type can
+/// gain variants later without breaking a `Result` alias callers rely on.
 #[derive(Debug, Clone)]
 pub enum FactLoadResult<V> {
     /// The fact exists and has the given value.
@@ -183,7 +199,43 @@ impl fmt::Display for FactSourceRegistrationError {
 
 impl std::error::Error for FactSourceRegistrationError {}
 
-/// Canonical ReBAC fact key.
+/// Canonical fact key for relationship (ReBAC) lookups.
+///
+/// A `RelationshipQuery` encodes one yes/no question: does `subject_id` have
+/// `relation` to `resource_id`? It is the [`FactKey`] used by the built-in
+/// [`crate::RebacPolicy`], with [`FactKey::Value`] = `bool` — a registered
+/// [`FactSource`] answers `true` when the relationship exists and `false`
+/// otherwise.
+///
+/// The three identifier types are generic so callers can use their own
+/// strongly-typed ids and relation enums rather than stringly-typed keys.
+/// Because the session registry is keyed by the concrete Rust type (see
+/// [`crate::EvaluationSession`]), two logically distinct relationship graphs
+/// that share the same `RelationshipQuery<…>` instantiation resolve to the same
+/// source; give them distinct id or relation types if they must be backed
+/// separately.
+///
+/// For relationships that carry a payload (a rank, weight, or scope set) rather
+/// than a plain boolean, define a custom [`FactKey`] with `Value =
+/// YourPayload` instead of using this type.
+///
+/// # Example
+///
+/// ```rust
+/// # use gatehouse::RelationshipQuery;
+/// #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+/// enum Relation {
+///     Owner,
+///     Viewer,
+/// }
+///
+/// let query = RelationshipQuery {
+///     subject_id: "user:42".to_string(),
+///     resource_id: "doc:7".to_string(),
+///     relation: Relation::Owner,
+/// };
+/// assert_eq!(query.relation, Relation::Owner);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RelationshipQuery<SubjectId, ResourceId, Relation> {
     /// Subject identifier.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,15 +133,9 @@
 //! impl Policy<User, Document, ReadAction, EmptyContext> for AdminPolicy {
 //!     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Document, ReadAction, EmptyContext>) -> PolicyEvalResult {
 //!         if ctx.subject.roles.contains(&"admin".to_string()) {
-//!             PolicyEvalResult::Granted {
-//!                 policy_type: self.policy_type().to_string(),
-//!                 reason: Some("User is admin".to_string()),
-//!             }
+//!             PolicyEvalResult::granted(self.policy_type(), Some("User is admin".to_string()))
 //!         } else {
-//!             PolicyEvalResult::Denied {
-//!                 policy_type: self.policy_type().to_string(),
-//!                 reason: "User is not admin".to_string(),
-//!             }
+//!             PolicyEvalResult::denied(self.policy_type(), "User is not admin")
 //!         }
 //!     }
 //!     fn policy_type(&self) -> &str { "AdminPolicy" }
@@ -154,15 +148,9 @@
 //! impl Policy<User, Document, ReadAction, EmptyContext> for OwnerPolicy {
 //!     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Document, ReadAction, EmptyContext>) -> PolicyEvalResult {
 //!         if ctx.subject.id == ctx.resource.owner_id {
-//!             PolicyEvalResult::Granted {
-//!                 policy_type: self.policy_type().to_string(),
-//!                 reason: Some("User is the owner".to_string()),
-//!             }
+//!             PolicyEvalResult::granted(self.policy_type(), Some("User is the owner".to_string()))
 //!         } else {
-//!             PolicyEvalResult::Denied {
-//!                policy_type: self.policy_type().to_string(),
-//!                reason: "User is not the owner".to_string(),
-//!            }
+//!             PolicyEvalResult::denied(self.policy_type(), "User is not the owner")
 //!         }
 //!     }
 //!     fn policy_type(&self) -> &str {
@@ -288,7 +276,9 @@ pub use metadata::SecurityRuleMetadata;
 pub(crate) use metadata::{DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE};
 pub use policies::{AbacPolicy, DelegatingPolicy, RbacPolicy, RebacPolicy};
 pub use policy::{BatchEvalCtx, EvalCtx, Policy, PolicyBatchItem};
-pub use results::{AccessEvaluation, CombineOp, EvalTrace, PolicyEvalResult};
+pub use results::{
+    AccessEvaluation, CombineOp, EvalTrace, FactOutcome, FactProvenance, PolicyEvalResult,
+};
 pub use session::{EvaluationSession, EvaluationSessionBuilder};
 
 // The shared unit-test module pulls in tokio-based async tests via dev-deps

--- a/src/policies/abac.rs
+++ b/src/policies/abac.rs
@@ -95,15 +95,12 @@ where
         let condition_met = (self.condition)(ctx.subject, ctx.resource, ctx.action, ctx.context);
 
         if condition_met {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("Condition evaluated to true".to_string()),
-            }
+            PolicyEvalResult::granted(
+                self.policy_type(),
+                Some("Condition evaluated to true".to_string()),
+            )
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "Condition evaluated to false".to_string(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "Condition evaluated to false")
         }
     }
 

--- a/src/policies/delegating.rs
+++ b/src/policies/delegating.rs
@@ -17,19 +17,19 @@ fn delegated_evaluation_to_result(
         } => PolicyEvalResult::Combined {
             policy_type: policy_type.to_string(),
             operation: CombineOp::Delegate,
-            children: vec![trace.root().cloned().unwrap_or(PolicyEvalResult::Granted {
-                policy_type: child_policy_type,
-                reason,
-            })],
+            children: vec![trace
+                .root()
+                .cloned()
+                .unwrap_or(PolicyEvalResult::granted(child_policy_type, reason))],
             outcome: true,
         },
         AccessEvaluation::Denied { reason, trace } => PolicyEvalResult::Combined {
             policy_type: policy_type.to_string(),
             operation: CombineOp::Delegate,
-            children: vec![trace.root().cloned().unwrap_or(PolicyEvalResult::Denied {
-                policy_type: PERMISSION_CHECKER_POLICY_TYPE.to_string(),
+            children: vec![trace.root().cloned().unwrap_or(PolicyEvalResult::denied(
+                PERMISSION_CHECKER_POLICY_TYPE,
                 reason,
-            })],
+            ))],
             outcome: false,
         },
     }

--- a/src/policies/rbac.rs
+++ b/src/policies/rbac.rs
@@ -78,15 +78,15 @@ where
         let has_role = required_roles.iter().any(|role| user_roles.contains(role));
 
         if has_role {
-            PolicyEvalResult::Granted {
-                policy_type: Policy::<S, R, A, C>::policy_type(self).to_string(),
-                reason: Some("User has required role".to_string()),
-            }
+            PolicyEvalResult::granted(
+                Policy::<S, R, A, C>::policy_type(self),
+                Some("User has required role".to_string()),
+            )
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: Policy::<S, R, A, C>::policy_type(self).to_string(),
-                reason: "User doesn't have required role".to_string(),
-            }
+            PolicyEvalResult::denied(
+                Policy::<S, R, A, C>::policy_type(self),
+                "User doesn't have required role",
+            )
         }
     }
 

--- a/src/policies/rebac.rs
+++ b/src/policies/rebac.rs
@@ -1,4 +1,7 @@
-use crate::{BatchEvalCtx, EvalCtx, FactLoadResult, Policy, PolicyEvalResult, RelationshipQuery};
+use crate::{
+    BatchEvalCtx, EvalCtx, FactKey, FactLoadResult, FactOutcome, FactProvenance, Policy,
+    PolicyEvalResult, RelationshipQuery,
+};
 use async_trait::async_trait;
 use std::fmt;
 use std::hash::Hash;
@@ -29,10 +32,22 @@ use std::sync::Arc;
 /// a custom [`crate::FactKey`] with `Value = YourPayload` and write a [`crate::Policy`] that
 /// interprets the loaded value.
 ///
-/// `Relation` must implement [`fmt::Display`] only so Gatehouse can produce
-/// human-readable denial reasons and traces. Backend serialization should live
-/// in the [`crate::FactSource`], not in the display string unless that is explicitly
-/// your storage format.
+/// `Relation` must implement [`fmt::Display`] so Gatehouse can produce
+/// human-readable denial reasons and traces. The subject and resource ID types
+/// must implement [`fmt::Debug`] so the consulted relationship can be rendered
+/// into the [`crate::FactProvenance`] attached to each decision; common ID
+/// types (`Uuid`, `String`, integers) already satisfy this, but a custom ID
+/// newtype must `#[derive(Debug)]` or it will fail to satisfy the `Policy`
+/// bound. Backend serialization should live in the [`crate::FactSource`], not
+/// in the `Debug`/`Display` output, unless that is explicitly your storage
+/// format.
+///
+/// **Provenance/log safety.** The rendered relationship inside
+/// [`crate::FactProvenance::key`] uses the `Debug` output of your ID types
+/// verbatim. If those IDs carry fields that should not be written to audit
+/// logs (e.g. a token, a tenant secret), implement `Debug` manually to
+/// redact them before this policy is used in a checker whose decisions are
+/// persisted.
 ///
 /// ```rust
 /// use async_trait::async_trait;
@@ -133,23 +148,28 @@ where
     R: Sync + Send,
     A: Sync + Send,
     C: Sync + Send,
-    SubjectId: Eq + Hash + Clone + Send + Sync + 'static,
-    ResourceId: Eq + Hash + Clone + Send + Sync + 'static,
+    SubjectId: Eq + Hash + Clone + Send + Sync + fmt::Debug + 'static,
+    ResourceId: Eq + Hash + Clone + Send + Sync + fmt::Debug + 'static,
     Relation: Eq + Hash + Clone + Send + Sync + fmt::Display + 'static,
 {
     async fn evaluate(&self, ctx: &EvalCtx<'_, S, R, A, C>) -> PolicyEvalResult {
+        // Capture the FactKey::NAME here so `result_from_fact` does not need
+        // to carry the full FactKey trait bound on its impl block.
+        let fact_name = <RelationshipQuery<SubjectId, ResourceId, Relation> as FactKey>::NAME;
         let key = RelationshipQuery {
             subject_id: (self.subject_id)(ctx.subject),
             resource_id: (self.resource_id)(ctx.resource),
             relation: self.relation.clone(),
         };
-        self.result_from_fact(ctx.session.get(key).await)
+        let key_repr = Self::render_key(&key);
+        self.result_from_fact(fact_name, &key_repr, ctx.session.get(key).await)
     }
 
     async fn evaluate_batch<'item>(
         &self,
         ctx: &BatchEvalCtx<'item, S, R, A, C>,
     ) -> Vec<PolicyEvalResult> {
+        let fact_name = <RelationshipQuery<SubjectId, ResourceId, Relation> as FactKey>::NAME;
         let subject_id = (self.subject_id)(ctx.subject);
         let keys = ctx
             .items
@@ -166,17 +186,18 @@ where
             return ctx
                 .items
                 .iter()
-                .map(|_| PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "Relationship fact source returned the wrong number of results"
-                        .to_string(),
+                .map(|_| {
+                    PolicyEvalResult::denied(
+                        self.policy_type(),
+                        "Relationship fact source returned the wrong number of results",
+                    )
                 })
                 .collect();
         }
 
-        facts
-            .into_iter()
-            .map(|fact| self.result_from_fact(fact))
+        keys.iter()
+            .zip(facts)
+            .map(|(key, fact)| self.result_from_fact(fact_name, &Self::render_key(key), fact))
             .collect()
     }
 
@@ -188,32 +209,63 @@ where
 impl<S, R, A, C, SubjectId, ResourceId, Relation>
     RebacPolicy<S, R, A, C, SubjectId, ResourceId, Relation>
 where
+    SubjectId: fmt::Debug,
+    ResourceId: fmt::Debug,
     Relation: fmt::Display,
 {
-    fn result_from_fact(&self, fact: FactLoadResult<bool>) -> PolicyEvalResult {
+    /// Renders a relationship key for the [`FactProvenance`] attached to a
+    /// decision node, e.g. `User(42) -[owner]-> Doc(7)`.
+    fn render_key(key: &RelationshipQuery<SubjectId, ResourceId, Relation>) -> String {
+        format!(
+            "{:?} -[{}]-> {:?}",
+            key.subject_id, key.relation, key.resource_id
+        )
+    }
+
+    fn result_from_fact(
+        &self,
+        fact_name: &'static str,
+        key_repr: &str,
+        fact: FactLoadResult<bool>,
+    ) -> PolicyEvalResult {
+        let outcome = FactOutcome::from_load_result(&fact);
+        let detail = match &fact {
+            FactLoadResult::Error(error) => Some(error.to_string()),
+            _ => None,
+        };
+        // `fact_name` is captured from `<RelationshipQuery as FactKey>::NAME`
+        // at the Policy impl call site, so the provenance label tracks the
+        // typed key rather than a hardcoded literal that could silently
+        // drift if `RelationshipQuery::NAME` ever changes.
+        let provenance = vec![FactProvenance::new(fact_name, key_repr, outcome, detail)];
+
         match fact {
-            FactLoadResult::Found(true) => PolicyEvalResult::Granted {
-                policy_type: "RebacPolicy".to_string(),
-                reason: Some(format!(
+            FactLoadResult::Found(true) => PolicyEvalResult::granted_with_facts(
+                "RebacPolicy",
+                Some(format!(
                     "Subject has '{}' relationship with resource",
                     self.relation
                 )),
-            },
-            FactLoadResult::Found(false) => PolicyEvalResult::Denied {
-                policy_type: "RebacPolicy".to_string(),
-                reason: format!(
+                provenance,
+            ),
+            FactLoadResult::Found(false) => PolicyEvalResult::denied_with_facts(
+                "RebacPolicy",
+                format!(
                     "Subject does not have '{}' relationship with resource",
                     self.relation
                 ),
-            },
-            FactLoadResult::Missing => PolicyEvalResult::Denied {
-                policy_type: "RebacPolicy".to_string(),
-                reason: format!("Relationship '{}' fact is missing", self.relation),
-            },
-            FactLoadResult::Error(error) => PolicyEvalResult::Denied {
-                policy_type: "RebacPolicy".to_string(),
-                reason: format!("Relationship '{}' fact load failed: {error}", self.relation),
-            },
+                provenance,
+            ),
+            FactLoadResult::Missing => PolicyEvalResult::denied_with_facts(
+                "RebacPolicy",
+                format!("Relationship '{}' fact is missing", self.relation),
+                provenance,
+            ),
+            FactLoadResult::Error(error) => PolicyEvalResult::denied_with_facts(
+                "RebacPolicy",
+                format!("Relationship '{}' fact load failed: {error}", self.relation),
+                provenance,
+            ),
         }
     }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -27,12 +27,24 @@ pub struct EvalCtx<'a, Subject, Resource, Action, Context> {
 }
 
 /// Batch policy evaluation context.
+///
+/// A batch holds one `subject` and one `action` evaluated against many
+/// `(resource, context)` items — it answers "can this subject perform this
+/// action on each of these resources?". This matches the dominant batch shape
+/// (filtering a list of resources by a single verb, or authorizing a fan-out of
+/// frames that share an action) and is what lets set-oriented backends load the
+/// facts for every item in one round trip: the shared `(subject, action)` is
+/// the stable axis the prefetch keys on.
+///
+/// If items need different actions, either group them and run one batch per
+/// action, or carry the per-item action inside `Context` and have the policy
+/// read it from there.
 pub struct BatchEvalCtx<'a, Subject, Resource, Action, Context> {
     /// Request-scoped fact session.
     pub session: &'a EvaluationSession,
     /// Entity requesting access.
     pub subject: &'a Subject,
-    /// Action being performed.
+    /// Action being performed, shared across every item in the batch.
     pub action: &'a Action,
     /// Borrowed resource/context pairs.
     pub items: &'a [PolicyBatchItem<'a, Resource, Context>],

--- a/src/results.rs
+++ b/src/results.rs
@@ -24,6 +24,101 @@ impl fmt::Display for CombineOp {
     }
 }
 
+/// How a fact load that informed a policy decision resolved.
+///
+/// This mirrors [`crate::FactLoadResult`] without its value type, so it can be
+/// recorded on the non-generic [`PolicyEvalResult`] tree and serialized into
+/// audit logs. The concrete value (for example the `bool` of a relationship
+/// check) is reflected by the grant/deny outcome and the node's reason, not by
+/// this enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FactOutcome {
+    /// The fact existed.
+    Found,
+    /// The fact source was reached, but had no value for the key.
+    Missing,
+    /// The fact load failed.
+    Error,
+}
+
+impl FactOutcome {
+    /// Classifies a [`crate::FactLoadResult`] into the value-erased outcome.
+    pub fn from_load_result<V>(result: &crate::FactLoadResult<V>) -> Self {
+        match result {
+            crate::FactLoadResult::Found(_) => Self::Found,
+            crate::FactLoadResult::Missing => Self::Missing,
+            crate::FactLoadResult::Error(_) => Self::Error,
+        }
+    }
+}
+
+impl fmt::Display for FactOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Found => write!(f, "found"),
+            Self::Missing => write!(f, "missing"),
+            Self::Error => write!(f, "error"),
+        }
+    }
+}
+
+/// A record that a policy consulted a fact while reaching its decision.
+///
+/// Fact-backed policies (such as [`crate::RebacPolicy`]) attach one of these per
+/// fact lookup to their [`PolicyEvalResult::Granted`] or
+/// [`PolicyEvalResult::Denied`] node, so a decision's *inputs* are explained
+/// alongside its outcome. Provenance is intentionally type-erased — a fact
+/// name, a rendered key, an outcome, and optional detail — rather than the
+/// typed [`crate::FactKey`], so it lives on the non-generic result tree and is
+/// straightforward to log.
+///
+/// Operational fact-load telemetry (latencies, batch fan-out, cache hits) is a
+/// separate concern surfaced through `tracing` spans (`gatehouse.fact_load`);
+/// this type is for per-decision explanation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FactProvenance {
+    /// The [`crate::FactKey::NAME`] of the consulted fact (e.g. `"relationship"`).
+    pub fact_name: &'static str,
+    /// A human-readable rendering of the fact key that was looked up.
+    pub key: String,
+    /// How the load resolved.
+    pub outcome: FactOutcome,
+    /// Optional extra detail, such as the backend error message when
+    /// `outcome` is [`FactOutcome::Error`].
+    pub detail: Option<String>,
+}
+
+impl FactProvenance {
+    /// Records a consulted fact.
+    pub fn new(
+        fact_name: &'static str,
+        key: impl Into<String>,
+        outcome: FactOutcome,
+        detail: Option<String>,
+    ) -> Self {
+        Self {
+            fact_name,
+            key: key.into(),
+            outcome,
+            detail,
+        }
+    }
+}
+
+impl fmt::Display for FactProvenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "fact {} [{}]: {}",
+            self.fact_name, self.outcome, self.key
+        )?;
+        if let Some(detail) = &self.detail {
+            write!(f, " ({detail})")?;
+        }
+        Ok(())
+    }
+}
+
 /// The result of evaluating a single policy (or a combination).
 ///
 /// This enum is used both by individual policies and by combinators to represent the
@@ -40,6 +135,9 @@ pub enum PolicyEvalResult {
         policy_type: String,
         /// An optional human-readable reason for the grant.
         reason: Option<String>,
+        /// Facts the policy consulted to reach this decision. Empty for
+        /// policies that are not fact-backed (RBAC, ABAC, combinators).
+        provenance: Vec<FactProvenance>,
     },
     /// Access denied. Contains the policy type and a reason.
     Denied {
@@ -47,6 +145,9 @@ pub enum PolicyEvalResult {
         policy_type: String,
         /// A human-readable reason for the denial.
         reason: String,
+        /// Facts the policy consulted to reach this decision. Empty for
+        /// policies that are not fact-backed (RBAC, ABAC, combinators).
+        provenance: Vec<FactProvenance>,
     },
     /// Combined result from multiple policy evaluations.
     /// Contains the policy type, the combining operation ([`CombineOp`]),
@@ -222,6 +323,13 @@ impl fmt::Display for AccessEvaluation {
 /// Returned as part of [`AccessEvaluation`]. Use [`EvalTrace::format`] to render
 /// a human-readable tree, useful for debugging and audit logging.
 ///
+/// The tree records policy *decisions*. The *inputs* that informed a decision —
+/// the facts a fact-backed policy consulted — are attached to the individual
+/// [`PolicyEvalResult`] nodes as [`FactProvenance`] and rendered inline by
+/// [`EvalTrace::format`]. Operational fact-load telemetry (latency, batch
+/// fan-out, cache hits) is a separate concern surfaced through `tracing` spans
+/// (`gatehouse.fact_load`), not through this tree.
+///
 /// # Example
 ///
 /// ```rust
@@ -231,10 +339,10 @@ impl fmt::Display for AccessEvaluation {
 /// assert_eq!(empty.format(), "No evaluation trace available");
 ///
 /// // A trace built from a policy result renders a decision tree:
-/// let trace = EvalTrace::with_root(PolicyEvalResult::Granted {
-///     policy_type: "AdminPolicy".into(),
-///     reason: Some("User is admin".into()),
-/// });
+/// let trace = EvalTrace::with_root(PolicyEvalResult::granted(
+///     "AdminPolicy",
+///     Some("User is admin".into()),
+/// ));
 /// assert!(trace.format().contains("AdminPolicy GRANTED"));
 /// ```
 #[derive(Debug, Clone, Default)]
@@ -276,6 +384,56 @@ impl EvalTrace {
 }
 
 impl PolicyEvalResult {
+    /// Builds a granted leaf result with no fact provenance.
+    ///
+    /// Prefer this over constructing [`PolicyEvalResult::Granted`] directly; use
+    /// [`Self::granted_with_facts`] when the decision was informed by facts.
+    pub fn granted(policy_type: impl Into<String>, reason: Option<String>) -> Self {
+        Self::Granted {
+            policy_type: policy_type.into(),
+            reason,
+            provenance: Vec::new(),
+        }
+    }
+
+    /// Builds a denied leaf result with no fact provenance.
+    ///
+    /// Prefer this over constructing [`PolicyEvalResult::Denied`] directly; use
+    /// [`Self::denied_with_facts`] when the decision was informed by facts.
+    pub fn denied(policy_type: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::Denied {
+            policy_type: policy_type.into(),
+            reason: reason.into(),
+            provenance: Vec::new(),
+        }
+    }
+
+    /// Builds a granted leaf result carrying the facts that informed it.
+    pub fn granted_with_facts(
+        policy_type: impl Into<String>,
+        reason: Option<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self::Granted {
+            policy_type: policy_type.into(),
+            reason,
+            provenance,
+        }
+    }
+
+    /// Builds a denied leaf result carrying the facts that informed it.
+    pub fn denied_with_facts(
+        policy_type: impl Into<String>,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self::Denied {
+            policy_type: policy_type.into(),
+            reason: reason.into(),
+            provenance,
+        }
+    }
+
     /// Returns whether this evaluation resulted in access being granted
     pub fn is_granted(&self) -> bool {
         match self {
@@ -294,6 +452,16 @@ impl PolicyEvalResult {
         }
     }
 
+    /// Returns the facts the policy consulted to reach this decision.
+    ///
+    /// Empty for combinators and for policies that are not fact-backed.
+    pub fn provenance(&self) -> &[FactProvenance] {
+        match self {
+            Self::Granted { provenance, .. } | Self::Denied { provenance, .. } => provenance,
+            Self::Combined { .. } => &[],
+        }
+    }
+
     /// Formats the evaluation tree with indentation for readability
     pub fn format(&self, indent: usize) -> String {
         let indent_str = " ".repeat(indent);
@@ -302,17 +470,21 @@ impl PolicyEvalResult {
             Self::Granted {
                 policy_type,
                 reason,
+                provenance,
             } => {
                 let reason_text = reason
                     .as_ref()
                     .map_or("".to_string(), |r| format!(": {}", r));
-                format!("{}✔ {} GRANTED{}", indent_str, policy_type, reason_text)
+                let headline = format!("{}✔ {} GRANTED{}", indent_str, policy_type, reason_text);
+                Self::append_provenance(headline, &indent_str, provenance)
             }
             Self::Denied {
                 policy_type,
                 reason,
+                provenance,
             } => {
-                format!("{}✘ {} DENIED: {}", indent_str, policy_type, reason)
+                let headline = format!("{}✘ {} DENIED: {}", indent_str, policy_type, reason);
+                Self::append_provenance(headline, &indent_str, provenance)
             }
             Self::Combined {
                 policy_type,
@@ -332,6 +504,19 @@ impl PolicyEvalResult {
                 result
             }
         }
+    }
+
+    /// Appends one indented `↳ fact …` line per consulted fact under a leaf node.
+    fn append_provenance(
+        headline: String,
+        indent_str: &str,
+        provenance: &[FactProvenance],
+    ) -> String {
+        let mut result = headline;
+        for fact in provenance {
+            result.push_str(&format!("\n{indent_str}  ↳ {fact}"));
+        }
+        result
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -345,10 +345,7 @@ mod core_tests {
             &self,
             _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("Always allow policy".to_string()),
-            }
+            PolicyEvalResult::granted(self.policy_type(), Some("Always allow policy".to_string()))
         }
 
         fn policy_type(&self) -> &str {
@@ -365,10 +362,7 @@ mod core_tests {
             &self,
             _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: self.0.to_string(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), self.0)
         }
 
         fn policy_type(&self) -> &str {
@@ -389,15 +383,9 @@ mod core_tests {
         ) -> PolicyEvalResult {
             self.single_calls.fetch_add(1, Ordering::SeqCst);
             if ctx.resource.id.as_u128().is_multiple_of(2) {
-                PolicyEvalResult::Granted {
-                    policy_type: self.policy_type().to_string(),
-                    reason: Some("even resource".to_string()),
-                }
+                PolicyEvalResult::granted(self.policy_type(), Some("even resource".to_string()))
             } else {
-                PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "odd resource".to_string(),
-                }
+                PolicyEvalResult::denied(self.policy_type(), "odd resource")
             }
         }
 
@@ -433,10 +421,7 @@ mod core_tests {
             &self,
             _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("single item fallback".to_string()),
-            }
+            PolicyEvalResult::granted(self.policy_type(), Some("single item fallback".to_string()))
         }
 
         async fn evaluate_batch<'item>(
@@ -446,9 +431,11 @@ mod core_tests {
             ctx.items
                 .iter()
                 .skip(1)
-                .map(|_| PolicyEvalResult::Granted {
-                    policy_type: self.policy_type().to_string(),
-                    reason: Some("wrong batch length".to_string()),
+                .map(|_| {
+                    PolicyEvalResult::granted(
+                        self.policy_type(),
+                        Some("wrong batch length".to_string()),
+                    )
                 })
                 .collect()
         }
@@ -466,10 +453,7 @@ mod core_tests {
             &self,
             _ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, TestContext>,
         ) -> PolicyEvalResult {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "Blocked by custom rule".to_string(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "Blocked by custom rule")
         }
 
         fn policy_type(&self) -> &str {
@@ -1366,6 +1350,45 @@ mod core_tests {
         let result = policy.evaluate(&ctx).await;
 
         assert!(result.is_granted());
+        // A fact-backed grant records the consulted relationship as provenance.
+        let provenance = result.provenance();
+        assert_eq!(provenance.len(), 1);
+        assert_eq!(provenance[0].fact_name, "relationship");
+        assert_eq!(provenance[0].outcome, FactOutcome::Found);
+        assert!(provenance[0].detail.is_none());
+        // The rendered trace surfaces the fact inline.
+        assert!(result.format(0).contains("↳ fact relationship [found]"));
+    }
+
+    #[tokio::test]
+    async fn test_rebac_policy_records_provenance_on_load_error() {
+        let policy = relationship_policy("manager".to_string());
+        let subject = TestSubject {
+            id: uuid::Uuid::new_v4(),
+        };
+        let resource = TestResource {
+            id: uuid::Uuid::new_v4(),
+        };
+        let session = EvaluationSession::new();
+        session.register::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(
+            ErrorRelationshipSource,
+        );
+        let ctx = EvalCtx {
+            session: &session,
+            subject: &subject,
+            action: &TestAction,
+            resource: &resource,
+            context: &TestContext,
+        };
+
+        let result = policy.evaluate(&ctx).await;
+
+        assert!(!result.is_granted());
+        let provenance = result.provenance();
+        assert_eq!(provenance.len(), 1);
+        assert_eq!(provenance[0].outcome, FactOutcome::Error);
+        // The backend error message is carried as provenance detail.
+        assert!(provenance[0].detail.is_some());
     }
 
     #[tokio::test]
@@ -1850,15 +1873,12 @@ mod core_tests {
             ctx: &EvalCtx<'_, TestSubject, TestResource, TestAction, FeatureFlagContext>,
         ) -> PolicyEvalResult {
             if ctx.context.feature_enabled {
-                PolicyEvalResult::Granted {
-                    policy_type: self.policy_type().to_string(),
-                    reason: Some("Feature flag enabled".to_string()),
-                }
+                PolicyEvalResult::granted(
+                    self.policy_type(),
+                    Some("Feature flag enabled".to_string()),
+                )
             } else {
-                PolicyEvalResult::Denied {
-                    policy_type: self.policy_type().to_string(),
-                    reason: "Feature flag disabled".to_string(),
-                }
+                PolicyEvalResult::denied(self.policy_type(), "Feature flag disabled")
             }
         }
 
@@ -1953,6 +1973,7 @@ mod core_tests {
             PolicyEvalResult::Denied {
                 policy_type,
                 reason,
+                ..
             } => {
                 assert_eq!(policy_type, "AbacPolicy");
                 assert!(reason.contains("false"));
@@ -2081,6 +2102,7 @@ mod core_tests {
             PolicyEvalResult::Denied {
                 policy_type,
                 reason,
+                ..
             } => {
                 assert_eq!(policy_type, "RbacPolicy");
                 assert!(reason.contains("doesn't have required role"));
@@ -2223,15 +2245,12 @@ mod core_tests {
                 self.counter.fetch_add(1, Ordering::SeqCst);
 
                 if self.result {
-                    PolicyEvalResult::Granted {
-                        policy_type: self.policy_type().to_string(),
-                        reason: Some("Counting policy granted".to_string()),
-                    }
+                    PolicyEvalResult::granted(
+                        self.policy_type(),
+                        Some("Counting policy granted".to_string()),
+                    )
                 } else {
-                    PolicyEvalResult::Denied {
-                        policy_type: self.policy_type().to_string(),
-                        reason: "Counting policy denied".to_string(),
-                    }
+                    PolicyEvalResult::denied(self.policy_type(), "Counting policy denied")
                 }
             }
 
@@ -2473,10 +2492,7 @@ mod core_tests {
 
     #[test]
     fn test_eval_trace_with_root() {
-        let result = PolicyEvalResult::Granted {
-            policy_type: "TestPolicy".to_string(),
-            reason: Some("Test reason".to_string()),
-        };
+        let result = PolicyEvalResult::granted("TestPolicy", Some("Test reason".to_string()));
         let trace = EvalTrace::with_root(result);
 
         assert!(trace.root().is_some(), "Trace with root should have a root");
@@ -2496,10 +2512,7 @@ mod core_tests {
         let mut trace = EvalTrace::new();
         assert!(trace.root().is_none());
 
-        let result = PolicyEvalResult::Denied {
-            policy_type: "DenyPolicy".to_string(),
-            reason: "Denied for testing".to_string(),
-        };
+        let result = PolicyEvalResult::denied("DenyPolicy", "Denied for testing");
         trace.set_root(result);
 
         assert!(
@@ -2521,26 +2534,17 @@ mod core_tests {
 
     #[test]
     fn test_policy_eval_result_reason_granted() {
-        let result = PolicyEvalResult::Granted {
-            policy_type: "TestPolicy".to_string(),
-            reason: Some("Grant reason".to_string()),
-        };
+        let result = PolicyEvalResult::granted("TestPolicy", Some("Grant reason".to_string()));
         assert_eq!(result.reason(), Some("Grant reason".to_string()));
 
         // Test with None reason
-        let result_no_reason = PolicyEvalResult::Granted {
-            policy_type: "TestPolicy".to_string(),
-            reason: None,
-        };
+        let result_no_reason = PolicyEvalResult::granted("TestPolicy", None);
         assert_eq!(result_no_reason.reason(), None);
     }
 
     #[test]
     fn test_policy_eval_result_reason_denied() {
-        let result = PolicyEvalResult::Denied {
-            policy_type: "TestPolicy".to_string(),
-            reason: "Deny reason".to_string(),
-        };
+        let result = PolicyEvalResult::denied("TestPolicy", "Deny reason");
         assert_eq!(result.reason(), Some("Deny reason".to_string()));
     }
 
@@ -2561,10 +2565,7 @@ mod core_tests {
 
     #[test]
     fn test_policy_eval_result_format_indentation() {
-        let result = PolicyEvalResult::Granted {
-            policy_type: "TestPolicy".to_string(),
-            reason: Some("Test".to_string()),
-        };
+        let result = PolicyEvalResult::granted("TestPolicy", Some("Test".to_string()));
 
         let formatted_0 = result.format(0);
         let formatted_4 = result.format(4);
@@ -2581,10 +2582,7 @@ mod core_tests {
 
     #[test]
     fn test_policy_eval_result_display() {
-        let result = PolicyEvalResult::Denied {
-            policy_type: "TestPolicy".to_string(),
-            reason: "Test denial".to_string(),
-        };
+        let result = PolicyEvalResult::denied("TestPolicy", "Test denial");
 
         let display_str = format!("{}", result);
         assert!(display_str.contains("TestPolicy"));

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -67,15 +67,9 @@ impl Policy<Subject, Resource, Action, Ctx> for BatchGrantPolicy {
 impl BatchGrantPolicy {
     fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
         if (self.grant)(resource_id) {
-            PolicyEvalResult::Granted {
-                policy_type: self.name.to_string(),
-                reason: Some(format!("{resource_id} granted")),
-            }
+            PolicyEvalResult::granted(self.name, Some(format!("{resource_id} granted")))
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.name.to_string(),
-                reason: format!("{resource_id} denied"),
-            }
+            PolicyEvalResult::denied(self.name, format!("{resource_id} denied"))
         }
     }
 }
@@ -114,15 +108,9 @@ impl RandomStackPolicy {
     fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
         let score = ((resource_id as u16 * 37) ^ self.salt).wrapping_add(self.salt / 3) % 100;
         if score < self.grant_percent as u16 {
-            PolicyEvalResult::Granted {
-                policy_type: self.name.clone(),
-                reason: Some(format!("{resource_id} granted")),
-            }
+            PolicyEvalResult::granted(self.name.clone(), Some(format!("{resource_id} granted")))
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.name.clone(),
-                reason: format!("{resource_id} denied"),
-            }
+            PolicyEvalResult::denied(self.name.clone(), format!("{resource_id} denied"))
         }
     }
 }
@@ -138,10 +126,7 @@ impl Policy<Subject, Resource, Action, Ctx> for NeverConsultedPolicy {
         _ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
     ) -> PolicyEvalResult {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        PolicyEvalResult::Denied {
-            policy_type: self.policy_type().to_string(),
-            reason: "single called".to_string(),
-        }
+        PolicyEvalResult::denied(self.policy_type(), "single called")
     }
 
     async fn evaluate_batch<'item>(

--- a/tests/lookup_contract.rs
+++ b/tests/lookup_contract.rs
@@ -55,17 +55,17 @@ struct OwnerPolicy {
 impl Policy<User, Doc, ReadAction, Ctx> for OwnerPolicy {
     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Doc, ReadAction, Ctx>) -> PolicyEvalResult {
         match self.owns.get(&ctx.resource.id) {
-            Some(owner) if *owner == ctx.subject.id => PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some(format!("user {} owns doc {}", owner, ctx.resource.id)),
-            },
-            _ => PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: format!(
+            Some(owner) if *owner == ctx.subject.id => PolicyEvalResult::granted(
+                self.policy_type(),
+                Some(format!("user {} owns doc {}", owner, ctx.resource.id)),
+            ),
+            _ => PolicyEvalResult::denied(
+                self.policy_type(),
+                format!(
                     "user {} does not own doc {}",
                     ctx.subject.id, ctx.resource.id
                 ),
-            },
+            ),
         }
     }
     fn policy_type(&self) -> &str {
@@ -82,15 +82,9 @@ struct PublicDocPolicy;
 impl Policy<User, Doc, ReadAction, Ctx> for PublicDocPolicy {
     async fn evaluate(&self, ctx: &EvalCtx<'_, User, Doc, ReadAction, Ctx>) -> PolicyEvalResult {
         if ctx.resource.public {
-            PolicyEvalResult::Granted {
-                policy_type: self.policy_type().to_string(),
-                reason: Some("public doc".into()),
-            }
+            PolicyEvalResult::granted(self.policy_type(), Some("public doc".into()))
         } else {
-            PolicyEvalResult::Denied {
-                policy_type: self.policy_type().to_string(),
-                reason: "doc is not public".into(),
-            }
+            PolicyEvalResult::denied(self.policy_type(), "doc is not public")
         }
     }
     fn policy_type(&self) -> &str {

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -56,15 +56,9 @@ impl Policy<Subject, Resource, Action, Ctx> for TracePolicy {
 
 fn result_for(allowed: bool) -> PolicyEvalResult {
     if allowed {
-        PolicyEvalResult::Granted {
-            policy_type: "TracePolicy".to_string(),
-            reason: Some("allowed".to_string()),
-        }
+        PolicyEvalResult::granted("TracePolicy", Some("allowed".to_string()))
     } else {
-        PolicyEvalResult::Denied {
-            policy_type: "TracePolicy".to_string(),
-            reason: "denied".to_string(),
-        }
+        PolicyEvalResult::denied("TracePolicy", "denied")
     }
 }
 


### PR DESCRIPTION
The v0.3.0-alpha.2 release PR (#33) was branched from a **stale local HEAD predating #31**. Its squash-merge therefore reverted every file #31 touched: \`FactProvenance\` / \`FactOutcome\`, the new constructors, the \`provenance()\` accessor, \`RebacPolicy\`'s provenance recording, the new Debug bounds, and the expanded docstrings.

This PR restores those source-file changes from #31 (\`2b94caa\`) while keeping the alpha.2 version bump and CHANGELOG header that the release commit got right.

The GitHub Release was deliberately not created from the broken state, so crates.io has not seen the regression. After this PR merges, the alpha.2 release will be cut from a correct state.

## Validation
- \`cargo fmt --all --check\` ✅
- \`cargo clippy --all-targets --all-features -- -D warnings\` ✅
- \`cargo test --all-targets --all-features\` ✅ (86 lib + integration suites)
- \`RUSTFLAGS=\"--cfg loom\" cargo test --lib --release\` ✅ (16 models)

## Future-proofing
Root cause: stale local main worktree HEAD after a sequence of admin-merges in this session. Avoiding next time means either \`git pull --ff-only\` (not just \`fetch\`) before each release branch, or doing the release work in a fresh worktree.