### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-10
+
+A small, backward-leaning follow-up to 0.3.0: result-type and `RbacPolicy` ergonomics, plus a reviewed-and-tightened example suite. The one thing to know when upgrading is the `RbacPolicy` role-type generalization below — existing `Uuid`-based code compiles unchanged, but a resolver closure that returned a bare `vec![]` with the role type otherwise unmentioned may now need a type annotation. The minor version bump reflects that single inference edge; everything else is additive.
+
 ### Added
 
 - `RbacPolicy` is now generic over the role identifier type. Any `PartialEq` type works — a domain enum, string ids, or `Uuid`s — inferred from the resolver closures' return types. Existing `Uuid`-based code keeps working unchanged; the one edge is closures whose role type was previously pinned only by the impl (e.g. a bare `vec![]` with no other mention of the role type), which may now need an annotation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "gatehouse"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix-web",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehouse"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 # 1.82 is required for `Option::is_none_or` (stabilized 2024-10-17), used
 # in the builder's per-axis predicate evaluation. Other dependencies on


### PR DESCRIPTION
Cuts the **v0.4.0** release.

## Changes
- `Cargo.toml` / `Cargo.lock`: `0.3.0` → `0.4.0`
- `CHANGELOG.md`: `[Unreleased]` → `## [0.4.0] - 2026-06-10`, with an intro flagging the one upgrade caveat

## What's in this release
Result-type and `RbacPolicy` ergonomics plus a reviewed-and-tightened example suite (from #43). Public-API surface:

- **`RbacPolicy` is now generic over the role identifier type** — domain enums / string ids / `Uuid`s, inferred from the resolver closures.
- `AccessEvaluation::trace()` — trace accessor regardless of outcome.
- `PolicyEvalResult::reason_str()` — borrowing analogue of `reason()`.
- `EmptyPoliciesError: Display + std::error::Error`.
- `CombineOp: Copy + Eq`.

## Versioning note
Minor bump (0.x compatibility-major). Four of the five API changes are strictly additive. The `RbacPolicy` generalization is additive in the common case — the struct and `RbacPolicy::new()` are unchanged and existing `Uuid` code compiles as-is — but a resolver closure returning a bare `vec![]` with the role type otherwise unmentioned may now need a type annotation. The bump reflects that single inference edge.

## Validation
`cargo build --workspace`, `fmt`, `clippy --all-targets --all-features -- -D warnings`, full test suite (106 unit + 11 actix + 15 axum + contract/tracing), `cargo test --doc`, and `cargo publish --dry-run` all pass.

## After merge
Publishing to crates.io is triggered by creating a GitHub Release tagged `v0.4.0` (CI `release` job runs `cargo publish`) — not by the merge itself.