### PR TITLE
Polish examples + document FactSource/Hydrator as DataLoader-style primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Crate-level, `FactSource`, and `Hydrator` rustdoc now frame these traits as gatehouse's request-scoped DataLoader-style primitives, and call out that callers may invoke an existing DataLoader implementation (`async-graphql::dataloader`, `ultra-batch`, or a home-grown batcher) directly from inside `FactSource::load_many` or `Hydrator::hydrate`. Gatehouse owns the per-request fact graph; the underlying loader owns batching across the rest of the request and any longer-lived caching.
+- Crate-level, `FactSource`, and `Hydrator` rustdoc now frame these traits as gatehouse's request-scoped DataLoader-style primitives, and call out that callers may invoke an existing DataLoader implementation (`async_graphql::dataloader` from the `async-graphql` crate, the `ultra-batch` crate, or a home-grown batcher) directly from inside `FactSource::load_many` or `Hydrator::hydrate`. Gatehouse owns the per-request fact graph; the underlying loader owns batching across the rest of the request and any longer-lived caching. The `Hydrator` docs also call out that gatehouse expects `Vec<Option<Resource>>` in input order, so a hydrator wrapping a map-returning DataLoader re-orders the loader's output back into the slice shape.
 - Examples polished for v0.3 idiom: `combinator_policy` uses `EvaluationSession::empty()` for its RBAC/ABAC-only setup; `groups_policy` gained a `//!` file header; the `axum` test helper formerly named `evaluate_access` was renamed `check_in_empty_session` to avoid evoking the pre-v0.3 API.
 
 ## [0.3.0-alpha.2] - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Crate-level, `FactSource`, and `Hydrator` rustdoc now frame these traits as gatehouse's request-scoped DataLoader-style primitives, and call out that callers may invoke an existing DataLoader implementation (`async-graphql::dataloader`, `ultra-batch`, or a home-grown batcher) directly from inside `FactSource::load_many` or `Hydrator::hydrate`. Gatehouse owns the per-request fact graph; the underlying loader owns batching across the rest of the request and any longer-lived caching.
+- Examples polished for v0.3 idiom: `combinator_policy` uses `EvaluationSession::empty()` for its RBAC/ABAC-only setup; `groups_policy` gained a `//!` file header; the `axum` test helper formerly named `evaluate_access` was renamed `check_in_empty_session` to avoid evoking the pre-v0.3 API.
+
 ## [0.3.0-alpha.2] - 2026-06-01
 
 ### Breaking

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -1,5 +1,8 @@
 // Axum service that authorizes multiple resource types (Invoices, Payments)
-// using a single PermissionChecker. Demonstrates multiple policies and actions.
+// using a single PermissionChecker. Demonstrates multiple policies and
+// actions, app-state-owned fact sources, and per-request
+// [`EvaluationSession`] construction via
+// [`EvaluationSession::builder`].
 
 use async_trait::async_trait;
 use axum::{
@@ -693,7 +696,7 @@ mod tests {
     }
 
     trait TestCheckerExt {
-        fn evaluate_access<'a>(
+        fn check_in_empty_session<'a>(
             &'a self,
             user: &'a User,
             action: &'a Action,
@@ -703,7 +706,7 @@ mod tests {
     }
 
     impl TestCheckerExt for PermissionChecker<User, Resource, Action, RequestContext> {
-        fn evaluate_access<'a>(
+        fn check_in_empty_session<'a>(
             &'a self,
             user: &'a User,
             action: &'a Action,
@@ -735,7 +738,7 @@ mod tests {
         let resource = Resource::Invoice(invoice);
 
         let result = checker
-            .evaluate_access(&admin_user, &Action::Edit, &resource, &context_now())
+            .check_in_empty_session(&admin_user, &Action::Edit, &resource, &context_now())
             .await;
 
         assert!(
@@ -766,7 +769,7 @@ mod tests {
 
         // The user is the owner, the invoice is unlocked, <30 days old => should be granted
         let result = checker
-            .evaluate_access(&user, &Action::Edit, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::Edit, &resource, &context_now())
             .await;
 
         assert!(
@@ -789,7 +792,7 @@ mod tests {
         let resource = Resource::Invoice(invoice);
 
         let result = checker
-            .evaluate_access(&user, &Action::Edit, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::Edit, &resource, &context_now())
             .await;
 
         assert!(
@@ -827,7 +830,7 @@ mod tests {
         let resource = Resource::Invoice(invoice);
 
         let result = checker
-            .evaluate_access(&user, &Action::Edit, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::Edit, &resource, &context_now())
             .await;
 
         assert!(
@@ -858,7 +861,7 @@ mod tests {
         let resource = Resource::Invoice(invoice);
 
         let result = checker
-            .evaluate_access(&user, &Action::Edit, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::Edit, &resource, &context_now())
             .await;
         assert!(
             !result.is_granted(),
@@ -883,7 +886,7 @@ mod tests {
         let resource = Resource::Payment(payment);
 
         let result = checker
-            .evaluate_access(&user, &Action::ApprovePayment, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::ApprovePayment, &resource, &context_now())
             .await;
 
         assert!(
@@ -908,7 +911,7 @@ mod tests {
         let resource = Resource::Payment(payment);
 
         let result = checker
-            .evaluate_access(&user, &Action::ApprovePayment, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::ApprovePayment, &resource, &context_now())
             .await;
 
         assert!(
@@ -930,7 +933,7 @@ mod tests {
 
         // Not finance_manager or admin => deny
         let result = checker
-            .evaluate_access(&user, &Action::ApprovePayment, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::ApprovePayment, &resource, &context_now())
             .await;
         assert!(
             !result.is_granted(),
@@ -956,7 +959,7 @@ mod tests {
 
         // 1) finance_manager can refund
         let res1 = checker
-            .evaluate_access(
+            .check_in_empty_session(
                 &user_finance,
                 &Action::RefundPayment,
                 &resource,
@@ -967,7 +970,7 @@ mod tests {
 
         // 2) refund_specialist can refund
         let res2 = checker
-            .evaluate_access(
+            .check_in_empty_session(
                 &user_refund_specialist,
                 &Action::RefundPayment,
                 &resource,
@@ -990,7 +993,7 @@ mod tests {
 
         // Should be denied
         let result = checker
-            .evaluate_access(&user, &Action::RefundPayment, &resource, &context_now())
+            .check_in_empty_session(&user, &Action::RefundPayment, &resource, &context_now())
             .await;
         assert!(!result.is_granted(), "Regular user can't refund payment");
     }

--- a/examples/combinator_policy.rs
+++ b/examples/combinator_policy.rs
@@ -79,7 +79,8 @@ async fn main() {
     let document = Document::new();
     let action = ViewAction;
     let context = EmptyContext;
-    let session = EvaluationSession::new();
+    // RBAC-only example: no fact sources, so the empty session is enough.
+    let session = EvaluationSession::empty();
 
     println!("=== AND Policy Short-Circuit Example ===");
     {

--- a/examples/groups_policy.rs
+++ b/examples/groups_policy.rs
@@ -1,3 +1,11 @@
+//! Composing two custom policies (an org-admin shortcut and a per-permission
+//! staff check) into a single `PermissionChecker` and reading the per-policy
+//! reasons out of the evaluation trace.
+//!
+//! Demonstrates: custom `Policy` impls with the new
+//! `PolicyEvalResult::granted` / `denied` constructors, OR semantics across
+//! policies, and using `EvalTrace` to surface the reason chain.
+
 use async_trait::async_trait;
 use gatehouse::*;
 use uuid::Uuid;

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -142,11 +142,13 @@ pub enum FactLoadResult<V> {
 ///
 /// `FactSource` is gatehouse's request-scoped DataLoader-style primitive:
 /// the session deduplicates inputs, holds a per-session cache, and joins
-/// concurrent in-flight loads for the same key, then hands a unique slice
-/// to [`Self::load_many`]. If your application already runs a DataLoader
-/// implementation — `async-graphql::dataloader`, `ultra-batch`, or any
-/// home-grown batcher — call it directly from inside `load_many`. The two
-/// layers compose: gatehouse owns the per-request fact graph for one
+/// concurrent in-flight loads for the same key, then hands one or more
+/// unique-key slices to [`Self::load_many`] (chunked by
+/// [`Self::max_batch_size`]). If your application already runs a
+/// DataLoader implementation — `async_graphql::dataloader` (from the
+/// `async-graphql` crate), the `ultra-batch` crate, or any home-grown
+/// batcher — call it directly from inside `load_many`. The two layers
+/// compose: gatehouse owns the per-request fact graph for one
 /// authorization pass; the underlying loader owns batching across the rest
 /// of the request, request coalescing across many concurrent passes, and
 /// any longer-lived caching.

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -139,6 +139,17 @@ pub enum FactLoadResult<V> {
 /// Sources can be shared across many request sessions. The source owns
 /// backend-specific serialization and I/O; the session owns per-request
 /// deduplication, caching, chunking, and in-flight coalescing.
+///
+/// `FactSource` is gatehouse's request-scoped DataLoader-style primitive:
+/// the session deduplicates inputs, holds a per-session cache, and joins
+/// concurrent in-flight loads for the same key, then hands a unique slice
+/// to [`Self::load_many`]. If your application already runs a DataLoader
+/// implementation — `async-graphql::dataloader`, `ultra-batch`, or any
+/// home-grown batcher — call it directly from inside `load_many`. The two
+/// layers compose: gatehouse owns the per-request fact graph for one
+/// authorization pass; the underlying loader owns batching across the rest
+/// of the request, request coalescing across many concurrent passes, and
+/// any longer-lived caching.
 #[async_trait]
 pub trait FactSource<K>: Send + Sync
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,17 @@
 //! joins concurrent in-flight loads for the same key.
 //!
 //! [`FactSource`] is Gatehouse's **request-scoped DataLoader-style primitive**:
-//! the session deduplicates and caches keys, and the source receives one
-//! batched call per unique key set. If your application already uses a
-//! DataLoader implementation (for example `async-graphql::dataloader` or
-//! `ultra-batch`), call it directly from inside [`FactSource::load_many`] —
-//! gatehouse does not need its own batching layer for the data fetch, only
-//! for the per-request fact graph. The same composition pattern applies to
-//! the [`Hydrator`] used by lookup-style listings (`Hydrator::hydrate`).
+//! the session deduplicates and caches keys before calling the source, then
+//! chunks the unique key set according to
+//! [`FactSource::max_batch_size`] — so the source may receive one or more
+//! batched calls per request, each over a slice of the unique keys. If your
+//! application already uses a DataLoader implementation (for example
+//! `async_graphql::dataloader` from the `async-graphql` crate, or the
+//! `ultra-batch` crate), call it directly from inside
+//! [`FactSource::load_many`] — gatehouse does not need its own batching
+//! layer for the data fetch, only for the per-request fact graph. The same
+//! composition pattern applies to the [`Hydrator`] used by lookup-style
+//! listings (`Hydrator::hydrate`).
 //!
 //! [`RebacPolicy`] is the first built-in policy backed by this model. It
 //! extracts flat subject/resource IDs, builds [`RelationshipQuery`] keys, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,15 @@
 //! caller inputs, preserves caller order, caches results for the request, and
 //! joins concurrent in-flight loads for the same key.
 //!
+//! [`FactSource`] is Gatehouse's **request-scoped DataLoader-style primitive**:
+//! the session deduplicates and caches keys, and the source receives one
+//! batched call per unique key set. If your application already uses a
+//! DataLoader implementation (for example `async-graphql::dataloader` or
+//! `ultra-batch`), call it directly from inside [`FactSource::load_many`] —
+//! gatehouse does not need its own batching layer for the data fetch, only
+//! for the per-request fact graph. The same composition pattern applies to
+//! the [`Hydrator`] used by lookup-style listings (`Hydrator::hydrate`).
+//!
 //! [`RebacPolicy`] is the first built-in policy backed by this model. It
 //! extracts flat subject/resource IDs, builds [`RelationshipQuery`] keys, and
 //! asks the session for relationship facts.

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -107,6 +107,14 @@ pub struct LookupPage<Id> {
 /// Returning a vector of length other than `ids.len()` is a contract
 /// violation and is reported by gatehouse as a hydrator contract error.
 /// Returning `Err` aborts the consuming pipeline.
+///
+/// Like [`crate::FactSource`], a `Hydrator` is a natural place to call an
+/// existing DataLoader-style batch loader (`async-graphql::dataloader`,
+/// `ultra-batch`, or a home-grown batcher). The hydrator receives a
+/// candidate-page slice of IDs and returns one `Option<Resource>` per ID —
+/// exactly the shape a DataLoader's `load_many` returns. Gatehouse
+/// authorizes the resolved subset through the existing policy stack; the
+/// underlying loader owns request-wide batching and caching.
 #[async_trait]
 pub trait Hydrator<Id>: Send + Sync {
     /// The resource type produced by the hydrator.

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -109,12 +109,15 @@ pub struct LookupPage<Id> {
 /// Returning `Err` aborts the consuming pipeline.
 ///
 /// Like [`crate::FactSource`], a `Hydrator` is a natural place to call an
-/// existing DataLoader-style batch loader (`async-graphql::dataloader`,
-/// `ultra-batch`, or a home-grown batcher). The hydrator receives a
-/// candidate-page slice of IDs and returns one `Option<Resource>` per ID —
-/// exactly the shape a DataLoader's `load_many` returns. Gatehouse
-/// authorizes the resolved subset through the existing policy stack; the
-/// underlying loader owns request-wide batching and caching.
+/// existing DataLoader-style batch loader (`async_graphql::dataloader`
+/// from the `async-graphql` crate, the `ultra-batch` crate, or a
+/// home-grown batcher). Gatehouse hands the hydrator a candidate-page
+/// slice of IDs and expects `Vec<Option<Resource>>` *in input order*;
+/// most DataLoader APIs instead return a `HashMap<Id, Resource>`, so the
+/// hydrator implementation re-orders the loader's output into the slice
+/// shape gatehouse needs (with `None` for IDs that no longer resolve).
+/// Gatehouse authorizes the resolved subset through the existing policy
+/// stack; the underlying loader owns request-wide batching and caching.
 #[async_trait]
 pub trait Hydrator<Id>: Send + Sync {
     /// The resource type produced by the hydrator.


### PR DESCRIPTION
Two threads in one small PR.

## 1. Idiomatic v0.3 example polish

After a careful audit of all 10 examples, three small things were non-idiomatic:

- **\`combinator_policy.rs\`**: used \`EvaluationSession::new()\` for what is really an RBAC/ABAC-only walkthrough. Switched to \`empty()\` with a one-line comment explaining why.
- **\`groups_policy.rs\`**: missing the \`//!\` file header every other example has. Added one explaining the OrgAdmin OR StaffPolicy demo.
- **\`axum.rs\` (test module)**: a test-local helper named \`evaluate_access\` echoed the v0.2 API surface that no longer exists, which is misleading when scanning for legacy patterns. Renamed to \`check_in_empty_session\`.

The other 7 examples are already idiomatic. (\`actix_web\` and \`axum\` keep \`//\` file headers — they are pulled into integration tests via \`include!()\` inside a sub-module, which rejects \`//!\` inner doc comments; example file-level rustdoc is not actually surfaced anywhere.)

## 2. DataLoader-style composition docs

Per the request: spell out that \`FactSource\` is gatehouse's request-scoped DataLoader-style primitive, and that callers using an existing batch-loader implementation can plug it in directly.

- **Crate-level (\`src/lib.rs\`)**: new paragraph in the *Fact-Loaded Authorization* section framing \`FactSource\` as a DataLoader-style primitive and noting that \`async-graphql::dataloader\` / \`ultra-batch\` / home-grown batchers can be called directly from inside \`load_many\`. Same composition pattern applies to \`Hydrator\` for lookup-style listings.
- **\`FactSource\` trait (\`src/facts.rs\`)**: matching paragraph on the trait docstring so a reader who lands there sees the recipe without bouncing to the crate root.
- **\`Hydrator\` trait (\`src/lookup.rs\`)**: same paragraph in the trait's own context.

The end-to-end integration recipe example (e.g. \`examples/lookup_async_graphql_loader.rs\`) is deliberately deferred: it adds a dependency-coupled file, and the docs cover the mental model adequately for now.

## Validation

- \`cargo fmt --all --check\` ✅
- \`cargo clippy --all-targets --all-features -- -D warnings\` ✅
- \`cargo test --all-targets --all-features\` ✅ (86 + 9 + 24 + 10 + 11 + 18 + 4 + 0 + 12, 0 failures)
- \`cargo doc --all-features --no-deps\` ✅