### PR TITLE
Honor Effect::Deny in PermissionChecker (fixed deny-overrides semantics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+`PermissionChecker` now honors `Effect::Deny` with fixed deny-overrides semantics (#44). Checkers containing no `Effect::Deny` policies behave identically to before — for them this release is purely additive. **If you had already registered an `Effect::Deny` policy in a checker, its behavior changes: it used to do nothing (a matched deny composed into nothing under the old OR-only semantics — the trap this release fixes) and it now vetoes matching requests.** Audit existing `.effect(Effect::Deny)` call sites before upgrading.
+
+### Changed
+
+- **`PermissionChecker` decision semantics are now deny-overrides** (Cedar/IAM-style, fixed, no combining-algorithm knob): any policy that *forbids* denies the request, overriding every grant; otherwise OR-with-short-circuit over grants as before; otherwise default deny. Deny-effect policies are evaluated before allow policies, so a veto is independent of registration order. Applies identically to single, batch (`evaluate_batch_in_session_*`), filter, and lookup (`lookup_authorized*`) paths.
+- A matched `PolicyBuilder` policy with `.effect(Effect::Deny)` now returns the new `PolicyEvalResult::Forbidden` ("this policy forbids") instead of `Denied` ("this policy does not grant"); a non-match still returns `Denied` and never blocks anything.
+- The checker's trace root is now a `CombineOp::DenyOverrides` node (rendered `DENY_OVERRIDES`) instead of `Or`, with children in evaluation order (deny-effect policies first). A veto's summary reason is `"Forbidden by <policy>: <reason>"` rather than `"All policies denied access"`.
+- `Effect` moved from the builder module to sit alongside `Policy` (the crate-root re-export `gatehouse::Effect` is unchanged) and now derives `Copy`.
+- Inside `AndPolicy` / `OrPolicy` / `NotPolicy`, a `Forbidden` child behaves exactly like `Denied`: forbids are honored at the checker level, not propagated through combinator trees. Use `AndPolicy[grant, NotPolicy(block)]` for an exclusion scoped to one grant path (see the reworked `deny_override` example, which covers both shapes).
+
+### Added
+
+- `PolicyEvalResult::Forbidden` variant, with `PolicyEvalResult::forbidden` / `forbidden_with_facts` constructors and `is_forbidden()`. **Breaking for exhaustive `match`es over `PolicyEvalResult` and `CombineOp`** — add an arm for `Forbidden` / `DenyOverrides`.
+- `Policy::effect()` — defaulted trait method (`Effect::Allow`) declaring whether a policy grants or forbids on match. The checker uses it to schedule deny-effect policies first; hand-written policies that can forbid must override it (the contract is documented on the method). A policy declaring `Effect::Deny` that nevertheless returns `Granted` is treated as not applicable (fail-closed) with a warning.
+- `EvalCtx::forbid` / `EvalCtx::forbid_with_facts` shortcuts for custom policies.
+- `AccessEvaluation::forbidden_by()` — returns the name of the vetoing policy when a denial was a forbid (e.g. to distinguish "actively blocked" from "no grant matched"), and the `assert_forbidden_by` test helper.
+- Batch telemetry: `gatehouse.batch_policy` spans gain `policy.effect` and `policy.forbidden_count` fields; the security rule event gains a `policy.effect` attribute.
+
 ## [0.4.0] - 2026-06-10
 
 A small, backward-leaning follow-up to 0.3.0: result-type and `RbacPolicy` ergonomics, plus a reviewed-and-tightened example suite. The one thing to know when upgrading is the `RbacPolicy` role-type generalization below — existing `Uuid`-based code compiles unchanged, but a resolver closure that returned a bare `vec![]` with the role type otherwise unmentioned may now need a type annotation. The minor version bump reflects that single inference edge; everything else is additive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - The checker's trace root is now a `CombineOp::DenyOverrides` node (rendered `DENY_OVERRIDES`) instead of `Or`, with children in evaluation order (deny-effect policies first). A veto's summary reason is `"Forbidden by <policy>: <reason>"` rather than `"All policies denied access"`.
 - `Effect` moved from the builder module to sit alongside `Policy` (the crate-root re-export `gatehouse::Effect` is unchanged) and now derives `Copy`.
 - Inside `AndPolicy` / `OrPolicy` / `NotPolicy`, a `Forbidden` child behaves exactly like `Denied`: forbids are honored at the checker level, not propagated through combinator trees. Use `AndPolicy[grant, NotPolicy(block)]` for an exclusion scoped to one grant path (see the reworked `deny_override` example, which covers both shapes).
+- The `mfa_freshness_context` example's high-value MFA rule is now a deny-effect policy registered flat on the checker (`ctx.forbid` + an `effect()` override), replacing the previous `AndPolicy` gate whose "rule doesn't apply ⇒ grant" polarity carried a do-not-register-directly footgun warning. The veto now also binds any grant path added later.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 - A matched `PolicyBuilder` policy with `.effect(Effect::Deny)` now returns the new `PolicyEvalResult::Forbidden` ("this policy forbids") instead of `Denied` ("this policy does not grant"); a non-match still returns `Denied` and never blocks anything.
 - The checker's trace root is now a `CombineOp::DenyOverrides` node (rendered `DENY_OVERRIDES`) instead of `Or`, with children in evaluation order (deny-effect policies first). A veto's summary reason is `"Forbidden by <policy>: <reason>"` rather than `"All policies denied access"`.
 - `Effect` moved from the builder module to sit alongside `Policy` (the crate-root re-export `gatehouse::Effect` is unchanged) and now derives `Copy`.
-- Inside `AndPolicy` / `OrPolicy` / `NotPolicy`, a `Forbidden` child behaves exactly like `Denied`: forbids are honored at the checker level, not propagated through combinator trees. Use `AndPolicy[grant, NotPolicy(block)]` for an exclusion scoped to one grant path (see the reworked `deny_override` example, which covers both shapes).
-- The `mfa_freshness_context` example's high-value MFA rule is now a deny-effect policy registered flat on the checker (`ctx.forbid` + an `effect()` override), replacing the previous `AndPolicy` gate whose "rule doesn't apply ⇒ grant" polarity carried a do-not-register-directly footgun warning. The veto now also binds any grant path added later.
+- Inside `AndPolicy` / `OrPolicy` / `NotPolicy`, a `Forbidden` child behaves exactly like `Denied`: forbids are honored at the checker level, not propagated through combinator trees. Use `AndPolicy[grant, NotPolicy(block)]` for an exclusion scoped to one grant path.
+- Examples: `deny_override` and `mfa_freshness_context` now use flat `Effect::Deny` policies instead of their previous combinator workarounds.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,15 @@ If you are upgrading from 0.2, see `MIGRATION.md` for the `RelationshipResolver`
 
 ## Decision Semantics
 
-- `PermissionChecker` evaluates policies sequentially with `OR` semantics and short-circuits on the first grant.
+- `PermissionChecker` applies fixed **deny-overrides** semantics: any policy that *forbids* (an `Effect::Deny` policy whose predicate matches) denies the request, overriding every grant; otherwise any granting policy grants (`OR`, short-circuiting on the first grant); otherwise the request is denied.
+- Deny-effect policies are evaluated before allow policies, so a veto is never skipped by the grant short-circuit. Registration order does not change the decision. With no deny-effect policies, behavior is plain `OR`, exactly as before.
 - An empty `PermissionChecker` always denies with the reason `"No policies configured"`.
-- `AndPolicy` short-circuits on the first denial; `OrPolicy` short-circuits on the first grant.
+- `AndPolicy` short-circuits on the first non-grant; `OrPolicy` short-circuits on the first grant.
 - `NotPolicy` inverts the result of its inner policy.
-- `PolicyBuilder` combines all configured predicates with `AND` logic.
-- `PolicyBuilder::effect(Effect::Deny)` changes a matching policy result from allow to deny; a non-match is still treated as denied/non-applicable. It does not create global "deny overrides allow" behavior when used inside `PermissionChecker`.
-- `AccessEvaluation::Denied.reason` is a summary string such as `"All policies denied access"`. Inspect the trace tree for individual policy reasons.
-- Evaluation traces only contain policies and branches that were actually evaluated before short-circuiting.
+- Inside combinators a forbid behaves like an ordinary denial: forbids are honored at the checker level, not propagated through combinator trees. Register forbidding policies directly on the checker; use `AndPolicy[grant, NotPolicy(block)]` for an exclusion scoped to one grant path.
+- `PolicyBuilder` combines all configured predicates with `AND` logic. `PolicyBuilder::effect(Effect::Deny)` makes a matching policy *forbid* (`PolicyEvalResult::Forbidden`); a non-match is "not applicable" and never blocks anything. Hand-written policies that can forbid (via `ctx.forbid(...)`) must declare it by overriding `Policy::effect`.
+- `AccessEvaluation::Denied.reason` is a summary string: `"Forbidden by <policy>: <reason>"` for a veto (also exposed via `AccessEvaluation::forbidden_by()`), `"All policies denied access"` otherwise. Inspect the trace tree for individual policy reasons.
+- Evaluation traces only contain policies and branches that were actually evaluated before short-circuiting, in evaluation order (deny-effect policies first).
 
 ## Core Components
 
@@ -107,7 +108,7 @@ The foundation of the authorization system:
 ```rust
 use async_trait::async_trait;
 use std::borrow::Cow;
-use gatehouse::{BatchEvalCtx, EvalCtx, Policy, PolicyEvalResult, SecurityRuleMetadata};
+use gatehouse::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyEvalResult, SecurityRuleMetadata};
 
 #[async_trait]
 trait Policy<Subject, Resource, Action, Context>: Send + Sync {
@@ -121,20 +122,26 @@ trait Policy<Subject, Resource, Action, Context>: Send + Sync {
 
     fn policy_type(&self) -> Cow<'static, str>;
 
+    fn effect(&self) -> Effect {
+        Effect::Allow
+    }
+
     fn security_rule(&self) -> SecurityRuleMetadata {
         SecurityRuleMetadata::default()
     }
 }
 ```
 
-Within `evaluate`, prefer `ctx.grant("reason")` / `ctx.deny("reason")`
-(and the `*_with_facts` variants) to build the `PolicyEvalResult`
-instead of re-passing `self.policy_type()` — the checker captures the
-policy name on `EvalCtx` once per evaluation.
+Within `evaluate`, prefer `ctx.grant("reason")` / `ctx.deny("reason")` /
+`ctx.forbid("reason")` (and the `*_with_facts` variants) to build the
+`PolicyEvalResult` instead of re-passing `self.policy_type()` — the checker
+captures the policy name on `EvalCtx` once per evaluation. A policy that can
+`forbid` must also override `effect()` to return `Effect::Deny` so the
+checker schedules it ahead of the grant short-circuit.
 
 ### `PermissionChecker`
 
-Aggregates multiple policies (e.g. RBAC, ABAC) with `OR` logic by default: if any policy grants access, permission is granted. The returned `AccessEvaluation` contains both the final decision and a trace tree of the evaluated policies.
+Aggregates multiple policies (e.g. RBAC, ABAC) with deny-overrides semantics: any matching `Effect::Deny` policy denies; otherwise, if any policy grants access, permission is granted. The returned `AccessEvaluation` contains both the final decision and a trace tree of the evaluated policies.
 
 ```rust,ignore
 let mut checker = PermissionChecker::new();
@@ -179,7 +186,7 @@ let visible_posts = checker
     .await;
 ```
 
-The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item `OR` semantics as `evaluate_in_session`.
+The caller keeps ownership of resource loading and context construction. Gatehouse borrows the resource/context pair from each item, preserves input order, and applies the same per-item deny-overrides semantics as `evaluate_in_session`.
 
 If the item itself is the resource and the context type is `()`, use `evaluate_batch_resources_in_session` or `filter_authorized_resources_in_session`.
 
@@ -332,7 +339,7 @@ See the `examples` directory for complete demonstrations. Most examples are self
 - `rbac_policy` — basic role-based access control with `PermissionChecker`.
 - `policy_builder` — attribute-style custom policies via `PolicyBuilder`.
 - `combinator_policy` — combining policies with `AndPolicy` / `OrPolicy` / `NotPolicy`.
-- `deny_override` — enforce "deny overrides allow" (account suspensions, legal holds) by gating the allow set behind `NOT(blocklist)` under `AND`. Shows why adding a deny policy straight to the `OR`-based checker does not block anything.
+- `deny_override` — "deny overrides allow" with `Effect::Deny` policies (account suspensions, legal holds) registered flat on the checker, plus the `AndPolicy[grant, NotPolicy(block)]` shape for exclusions scoped to a single grant path.
 - `delegating_policy` — defer a decision to another domain's `PermissionChecker` with `DelegatingPolicy` (comment moderation inheriting document edit rights), keeping the trace across the boundary.
 - `mfa_freshness_context` — when (and when not) to populate the `Context` generic. Grounds the concept in a high-value-refund / MFA-freshness decision.
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ See the `examples` directory for complete demonstrations. Most examples are self
 - `combinator_policy` — combining policies with `AndPolicy` / `OrPolicy` / `NotPolicy`.
 - `deny_override` — "deny overrides allow" with `Effect::Deny` policies (account suspensions, legal holds) registered flat on the checker, plus the `AndPolicy[grant, NotPolicy(block)]` shape for exclusions scoped to a single grant path.
 - `delegating_policy` — defer a decision to another domain's `PermissionChecker` with `DelegatingPolicy` (comment moderation inheriting document edit rights), keeping the trace across the boundary.
-- `mfa_freshness_context` — when (and when not) to populate the `Context` generic. Grounds the concept in a high-value-refund / MFA-freshness decision.
+- `mfa_freshness_context` — when (and when not) to populate the `Context` generic, grounded in a high-value-refund / MFA-freshness decision. Also shows the hand-written deny-policy shape: `ctx.forbid(...)` plus an `effect()` override, registered flat on the checker.
 
 **Then learn request-scoped facts and list endpoints**
 

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -360,8 +360,9 @@ fn invoice_editing_policy() -> Box<dyn Policy<User, Invoice, Action, RequestCont
     )
 }
 
-/// (D) Combine the policies into a single `PermissionChecker`. OR semantics: if
-/// any policy grants, access is allowed (and evaluation short-circuits).
+/// (D) Combine the policies into a single `PermissionChecker`. With no
+/// deny-effect policies registered, deny-overrides reduces to OR semantics:
+/// if any policy grants, access is allowed (and evaluation short-circuits).
 pub fn build_permission_checker() -> PermissionChecker<User, Invoice, Action, RequestContext> {
     let mut checker = PermissionChecker::named("InvoiceChecker");
     checker.add_policy(admin_override_policy());

--- a/examples/deny_override.rs
+++ b/examples/deny_override.rs
@@ -3,21 +3,24 @@
 //! Almost every real authorization system eventually needs a rule that
 //! overrides all the others: a suspended account is locked out regardless of
 //! role, a document under legal hold is frozen even for its owner and for
-//! admins. The obvious move — "add a deny policy to the `PermissionChecker`" —
-//! does **not** do this. A `PermissionChecker` is `OR`: it grants on the first
-//! policy that grants, so a deny result is just one more "no" among the
-//! policies, and any sibling allow still wins. (`PolicyBuilder::effect(Deny)`
-//! does not change this; see the Decision Semantics section of the README.)
+//! admins. In gatehouse this is exactly what [`Effect::Deny`] does: a policy
+//! built with `.effect(Effect::Deny)` **forbids** the request when its
+//! predicate matches, and [`PermissionChecker`] honors a forbid over any
+//! grant from sibling policies — deny-overrides semantics, in the style of
+//! Cedar and AWS IAM.
 //!
-//! The shape that *does* work is to gate the whole allow set behind
-//! `NOT(blocklist)` under `AND`:
+//! The shape is flat: block rules are ordinary policies registered with
+//! `add_policy`, in natural polarity (predicate matches ⇒ forbidden), in any
+//! order. The decision rule is fixed:
 //!
-//! ```text
-//! AndPolicy [ NotPolicy(OrPolicy[ ...block rules ]),  OrPolicy[ ...allow rules ] ]
-//! ```
+//! 1. any matching `Effect::Deny` policy ⇒ **denied** (the trace names it);
+//! 2. otherwise any granting policy ⇒ **granted**;
+//! 3. otherwise ⇒ **denied** (default deny).
 //!
-//! `AndPolicy` denies if any arm denies, so a blocklist match (inverted by
-//! `NotPolicy` into a denial) overrides every grant in the allow set.
+//! Forbids are honored at the *checker* level. Inside combinators
+//! (`AndPolicy` / `OrPolicy` / `NotPolicy`) a forbid behaves like an
+//! ordinary denial — see the scoped-exclusion section at the bottom for the
+//! combinator shape that covers "this deny should only gate one grant path".
 //!
 //! Run with:
 //!
@@ -25,7 +28,7 @@
 //! cargo run --example deny_override
 //! ```
 
-use gatehouse::{AndPolicy, Effect, NotPolicy, OrPolicy, PermissionChecker, Policy, PolicyBuilder};
+use gatehouse::{AndPolicy, Effect, NotPolicy, PermissionChecker, Policy, PolicyBuilder};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -57,71 +60,48 @@ type DocPolicy = Box<dyn Policy<User, Document, Access, ()>>;
 
 // ---- the allow set -------------------------------------------------
 
-/// The grants: an admin override OR document ownership. This is the part an
-/// author writes first and is happy with — the bug only appears once a block
-/// rule has to override it.
-fn allow_set() -> DocPolicy {
-    let admin = PolicyBuilder::<User, Document, Access, ()>::new("AdminOverride")
+fn admin_override() -> DocPolicy {
+    PolicyBuilder::<User, Document, Access, ()>::new("AdminOverride")
         .subjects(|user| user.is_admin)
-        .build();
-    let owner = PolicyBuilder::<User, Document, Access, ()>::new("DocumentOwner")
+        .build()
+}
+
+fn document_owner() -> DocPolicy {
+    PolicyBuilder::<User, Document, Access, ()>::new("DocumentOwner")
         .when(|user, _action, document, _ctx| user.id == document.owner_id)
-        .build();
-
-    Box::new(
-        OrPolicy::try_new(vec![Arc::from(admin), Arc::from(owner)]).expect("allow set non-empty"),
-    )
+        .build()
 }
 
-// ---- the blocklist -------------------------------------------------
+// ---- the block rules -----------------------------------------------
 
-/// The block rules. Each one **grants when its block condition matches** — it
-/// reports "this request is on the blocklist". On its own that polarity looks
-/// backwards; it only makes sense wrapped in `NotPolicy` below, which turns a
-/// blocklist match into a denial.
-fn blocklist() -> DocPolicy {
-    let suspended = PolicyBuilder::<User, Document, Access, ()>::new("AccountSuspended")
+/// Account suspension: predicate matches ⇒ the request is forbidden. The
+/// effect travels with the policy, so this reads exactly as it behaves —
+/// no inverted polarity, no special registration call.
+fn account_suspended() -> DocPolicy {
+    PolicyBuilder::<User, Document, Access, ()>::new("AccountSuspended")
         .subjects(|user| user.suspended)
-        .build();
-    let legal_hold = PolicyBuilder::<User, Document, Access, ()>::new("LegalHold")
+        .effect(Effect::Deny)
+        .build()
+}
+
+/// Legal hold: a frozen document is blocked for everyone, owner and admin
+/// included.
+fn legal_hold() -> DocPolicy {
+    PolicyBuilder::<User, Document, Access, ()>::new("LegalHold")
         .resources(|document| document.legal_hold)
-        .build();
-
-    Box::new(
-        OrPolicy::try_new(vec![Arc::from(suspended), Arc::from(legal_hold)])
-            .expect("blocklist non-empty"),
-    )
+        .effect(Effect::Deny)
+        .build()
 }
 
-// ---- WRONG: a deny policy added straight to the checker ------------
-
-/// The tempting mistake. Add the blocklist to the checker as a deny-effect
-/// policy and assume it wins. It cannot: under `OR`, a deny is not a veto, and
-/// the admin/owner grant still short-circuits to a grant. Order does not save
-/// it either — the deny is listed first here and is still ignored.
-fn naive_checker() -> PermissionChecker<User, Document, Access, ()> {
-    let mut checker = PermissionChecker::named("NaiveDenyChecker");
-    checker.add_policy(
-        PolicyBuilder::<User, Document, Access, ()>::new("LegalHoldDeny")
-            .resources(|document| document.legal_hold)
-            .effect(Effect::Deny)
-            .build(),
-    );
-    checker.add_policy(allow_set());
-    checker
-}
-
-// ---- RIGHT: gate the allow set behind NOT(blocklist) ---------------
-
-/// The shape that actually enforces deny-overrides-allow.
-fn deny_override_checker() -> PermissionChecker<User, Document, Access, ()> {
-    let not_blocked: Arc<dyn Policy<User, Document, Access, ()>> =
-        Arc::new(NotPolicy::new(blocklist()));
-    let gate = AndPolicy::try_new(vec![not_blocked, Arc::from(allow_set())])
-        .expect("gate has the guard and the allow arm");
-
-    let mut checker = PermissionChecker::named("DenyOverrideChecker");
-    checker.add_policy(gate);
+fn document_checker() -> PermissionChecker<User, Document, Access, ()> {
+    let mut checker = PermissionChecker::named("DocumentChecker");
+    // Flat registration, any order: the deny policies' effect is declared
+    // on the policies themselves, and the checker evaluates deny-effect
+    // policies first so a veto can never be raced by a grant.
+    checker.add_policy(admin_override());
+    checker.add_policy(document_owner());
+    checker.add_policy(account_suspended());
+    checker.add_policy(legal_hold());
     checker
 }
 
@@ -160,8 +140,7 @@ async fn main() {
         legal_hold: true,
     };
 
-    let naive = naive_checker();
-    let correct = deny_override_checker();
+    let checker = document_checker();
 
     // (subject, resource, label)
     let cases = [
@@ -172,64 +151,122 @@ async fn main() {
         (&stranger, &normal_doc, "stranger, someone else's doc"),
     ];
 
-    println!(
-        "{:<32} {:>12} {:>12}",
-        "case", "naive (OR)", "deny-override"
-    );
-    println!("{}", "-".repeat(58));
+    println!("{:<32} {:>10} forbidden by", "case", "decision");
+    println!("{}", "-".repeat(60));
     for (subject, document, label) in cases {
-        let naive_granted = naive
-            .check(subject, &Access, document, &())
-            .await
-            .is_granted();
-        let correct_granted = correct
-            .check(subject, &Access, document, &())
-            .await
-            .is_granted();
+        let decision = checker.check(subject, &Access, document, &()).await;
         println!(
-            "{label:<32} {:>12} {:>12}",
-            verdict(naive_granted),
-            verdict(correct_granted),
+            "{label:<32} {:>10} {}",
+            verdict(decision.is_granted()),
+            decision.forbidden_by().unwrap_or("-"),
         );
     }
 
-    // The two rows where the checkers disagree are the whole point: the naive
-    // checker grants access it should have blocked.
-    assert!(
-        naive
-            .check(&admin, &Access, &held_doc, &())
-            .await
-            .is_granted(),
-        "naive OR checker leaks: admin is granted on a legal-hold document",
-    );
-    assert!(
-        !correct
-            .check(&admin, &Access, &held_doc, &())
-            .await
-            .is_granted(),
-        "deny-override checker blocks the legal-hold document even for an admin",
-    );
-    assert!(
-        !correct
-            .check(&suspended_owner, &Access, &normal_doc, &())
-            .await
-            .is_granted(),
-        "deny-override checker blocks a suspended account even on its own document",
-    );
-    // The allow set still gates everyone else: no grant, no access.
-    assert!(
-        !correct
-            .check(&stranger, &Access, &normal_doc, &())
-            .await
-            .is_granted(),
-        "a stranger with no grant is still denied",
-    );
+    // The grants still work where nothing blocks them.
+    checker
+        .check(&admin, &Access, &normal_doc, &())
+        .await
+        .assert_granted_by("AdminOverride");
+    checker
+        .check(&owner, &Access, &normal_doc, &())
+        .await
+        .assert_granted_by("DocumentOwner");
 
-    // Show the mechanism on the headline case: NOT(blocklist) denies first, so
-    // AND short-circuits before the allow arm is ever consulted.
-    println!("\nWhy the deny-override checker blocks 'admin, LEGAL-HOLD doc':");
-    let decision = correct.check(&admin, &Access, &held_doc, &()).await;
+    // The block rules override every grant — even the admin override.
+    checker
+        .check(&admin, &Access, &held_doc, &())
+        .await
+        .assert_forbidden_by("LegalHold");
+    checker
+        .check(&suspended_owner, &Access, &normal_doc, &())
+        .await
+        .assert_forbidden_by("AccountSuspended");
+
+    // Default deny is untouched: no grant, no access — and no forbid
+    // either, which `forbidden_by()` distinguishes for the caller.
+    let stranger_decision = checker.check(&stranger, &Access, &normal_doc, &()).await;
+    stranger_decision.assert_denied();
+    assert_eq!(stranger_decision.forbidden_by(), None);
+
+    // Show the mechanism on the headline case: the deny-effect policy is
+    // evaluated first and ends the evaluation; the allow set is never
+    // consulted.
+    println!("\nWhy 'admin, LEGAL-HOLD doc' is blocked:");
+    let decision = checker.check(&admin, &Access, &held_doc, &()).await;
     println!("{}", decision.display_trace());
+
+    scoped_exclusion_demo().await;
+}
+
+// ---- scoped exclusion: a deny that gates only one grant path --------
+
+/// `Effect::Deny` is a *global* veto: it blocks every grant path in the
+/// checker. When a block rule should only gate one grant path — here,
+/// muted users lose collaborator access but owners and admins keep
+/// theirs — scope it with combinators instead:
+/// `AndPolicy[ grant_arm, NotPolicy(block) ]`. Inside combinators a
+/// forbid has no special power, so the exclusion stays local to its arm.
+async fn scoped_exclusion_demo() {
+    #[derive(Debug, Clone)]
+    struct Member {
+        is_owner: bool,
+        is_collaborator: bool,
+        muted: bool,
+    }
+    #[derive(Debug, Clone)]
+    struct Thread;
+
+    let owner_policy = PolicyBuilder::<Member, Thread, Access, ()>::new("ThreadOwner")
+        .subjects(|member| member.is_owner)
+        .build();
+    let collaborator_policy: Arc<dyn Policy<Member, Thread, Access, ()>> = Arc::from(
+        PolicyBuilder::<Member, Thread, Access, ()>::new("Collaborator")
+            .subjects(|member| member.is_collaborator)
+            .build(),
+    );
+    // The block rule for the scoped case *grants when it matches* so that
+    // `NotPolicy` can invert it into a local gate. Compare with the
+    // checker-level rules above, where `Effect::Deny` keeps natural
+    // polarity — this inversion is the price of scoping, which is why a
+    // global block should prefer `Effect::Deny`.
+    let muted = PolicyBuilder::<Member, Thread, Access, ()>::new("Muted")
+        .subjects(|member| member.muted)
+        .build();
+
+    let collaborator_unless_muted = AndPolicy::try_new(vec![
+        collaborator_policy,
+        Arc::new(NotPolicy::new(muted)) as Arc<dyn Policy<Member, Thread, Access, ()>>,
+    ])
+    .expect("gate has the grant arm and the guard");
+
+    let mut checker = PermissionChecker::named("ThreadChecker");
+    checker.add_policy(owner_policy);
+    checker.add_policy(collaborator_unless_muted);
+
+    let muted_collaborator = Member {
+        is_owner: false,
+        is_collaborator: true,
+        muted: true,
+    };
+    let muted_owner = Member {
+        is_owner: true,
+        is_collaborator: false,
+        muted: true,
+    };
+
+    // The mute only gates the collaborator path...
+    checker
+        .check(&muted_collaborator, &Access, &Thread, &())
+        .await
+        .assert_denied();
+    // ...the owner path is untouched, which a global Effect::Deny mute
+    // could not express.
+    checker
+        .check(&muted_owner, &Access, &Thread, &())
+        .await
+        .assert_granted_by("ThreadOwner");
+
+    println!("\nScoped exclusion: muted collaborator blocked, muted owner unaffected.");
 }
 
 fn verdict(granted: bool) -> &'static str {

--- a/examples/mfa_freshness_context.rs
+++ b/examples/mfa_freshness_context.rs
@@ -13,12 +13,13 @@
 //!
 //! That last bit is what `Context` is for. We carry `mfa_verified_at`
 //! and the request's wall-clock time on `ApprovalContext`. The
-//! high-value policy short-circuits deny when MFA freshness has lapsed;
-//! the role policy ignores the field entirely. Same subject, same
-//! resource, different calls → different decisions.
+//! high-value rule is a deny-effect policy that **forbids** the approval
+//! when MFA freshness has lapsed; the role policy ignores the field
+//! entirely. Same subject, same resource, different calls → different
+//! decisions.
 
 use async_trait::async_trait;
-use gatehouse::{AccessEvaluation, EvalCtx, PermissionChecker, Policy, PolicyEvalResult};
+use gatehouse::{AccessEvaluation, Effect, EvalCtx, PermissionChecker, Policy, PolicyEvalResult};
 use std::borrow::Cow;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
@@ -79,21 +80,23 @@ impl Policy<User, RefundRequest, Approve, ApprovalContext> for FinanceCanApprove
     }
 }
 
-/// AND-gate: high-value refunds additionally require recent MFA.
+/// Deny rule: a high-value refund without fresh MFA is **forbidden**.
 ///
-/// This is the policy that *does* care about `Context`. It treats
-/// "not a high-value refund" as granted (the rule doesn't apply), so
-/// pairing it with [`FinanceCanApproveRefunds`] under [`AndPolicy`]
-/// only adds the freshness check when it's relevant.
+/// This is the policy that *does* care about `Context`, and it is a
+/// deny-effect policy in natural polarity: it matches exactly when the
+/// approval must be blocked, and returns `ctx.forbid(...)` for that
+/// case. Everything else — small refunds, fresh MFA — is "not
+/// applicable" (`ctx.deny`), which never blocks and never grants.
 ///
-/// **DO NOT add this policy directly to a `PermissionChecker`** —
-/// the checker uses `OR` semantics, so the "rule doesn't apply"
-/// grant on every below-threshold call would grant *everyone* on
-/// every small refund, regardless of role. This shape is only safe
-/// inside an `AndPolicy` (or any `AND`-combining context) where the
-/// sibling policies enforce the actual access decision. The pattern
-/// is "augment an existing grant with an additional gate," not
-/// "decide on its own."
+/// Registered flat on the [`PermissionChecker`], the forbid overrides
+/// every grant under deny-overrides semantics. That is the right
+/// strength for an MFA requirement: if an admin-override or
+/// service-account grant path is added later, a stale session still
+/// cannot approve a high-value refund through it.
+///
+/// Note the [`Policy::effect`] override below — a hand-written policy
+/// that can forbid must declare [`Effect::Deny`] so the checker
+/// schedules it ahead of the grant short-circuit.
 struct HighValueRequiresFreshMfa {
     threshold_cents: u64,
     max_age: Duration,
@@ -105,14 +108,14 @@ impl Policy<User, RefundRequest, Approve, ApprovalContext> for HighValueRequires
         &self,
         ctx: &EvalCtx<'_, User, RefundRequest, Approve, ApprovalContext>,
     ) -> PolicyEvalResult {
-        // Rule doesn't apply below the threshold — grant. NOTE: this
-        // only behaves correctly under AND. See the struct's docstring.
+        // Rule doesn't apply below the threshold: not applicable, and a
+        // non-matching deny-effect policy blocks nothing.
         if ctx.resource.amount_cents < self.threshold_cents {
-            return ctx.grant("amount below high-value threshold");
+            return ctx.deny("amount below high-value threshold; rule not applicable");
         }
 
         let Some(verified_at) = ctx.context.mfa_verified_at else {
-            return ctx.deny(format!(
+            return ctx.forbid(format!(
                 "high-value refund (>={} cents) requires recent MFA, but this session has none",
                 self.threshold_cents,
             ));
@@ -124,12 +127,12 @@ impl Policy<User, RefundRequest, Approve, ApprovalContext> for HighValueRequires
             .duration_since(verified_at)
             .unwrap_or_default();
         if age <= self.max_age {
-            ctx.grant(format!(
-                "MFA reasserted {}s ago, within freshness window",
+            ctx.deny(format!(
+                "MFA reasserted {}s ago, within freshness window; rule not applicable",
                 age.as_secs(),
             ))
         } else {
-            ctx.deny(format!(
+            ctx.forbid(format!(
                 "MFA reasserted {}s ago, exceeds freshness window of {}s",
                 age.as_secs(),
                 self.max_age.as_secs(),
@@ -139,26 +142,21 @@ impl Policy<User, RefundRequest, Approve, ApprovalContext> for HighValueRequires
     fn policy_type(&self) -> Cow<'static, str> {
         Cow::Borrowed("HighValueRequiresFreshMfa")
     }
+    fn effect(&self) -> Effect {
+        Effect::Deny
+    }
 }
 
 fn build_checker() -> PermissionChecker<User, RefundRequest, Approve, ApprovalContext> {
-    use gatehouse::AndPolicy;
-    use std::sync::Arc;
-
-    // Approval requires BOTH the role check AND the MFA-freshness
-    // check. Both must grant — that's the AND.
-    let combined = AndPolicy::try_new(vec![
-        Arc::new(FinanceCanApproveRefunds)
-            as Arc<dyn Policy<User, RefundRequest, Approve, ApprovalContext>>,
-        Arc::new(HighValueRequiresFreshMfa {
-            threshold_cents: 1_000_000, // $10,000
-            max_age: Duration::from_secs(5 * 60),
-        }),
-    ])
-    .expect("non-empty policy list");
-
+    // Flat registration: the role grant and the MFA veto are siblings.
+    // The checker's deny-overrides rule does the combining — any forbid
+    // wins, otherwise any grant wins, otherwise default deny.
     let mut checker = PermissionChecker::named("RefundApprovalChecker");
-    checker.add_policy(combined);
+    checker.add_policy(FinanceCanApproveRefunds);
+    checker.add_policy(HighValueRequiresFreshMfa {
+        threshold_cents: 1_000_000, // $10,000
+        max_age: Duration::from_secs(5 * 60),
+    });
     checker
 }
 
@@ -181,7 +179,7 @@ async fn main() {
     let checker = build_checker();
 
     // Case 1: small refund, no MFA at all. Granted — the high-value
-    // rule doesn't apply below the threshold.
+    // rule doesn't apply below the threshold, so the role grant decides.
     let small_no_mfa = ApprovalContext {
         current_time: now,
         mfa_verified_at: None,
@@ -190,32 +188,34 @@ async fn main() {
         .check(&alice, &Approve, &small_refund, &small_no_mfa)
         .await;
     report("small refund, no MFA", &r);
-    assert!(r.is_granted());
+    r.assert_granted_by("FinanceCanApproveRefunds");
 
-    // Case 2: large refund, no MFA. Denied by the freshness rule.
+    // Case 2: large refund, no MFA. Forbidden by the freshness rule —
+    // the veto overrides Alice's role grant.
     let r = checker
         .check(&alice, &Approve, &large_refund, &small_no_mfa)
         .await;
     report("large refund, no MFA", &r);
-    assert!(!r.is_granted());
+    r.assert_forbidden_by("HighValueRequiresFreshMfa");
 
-    // Case 3: large refund, MFA reasserted 8 minutes ago. Stale.
+    // Case 3: large refund, MFA reasserted 8 minutes ago. Stale → forbidden.
     let stale = ApprovalContext {
         current_time: now,
         mfa_verified_at: Some(now - Duration::from_secs(8 * 60)),
     };
     let r = checker.check(&alice, &Approve, &large_refund, &stale).await;
     report("large refund, MFA 8m old", &r);
-    assert!(!r.is_granted());
+    r.assert_forbidden_by("HighValueRequiresFreshMfa");
 
-    // Case 4: large refund, MFA reasserted 30 seconds ago. Granted.
+    // Case 4: large refund, MFA reasserted 30 seconds ago. The deny rule
+    // is not applicable, so the role grant decides.
     let fresh = ApprovalContext {
         current_time: now,
         mfa_verified_at: Some(now - Duration::from_secs(30)),
     };
     let r = checker.check(&alice, &Approve, &large_refund, &fresh).await;
     report("large refund, MFA 30s old", &r);
-    assert!(r.is_granted());
+    r.assert_granted_by("FinanceCanApproveRefunds");
 
     // The point: cases 2-4 all use the same subject and resource. The
     // only thing that varies is `ApprovalContext`. That's exactly the

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,16 +1,5 @@
-use crate::{BatchEvalCtx, EvalCtx, Policy, PolicyEvalResult};
+use crate::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyEvalResult};
 use async_trait::async_trait;
-
-/// Represents the intended effect of a policy.
-///
-/// `Allow` means the policy grants access; `Deny` means it denies access.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Effect {
-    /// The policy grants access when its predicates pass.
-    Allow,
-    /// The policy denies access when its predicates pass.
-    Deny,
-}
 
 /// An internal policy type (not exposed to API users) that is constructed via the builder.
 ///
@@ -38,9 +27,13 @@ impl<S, R, A, C> InternalPolicy<S, R, A, C> {
                     self.name.clone(),
                     Some("Policy allowed access".into()),
                 ),
-                Effect::Deny => PolicyEvalResult::denied(self.name.clone(), "Policy denied access"),
+                Effect::Deny => {
+                    PolicyEvalResult::forbidden(self.name.clone(), "Policy forbids access")
+                }
             }
         } else {
+            // A non-match is "not applicable", never a veto — even for
+            // Effect::Deny policies.
             PolicyEvalResult::denied(self.name.clone(), "Policy predicate did not match")
         }
     }
@@ -122,6 +115,10 @@ where
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Owned(self.name.clone())
     }
+
+    fn effect(&self) -> Effect {
+        self.effect
+    }
 }
 
 /// A builder API for creating custom policies.
@@ -134,11 +131,11 @@ where
 /// [`PolicyBuilder`] is designed for synchronous predicate logic. If your policy
 /// needs to perform async I/O or external lookups, implement [`Policy`] directly.
 ///
-/// [`PolicyBuilder::effect`] controls the result returned when the combined
-/// predicate matches. In particular, `Effect::Deny` means "this built policy
-/// returns [`PolicyEvalResult::Denied`] when it matches". A non-match is still
-/// treated as denied/non-applicable, and this does not introduce a global
-/// deny-overrides-allow rule when combined with other policies.
+/// [`PolicyBuilder::effect`] declares whether a match grants or forbids.
+/// With [`Effect::Deny`], a match returns [`PolicyEvalResult::Forbidden`],
+/// which [`crate::PermissionChecker`] honors over any sibling grant
+/// (deny-overrides). A non-match is "not applicable" either way and never
+/// blocks anything.
 ///
 /// # A note on allocation cost
 ///
@@ -346,10 +343,24 @@ where
     ///
     /// Defaults to [`Effect::Allow`].
     ///
-    /// `Effect::Deny` causes the built policy to return
-    /// [`PolicyEvalResult::Denied`] when its combined predicate matches. A
-    /// non-match is still treated as denied/non-applicable, and this does not
-    /// override grants from other policies evaluated by [`crate::PermissionChecker`].
+    /// With [`Effect::Deny`], the built policy returns
+    /// [`PolicyEvalResult::Forbidden`] when its combined predicate matches:
+    /// it reads exactly as it behaves — "predicate matches ⇒ this request is
+    /// forbidden". Inside a [`crate::PermissionChecker`] a forbid overrides
+    /// every grant, regardless of registration order. A non-match is "not
+    /// applicable" and blocks nothing.
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # #[derive(Clone)] struct User { is_suspended: bool }
+    /// # struct Doc; struct Read; struct Ctx;
+    /// let suspended = PolicyBuilder::<User, Doc, Read, Ctx>::new("SuspendedAccount")
+    ///     .subjects(|user| user.is_suspended)
+    ///     .effect(Effect::Deny)
+    ///     .build();
+    /// // checker.add_policy(suspended);  — a suspended user is now locked
+    /// // out even when an admin-override or owner policy would grant.
+    /// ```
     pub fn effect(mut self, effect: Effect) -> Self {
         self.effect = effect;
         self

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -438,7 +438,7 @@ where
 
         // If all policies denied access
         tracing::Span::current().record("outcome", "denied");
-        tracing::trace!("No policies allowed access, returning Forbidden");
+        tracing::trace!("No policy granted access, returning denied");
         let combined = checker_root(policy_results, false);
 
         AccessEvaluation::Denied {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,14 +1,53 @@
 use crate::{
-    AccessEvaluation, BatchEvalCtx, CombineOp, EvalCtx, EvalTrace, EvaluationSession, Hydrator,
-    LookupAuthorizedError, LookupAuthorizedPage, LookupSource, Policy, PolicyBatchItem,
+    AccessEvaluation, BatchEvalCtx, CombineOp, Effect, EvalCtx, EvalTrace, EvaluationSession,
+    Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupSource, Policy, PolicyBatchItem,
     PolicyEvalResult, DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE,
 };
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::Instrument;
 
-/// A container for multiple policies, applied in an "OR" fashion.
-/// (If any policy returns Ok, access is granted)
+/// Builds the top-level denial reason for a forbid, naming the policy that
+/// vetoed the request so the summary is actionable without opening the trace.
+fn forbid_summary(policy_type: &str, reason: Option<&str>) -> String {
+    match reason {
+        Some(reason) => format!("Forbidden by {policy_type}: {reason}"),
+        None => format!("Forbidden by {policy_type}"),
+    }
+}
+
+/// Leaf reason recorded when a deny-declared policy violates its contract by
+/// returning a grant; the checker fails closed and treats the result as not
+/// applicable. See [`Policy::effect`].
+const DENY_EFFECT_GRANT_REASON: &str =
+    "Deny-effect policy returned a grant; treated as not applicable";
+
+/// Builds the checker's root trace node: a deny-overrides combine over the
+/// policy results evaluated so far.
+fn checker_root(children: Vec<PolicyEvalResult>, outcome: bool) -> PolicyEvalResult {
+    PolicyEvalResult::Combined {
+        policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
+        operation: CombineOp::DenyOverrides,
+        children,
+        outcome,
+    }
+}
+
+/// A container for multiple policies, combined with fixed
+/// **deny-overrides** semantics:
+///
+/// 1. any policy that **forbids** ([`PolicyEvalResult::Forbidden`], produced
+///    by [`crate::Effect::Deny`] policies whose predicate matches) denies the
+///    request, overriding every grant;
+/// 2. otherwise any policy that grants, grants (OR semantics, short-circuits
+///    on the first grant);
+/// 3. otherwise the request is denied (default deny).
+///
+/// Policies declaring [`crate::Effect::Deny`] are evaluated before allow
+/// policies so a veto is always observed before the grant short-circuit.
+/// The semantics are fixed — there is no combining-algorithm knob — and the
+/// effect is declared on the policy itself, so a policy's behaviour is
+/// readable in isolation.
 ///
 /// **Important**: if no policies are added, access is always denied.
 ///
@@ -119,7 +158,16 @@ use tracing::Instrument;
 #[derive(Clone)]
 pub struct PermissionChecker<S, R, A, C> {
     name: Option<std::borrow::Cow<'static, str>>,
+    /// Policies in evaluation order: deny-effect policies first, then allow
+    /// policies, each group in registration order. [`Self::add_policy`]
+    /// maintains this invariant using the policy's declared
+    /// [`Policy::effect`], so evaluation iterates this list directly with no
+    /// per-call partitioning. Deny-first scheduling is what makes
+    /// deny-overrides deterministic: every policy that can veto runs before
+    /// the allow phase, where a grant short-circuits the evaluation.
     policies: Vec<Arc<dyn Policy<S, R, A, C>>>,
+    /// Number of deny-effect policies at the front of `policies`.
+    deny_count: usize,
     max_batch_size: Option<NonZeroUsize>,
 }
 
@@ -147,6 +195,7 @@ where
         Self {
             name: None,
             policies: Vec::new(),
+            deny_count: 0,
             max_batch_size: None,
         }
     }
@@ -165,6 +214,7 @@ where
         Self {
             name: Some(name.into()),
             policies: Vec::new(),
+            deny_count: 0,
             max_batch_size: None,
         }
     }
@@ -186,11 +236,31 @@ where
 
     /// Adds a policy to the checker.
     ///
+    /// The policy's [`Policy::effect`] is read once here: deny-effect
+    /// policies are scheduled ahead of allow policies so a veto is always
+    /// observed before the grant short-circuit (see the type-level docs).
+    /// Within each group, registration order is preserved.
+    ///
     /// # Arguments
     ///
     /// * `policy` - A type implementing [`Policy`]. It is stored as an `Arc` for shared ownership.
     pub fn add_policy<P: Policy<S, R, A, C> + 'static>(&mut self, policy: P) {
-        self.policies.push(Arc::new(policy));
+        if policy.effect() == Effect::Deny {
+            self.policies.insert(self.deny_count, Arc::new(policy));
+            self.deny_count += 1;
+        } else {
+            self.policies.push(Arc::new(policy));
+        }
+    }
+
+    /// The effect a policy declared when it was added, derived from its
+    /// position in the deny-first `policies` ordering.
+    fn declared_effect(&self, policy_index: usize) -> Effect {
+        if policy_index < self.deny_count {
+            Effect::Deny
+        } else {
+            Effect::Allow
+        }
     }
 
     /// Convenience for RBAC/ABAC-only callers: evaluates against the
@@ -232,14 +302,16 @@ where
     /// Evaluates all policies against the given parameters using a caller-owned
     /// request session.
     ///
-    /// Policies are evaluated sequentially with OR semantics and short-circuit
-    /// on the first success. The returned [`AccessEvaluation`] contains a
-    /// trace tree for the policies that were actually evaluated before
-    /// short-circuiting.
+    /// Policies are evaluated sequentially under deny-overrides semantics:
+    /// declared-deny policies first (a forbid ends the evaluation as a
+    /// denial), then allow policies with a short-circuit on the first grant.
+    /// The returned [`AccessEvaluation`] contains a trace tree for the
+    /// policies that were actually evaluated before short-circuiting.
     ///
-    /// If every policy denies access, the top-level denial reason is the
-    /// summary string `"All policies denied access"`. Inspect the trace for
-    /// individual policy reasons.
+    /// If a forbid fires, the top-level denial reason names the forbidding
+    /// policy (`"Forbidden by <policy>: <reason>"`). If no policy grants,
+    /// the reason is the summary string `"All policies denied access"`.
+    /// Inspect the trace for individual policy reasons.
     #[tracing::instrument(skip_all, fields(checker.name = tracing::field::Empty, policy_count = self.policies.len(), outcome = tracing::field::Empty, policy.type = tracing::field::Empty))]
     pub async fn evaluate_in_session(
         &self,
@@ -267,8 +339,10 @@ where
 
         let mut policy_results = Vec::with_capacity(self.policies.len());
 
-        // Evaluate each policy
-        for policy in &self.policies {
+        // Evaluate each policy; `policies` is kept in deny-first order by
+        // `add_policy`.
+        for (policy_index, policy) in self.policies.iter().enumerate() {
+            let declared_effect = self.declared_effect(policy_index);
             // Move the policy's name straight into the EvalCtx rather than
             // cloning, since for dynamic-name (`Cow::Owned`) policies the
             // clone is a fresh `String` allocation we don't need: the same
@@ -283,8 +357,17 @@ where
                 context,
                 policy_type: policy.policy_type(),
             };
-            let result = policy.evaluate(&ctx).await;
+            let mut result = policy.evaluate(&ctx).await;
+            if declared_effect == Effect::Deny && result.is_granted() {
+                tracing::warn!(
+                    policy.type = ctx.policy_type.as_ref(),
+                    "{DENY_EFFECT_GRANT_REASON}"
+                );
+                result =
+                    PolicyEvalResult::denied(ctx.policy_type.clone(), DENY_EFFECT_GRANT_REASON);
+            }
             let result_passes = result.is_granted();
+            let result_forbids = result.is_forbidden();
 
             // Extract metadata for tracing (always needed for security audit)
             let policy_type_str: &str = ctx.policy_type.as_ref();
@@ -299,6 +382,10 @@ where
                 .ruleset_name()
                 .unwrap_or(PERMISSION_CHECKER_POLICY_TYPE);
             let event_outcome = if result_passes { "success" } else { "failure" };
+            let policy_effect = match declared_effect {
+                Effect::Allow => "allow",
+                Effect::Deny => "deny",
+            };
 
             tracing::trace!(
                 target: "gatehouse::security",
@@ -313,6 +400,7 @@ where
                     security_rule.license = metadata.license(),
                     event.outcome = event_outcome,
                     policy.type = policy_type_str,
+                    policy.effect = policy_effect,
                     policy.result.reason = reason_str,
                 },
                 "Security rule evaluated"
@@ -320,16 +408,22 @@ where
 
             policy_results.push(result);
 
+            // A forbid overrides everything: stop evaluating and deny.
+            if result_forbids {
+                tracing::Span::current().record("outcome", "denied");
+                tracing::Span::current().record("policy.type", policy_type_str);
+                let combined = checker_root(policy_results, false);
+                return AccessEvaluation::Denied {
+                    trace: EvalTrace::with_root(combined),
+                    reason: forbid_summary(policy_type_str, reason.as_deref()),
+                };
+            }
+
             // If any policy allows access, return immediately
             if result_passes {
                 tracing::Span::current().record("outcome", "granted");
                 tracing::Span::current().record("policy.type", policy_type_str);
-                let combined = PolicyEvalResult::Combined {
-                    policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-                    operation: CombineOp::Or,
-                    children: policy_results,
-                    outcome: true,
-                };
+                let combined = checker_root(policy_results, true);
 
                 // Destructure to move policy_type out of the EvalCtx
                 // without an extra clone.
@@ -345,12 +439,7 @@ where
         // If all policies denied access
         tracing::Span::current().record("outcome", "denied");
         tracing::trace!("No policies allowed access, returning Forbidden");
-        let combined = PolicyEvalResult::Combined {
-            policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-            operation: CombineOp::Or,
-            children: policy_results,
-            outcome: false,
-        };
+        let combined = checker_root(policy_results, false);
 
         AccessEvaluation::Denied {
             trace: EvalTrace::with_root(combined),
@@ -362,10 +451,11 @@ where
     ///
     /// The `parts` callback tells gatehouse how to borrow the resource and
     /// context from each caller-owned item. Returned results preserve input
-    /// order, including duplicate resources. Policy evaluation still uses the
-    /// same OR semantics as [`Self::evaluate_in_session`], but the checker evaluates
-    /// each policy across the still-pending batch before moving to the next
-    /// policy. This lets policies with set-oriented backends override
+    /// order, including duplicate resources. Policy evaluation uses the same
+    /// deny-overrides semantics as [`Self::evaluate_in_session`] (declared-deny
+    /// policies first; a forbid finalizes an item as denied), but the checker
+    /// evaluates each policy across the still-pending batch before moving to
+    /// the next policy. This lets policies with set-oriented backends override
     /// [`Policy::evaluate_batch`] and collapse many point lookups into
     /// one backend call.
     ///
@@ -473,11 +563,15 @@ where
 
         let mut pending: Vec<usize> = (0..item_count).collect();
 
-        for policy in &self.policies {
+        // `policies` is kept in deny-first order by `add_policy`, so a
+        // forbid is always observed before an allow policy can grant an
+        // item out of the pending set.
+        for (policy_index, policy) in self.policies.iter().enumerate() {
             if pending.is_empty() {
                 break;
             }
 
+            let declared_effect = self.declared_effect(policy_index);
             let policy_type = policy.policy_type();
             let policy_type_str: &str = policy_type.as_ref();
             let mut still_pending = Vec::new();
@@ -491,14 +585,21 @@ where
                 let policy_span = tracing::debug_span!(
                     "gatehouse.batch_policy",
                     policy.type = policy_type_str,
+                    policy.effect = match declared_effect {
+                        Effect::Allow => "allow",
+                        Effect::Deny => "deny",
+                    },
                     policy.pending_count = pending_chunk.len(),
                     policy.chunk_index = chunk_index,
                     policy.chunk_count = chunk_count,
                     policy.granted_count = tracing::field::Empty,
                     policy.denied_count = tracing::field::Empty,
+                    policy.forbidden_count = tracing::field::Empty,
                 );
                 let mut policy_granted_count = 0usize;
                 let mut policy_denied_count = 0usize;
+                let mut policy_forbidden_count = 0usize;
+                let mut contract_violation_count = 0usize;
                 let batch_items: Vec<_> = pending_chunk
                     .iter()
                     .map(|&index| PolicyBatchItem {
@@ -527,12 +628,7 @@ where
                             "Policy batch result count did not match input count",
                         );
                         traces[index].push(policy_result);
-                        let combined = PolicyEvalResult::Combined {
-                            policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-                            operation: CombineOp::Or,
-                            children: std::mem::take(&mut traces[index]),
-                            outcome: false,
-                        };
+                        let combined = checker_root(std::mem::take(&mut traces[index]), false);
                         evaluations[index] = Some(AccessEvaluation::Denied {
                             trace: EvalTrace::with_root(combined),
                             reason: "Policy batch result count did not match input count"
@@ -541,23 +637,33 @@ where
                     }
                     policy_span.record("policy.granted_count", policy_granted_count);
                     policy_span.record("policy.denied_count", policy_denied_count);
+                    policy_span.record("policy.forbidden_count", policy_forbidden_count);
                     continue;
                 }
 
                 for (&index, result) in pending_chunk.iter().zip(policy_results) {
+                    let mut result = result;
+                    if declared_effect == Effect::Deny && result.is_granted() {
+                        contract_violation_count += 1;
+                        result =
+                            PolicyEvalResult::denied(policy_type.clone(), DENY_EFFECT_GRANT_REASON);
+                    }
                     let result_passes = result.is_granted();
+                    let result_forbids = result.is_forbidden();
                     let reason = result.reason();
 
                     traces[index].push(result);
 
-                    if result_passes {
+                    if result_forbids {
+                        policy_forbidden_count += 1;
+                        let combined = checker_root(std::mem::take(&mut traces[index]), false);
+                        evaluations[index] = Some(AccessEvaluation::Denied {
+                            trace: EvalTrace::with_root(combined),
+                            reason: forbid_summary(policy_type_str, reason.as_deref()),
+                        });
+                    } else if result_passes {
                         policy_granted_count += 1;
-                        let combined = PolicyEvalResult::Combined {
-                            policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-                            operation: CombineOp::Or,
-                            children: std::mem::take(&mut traces[index]),
-                            outcome: true,
-                        };
+                        let combined = checker_root(std::mem::take(&mut traces[index]), true);
                         evaluations[index] = Some(AccessEvaluation::Granted {
                             policy_type: policy_type.clone(),
                             reason,
@@ -568,19 +674,24 @@ where
                         still_pending.push(index);
                     }
                 }
+                if contract_violation_count > 0 {
+                    // One warning per chunk, not per item: a misbehaving
+                    // policy in a large batch would otherwise flood the log.
+                    tracing::warn!(
+                        policy.type = policy_type_str,
+                        item_count = contract_violation_count,
+                        "{DENY_EFFECT_GRANT_REASON}"
+                    );
+                }
                 policy_span.record("policy.granted_count", policy_granted_count);
                 policy_span.record("policy.denied_count", policy_denied_count);
+                policy_span.record("policy.forbidden_count", policy_forbidden_count);
             }
             pending = still_pending;
         }
 
         for index in pending {
-            let combined = PolicyEvalResult::Combined {
-                policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-                operation: CombineOp::Or,
-                children: std::mem::take(&mut traces[index]),
-                outcome: false,
-            };
+            let combined = checker_root(std::mem::take(&mut traces[index]), false);
             evaluations[index] = Some(AccessEvaluation::Denied {
                 trace: EvalTrace::with_root(combined),
                 reason: "All policies denied access".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,11 @@
 //!   requires an MFA assertion within the last 5 minutes." MFA freshness
 //!   lives on the request (the session token records when MFA was last
 //!   reasserted), not on the user record. A `mfa_verified_at:
-//!   Option<SystemTime>` on `Context` lets the high-value policy short-
-//!   circuit deny when freshness has lapsed without forcing every policy
-//!   to plumb the auth-session through their own arguments. See
-//!   `examples/mfa_freshness_context.rs` for the full end-to-end shape.
+//!   Option<SystemTime>` on `Context` lets a deny-effect high-value
+//!   policy forbid the request when freshness has lapsed without forcing
+//!   every policy to plumb the auth-session through their own arguments.
+//!   See `examples/mfa_freshness_context.rs` for the full end-to-end
+//!   shape.
 //!
 //! - **Device / network trust posture.** "Production database access
 //!   requires the request to come from a managed device on the corporate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@
 //!
 //! A *Policy* is an asynchronous decision unit that checks if a given subject may
 //! perform an action on a resource within a given context. Policies implement the
-//! [`Policy`] trait. A [`PermissionChecker`] aggregates multiple policies and uses OR
-//! logic by default (i.e. if any policy grants access, then access is allowed).
+//! [`Policy`] trait. A [`PermissionChecker`] aggregates multiple policies with
+//! deny-overrides semantics: any matching [`Effect::Deny`] policy denies access;
+//! otherwise, if any policy grants access, then access is allowed.
 //! The [`PolicyBuilder`] offers a builder pattern for creating custom policies.
 //! Custom [`Policy`] implementations must provide both [`Policy::evaluate`]
 //! and [`Policy::policy_type`].
@@ -60,7 +61,9 @@
 //! The checker's root node is a `DENY_OVERRIDES` combine node whose children
 //! appear in evaluation order: deny-effect policies first, then allow
 //! policies. A forbid ends the evaluation, so a vetoed request's trace shows
-//! the forbidding policy as its last child.
+//! the forbidding policy as its last child. The exception is a checker with
+//! no policies at all, whose trace is the single `"No policies configured"`
+//! denial leaf with no combine node around it.
 //!
 //! ## When to populate the Context type
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,31 +18,49 @@
 //!
 //! ## Decision Semantics
 //!
-//! `gatehouse` deliberately keeps decision semantics simple and explicit:
+//! `gatehouse` deliberately keeps decision semantics simple, explicit, and
+//! fixed — there is no combining-algorithm knob:
 //!
-//! - [`PermissionChecker`] evaluates policies sequentially with OR semantics and
-//!   short-circuits on the first grant.
+//! - [`PermissionChecker`] applies **deny-overrides**: any policy that
+//!   *forbids* (an [`Effect::Deny`] policy whose predicate matches, producing
+//!   [`PolicyEvalResult::Forbidden`]) denies the request, overriding every
+//!   grant. Otherwise the policies combine with OR semantics and
+//!   short-circuit on the first grant. Otherwise the request is denied.
+//! - Deny-effect policies are evaluated before allow policies, so a veto is
+//!   never skipped by the grant short-circuit. Registration order does not
+//!   change the decision.
 //! - An empty [`PermissionChecker`] denies access with the reason
 //!   `"No policies configured"`.
-//! - [`AndPolicy`] short-circuits on the first denial.
+//! - [`AndPolicy`] short-circuits on the first non-grant.
 //! - [`OrPolicy`] short-circuits on the first grant.
 //! - [`NotPolicy`] inverts the decision of its inner policy.
+//! - Inside combinators a `Forbidden` child behaves exactly like `Denied`:
+//!   forbids are honored at the checker level, not propagated through
+//!   combinator trees. Register forbidding policies directly on the checker;
+//!   use `AndPolicy[grant, NotPolicy(block)]` when an exclusion should gate
+//!   only one grant path (see `examples/deny_override.rs`).
 //! - [`PolicyBuilder`] combines all configured predicates with AND logic.
-//! - [`PolicyBuilder::effect`] changes the result returned by that specific
-//!   built policy when its combined predicate matches. A non-match is still
-//!   treated as denied/non-applicable, and the effect does not create global
-//!   deny-overrides-allow semantics when used inside [`PermissionChecker`].
+//!   [`PolicyBuilder::effect`] declares whether a match grants or forbids; a
+//!   non-match is "not applicable" either way and never blocks anything.
+//! - Hand-written policies that can return `Forbidden` (via
+//!   [`EvalCtx::forbid`]) must override [`Policy::effect`] to declare
+//!   [`Effect::Deny`]; see [`Policy::effect`] for the contract.
 //!
-//! Denials from [`AccessEvaluation`] are intentionally summary-level. For example,
-//! a failed [`PermissionChecker`] returns the top-level reason
-//! `"All policies denied access"`. Use the attached [`EvalTrace`] to inspect the
-//! individual policy reasons that led to that outcome.
+//! Denials from [`AccessEvaluation`] are intentionally summary-level: a veto
+//! reports `"Forbidden by <policy>: <reason>"` (also exposed structurally via
+//! [`AccessEvaluation::forbidden_by`]), and a no-grant denial reports
+//! `"All policies denied access"`. Use the attached [`EvalTrace`] to inspect
+//! the individual policy reasons that led to that outcome.
 //!
 //! ## Trace Semantics
 //!
 //! [`EvalTrace`] records the policies and combinator branches that were actually
 //! evaluated. Because [`PermissionChecker`], [`AndPolicy`], and [`OrPolicy`]
 //! short-circuit, the trace tree does not include policies that were never run.
+//! The checker's root node is a `DENY_OVERRIDES` combine node whose children
+//! appear in evaluation order: deny-effect policies first, then allow
+//! policies. A forbid ends the evaluation, so a vetoed request's trace shows
+//! the forbidding policy as its last child.
 //!
 //! ## When to populate the Context type
 //!
@@ -238,7 +256,8 @@
 //!     }
 //! }
 //!
-//! // Create a PermissionChecker (which uses OR semantics by default) and add both policies.
+//! // Create a PermissionChecker (deny-overrides over the registered policies;
+//! // with no deny-effect policies this is simply OR) and add both policies.
 //! fn create_document_checker() -> PermissionChecker<User, Document, ReadAction, EmptyContext> {
 //!     let mut checker = PermissionChecker::new();
 //!     checker.add_policy(AdminPolicy);
@@ -343,7 +362,7 @@ mod policy;
 mod results;
 mod session;
 
-pub use builder::{Effect, PolicyBuilder};
+pub use builder::PolicyBuilder;
 pub use checker::PermissionChecker;
 pub use combinators::{AndPolicy, EmptyPoliciesError, NotPolicy, OrPolicy};
 pub use facts::{
@@ -354,7 +373,7 @@ pub use lookup::{Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupPa
 pub use metadata::SecurityRuleMetadata;
 pub(crate) use metadata::{DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE};
 pub use policies::{AbacPolicy, DelegatingPolicy, RbacPolicy, RebacPolicy};
-pub use policy::{BatchEvalCtx, EvalCtx, Policy, PolicyBatchItem};
+pub use policy::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyBatchItem};
 pub use results::{
     AccessEvaluation, CombineOp, EvalTrace, FactOutcome, FactProvenance, PolicyEvalResult,
 };

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -36,10 +36,12 @@ use std::num::NonZeroUsize;
 /// out-of-band signal that completeness was broken: the caller will simply
 /// see fewer resources than they should.
 ///
-/// In particular, [`PermissionChecker`] uses OR semantics across policies.
-/// If you compose policies whose grant axes are independent (for example,
-/// "I own it" OR "it is public" OR "the admin override applies"), the
-/// `LookupSource` must enumerate the union of every axis. Lookup is the
+/// In particular, [`PermissionChecker`] grants when any allow policy
+/// grants (deny-overrides over OR). If you compose policies whose grant
+/// axes are independent (for example, "I own it" OR "it is public" OR
+/// "the admin override applies"), the `LookupSource` must enumerate the
+/// union of every grant axis. Deny-effect policies only *remove* results,
+/// so they never widen what the source must enumerate. Lookup is the
 /// scaling story for the narrow case where one axis dominates; it is
 /// **not** a way to express policy logic inside the data layer.
 ///

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -2,6 +2,25 @@ use crate::{EvaluationSession, FactProvenance, PolicyEvalResult, SecurityRuleMet
 use async_trait::async_trait;
 use std::borrow::Cow;
 
+/// The declared effect of a policy: whether a match grants or forbids access.
+///
+/// `Allow` (the default everywhere) means the policy grants access when it
+/// matches. `Deny` means the policy **forbids** access when it matches — a
+/// matched deny produces [`PolicyEvalResult::Forbidden`], which
+/// [`crate::PermissionChecker`] honors over any grant from sibling policies
+/// (deny-overrides semantics).
+///
+/// The effect travels with the policy: set it via
+/// [`crate::PolicyBuilder::effect`], or declare it on a hand-written policy
+/// by overriding [`Policy::effect`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Effect {
+    /// The policy grants access when its predicates pass.
+    Allow,
+    /// The policy forbids access when its predicates pass.
+    Deny,
+}
+
 /// A borrowed resource/context pair passed to batch policy evaluators.
 ///
 /// Values are borrowed from caller-owned batch items, so policy implementations
@@ -88,6 +107,17 @@ impl<'a, S, R, A, C> EvalCtx<'a, S, R, A, C> {
         PolicyEvalResult::denied(self.policy_type.clone(), reason)
     }
 
+    /// Shorthand for `PolicyEvalResult::forbidden(ctx.policy_type, reason)`.
+    ///
+    /// Use this for an **active veto** — "this request is forbidden" — as
+    /// opposed to [`Self::deny`]'s "this policy does not grant". A policy
+    /// that can return a forbid should also override [`Policy::effect`] to
+    /// return [`Effect::Deny`] so [`crate::PermissionChecker`] evaluates it
+    /// before grant short-circuiting can skip it.
+    pub fn forbid(&self, reason: impl Into<String>) -> PolicyEvalResult {
+        PolicyEvalResult::forbidden(self.policy_type.clone(), reason)
+    }
+
     /// Shorthand for [`PolicyEvalResult::granted_with_facts`] tagged with
     /// `ctx.policy_type`. See [`Self::grant`] for the reason-handling
     /// rationale.
@@ -111,6 +141,17 @@ impl<'a, S, R, A, C> EvalCtx<'a, S, R, A, C> {
         provenance: Vec<FactProvenance>,
     ) -> PolicyEvalResult {
         PolicyEvalResult::denied_with_facts(self.policy_type.clone(), reason, provenance)
+    }
+
+    /// Shorthand for [`PolicyEvalResult::forbidden_with_facts`] tagged with
+    /// `ctx.policy_type`. See [`Self::forbid`] for when a forbid is the
+    /// right result.
+    pub fn forbid_with_facts(
+        &self,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> PolicyEvalResult {
+        PolicyEvalResult::forbidden_with_facts(self.policy_type.clone(), reason, provenance)
     }
 }
 
@@ -235,6 +276,29 @@ where
     /// extra cost.
     fn policy_type(&self) -> Cow<'static, str>;
 
+    /// The declared effect of this policy. Defaults to [`Effect::Allow`].
+    ///
+    /// [`crate::PermissionChecker`] reads this declaration **once, when the
+    /// policy is added**, to schedule evaluation: policies declaring
+    /// [`Effect::Deny`] run **before** the allow policies, so a matched
+    /// forbid is always observed before the grant short-circuit can end the
+    /// evaluation. The declaration must therefore be constant for the
+    /// policy's lifetime. Policies built with
+    /// [`crate::PolicyBuilder::effect`] declare this automatically.
+    ///
+    /// **Contract:** a hand-written policy that can return
+    /// [`PolicyEvalResult::Forbidden`] must override this to return
+    /// [`Effect::Deny`]. The checker still honors a forbid it happens to
+    /// observe from an undeclared policy, but without the declaration a
+    /// sibling's grant can short-circuit evaluation before the forbid is
+    /// reached — the veto would then depend on registration order.
+    /// Conversely, a policy declaring `Effect::Deny` must not return
+    /// `Granted`; the checker treats such a result as not applicable
+    /// (fail-closed) and logs a warning.
+    fn effect(&self) -> Effect {
+        Effect::Allow
+    }
+
     /// Metadata describing the security rule that backs this policy.
     ///
     /// Implementors can override this method to surface additional semantic
@@ -268,6 +332,10 @@ where
 
     fn policy_type(&self) -> Cow<'static, str> {
         (**self).policy_type()
+    }
+
+    fn effect(&self) -> Effect {
+        (**self).effect()
     }
 
     fn security_rule(&self) -> SecurityRuleMetadata {

--- a/src/results.rs
+++ b/src/results.rs
@@ -12,6 +12,9 @@ pub enum CombineOp {
     Not,
     /// A parent policy delegated the decision to another checker.
     Delegate,
+    /// Any forbidding policy denies; otherwise at least one policy must
+    /// grant. The root operation of [`crate::PermissionChecker`].
+    DenyOverrides,
 }
 
 impl fmt::Display for CombineOp {
@@ -21,6 +24,7 @@ impl fmt::Display for CombineOp {
             CombineOp::Or => write!(f, "OR"),
             CombineOp::Not => write!(f, "NOT"),
             CombineOp::Delegate => write!(f, "DELEGATE"),
+            CombineOp::DenyOverrides => write!(f, "DENY_OVERRIDES"),
         }
     }
 }
@@ -126,7 +130,14 @@ impl fmt::Display for FactProvenance {
 /// outcome of access evaluation.
 ///
 /// - [`PolicyEvalResult::Granted`]: Indicates that access is granted, with an optional reason.
-/// - [`PolicyEvalResult::Denied`]: Indicates that access is denied, along with an explanatory reason.
+/// - [`PolicyEvalResult::Denied`]: Indicates the policy did not grant access — either its
+///   predicate did not match (the policy is not applicable to this request) or it simply
+///   has nothing positive to say. A `Denied` from one policy never overrides a sibling's grant.
+/// - [`PolicyEvalResult::Forbidden`]: Indicates the policy **actively forbids** this request.
+///   Inside a [`crate::PermissionChecker`] a forbid overrides every grant (deny-overrides
+///   semantics). Produced by [`crate::PolicyBuilder`] policies with
+///   [`crate::Effect::Deny`] whose predicate matches, or by custom policies via
+///   [`crate::EvalCtx::forbid`].
 /// - [`PolicyEvalResult::Combined`]: Represents the aggregate result of combining multiple policies.
 #[derive(Debug, Clone)]
 pub enum PolicyEvalResult {
@@ -152,6 +163,24 @@ pub enum PolicyEvalResult {
         reason: String,
         /// Facts the policy consulted to reach this decision. Empty for
         /// policies that are not fact-backed (RBAC, ABAC, combinators).
+        provenance: Vec<FactProvenance>,
+    },
+    /// Access actively forbidden: the policy matched and vetoes this request.
+    ///
+    /// Unlike [`PolicyEvalResult::Denied`] ("this policy does not grant"),
+    /// `Forbidden` means "this policy forbids". [`crate::PermissionChecker`]
+    /// honors a forbid over any grant from sibling policies. Combinators
+    /// ([`crate::AndPolicy`], [`crate::OrPolicy`], [`crate::NotPolicy`]) treat
+    /// a `Forbidden` child exactly like `Denied` — the veto is honored at the
+    /// checker level, not propagated through combinator trees. Register
+    /// forbidding policies directly on the checker.
+    Forbidden {
+        /// The name of the policy that forbids access.
+        policy_type: Cow<'static, str>,
+        /// A human-readable reason for the veto.
+        reason: String,
+        /// Facts the policy consulted to reach this decision. Empty for
+        /// policies that are not fact-backed.
         provenance: Vec<FactProvenance>,
     },
     /// Combined result from multiple policy evaluations.
@@ -234,12 +263,13 @@ pub enum AccessEvaluation {
     },
 }
 
-/// Walks a [`PolicyEvalResult`] tree looking for a `Denied` leaf whose
-/// `policy_type` equals `expected`. Used by
+/// Walks a [`PolicyEvalResult`] tree looking for a `Denied` or `Forbidden`
+/// leaf whose `policy_type` equals `expected`. Used by
 /// [`AccessEvaluation::assert_denied_by`].
 fn leaf_denial_matches(node: &PolicyEvalResult, expected: &str) -> bool {
     match node {
-        PolicyEvalResult::Denied { policy_type, .. } => policy_type.as_ref() == expected,
+        PolicyEvalResult::Denied { policy_type, .. }
+        | PolicyEvalResult::Forbidden { policy_type, .. } => policy_type.as_ref() == expected,
         PolicyEvalResult::Granted { .. } => false,
         PolicyEvalResult::Combined { children, .. } => children
             .iter()
@@ -283,6 +313,36 @@ impl AccessEvaluation {
             Self::Denied { reason, .. } => Some(reason),
             Self::Granted { .. } => None,
         }
+    }
+
+    /// Returns the name of the policy whose forbid caused this denial, if
+    /// the denial was a deny-overrides veto rather than a plain
+    /// "no policy granted" outcome.
+    ///
+    /// Useful for distinguishing "actively blocked" (suspension, legal
+    /// hold) from "no grant matched" — for example to map the former to a
+    /// distinct HTTP status or audit event. Returns `None` for grants and
+    /// for ordinary denials.
+    pub fn forbidden_by(&self) -> Option<&str> {
+        let Self::Denied { trace, .. } = self else {
+            return None;
+        };
+        let Some(PolicyEvalResult::Combined {
+            operation: CombineOp::DenyOverrides,
+            children,
+            ..
+        }) = trace.root()
+        else {
+            return None;
+        };
+        // The checker honors forbids only from directly-registered
+        // policies, so only direct children of the deny-overrides root
+        // are considered — a Forbidden buried in a combinator subtree
+        // did not veto and must not be reported as if it had.
+        children.iter().find_map(|child| match child {
+            PolicyEvalResult::Forbidden { policy_type, .. } => Some(policy_type.as_ref()),
+            _ => None,
+        })
     }
 
     /// Test helper: panic unless the evaluation is `Granted` and the
@@ -412,6 +472,50 @@ impl AccessEvaluation {
                     );
                 }
             }
+        }
+    }
+
+    /// Test helper: panic unless the evaluation is `Denied` *because of a
+    /// forbid* by the policy named `expected`.
+    ///
+    /// Stronger than [`Self::assert_denied_by`]: this asserts the denial
+    /// was a deny-overrides veto attributed to `expected` (via
+    /// [`Self::forbidden_by`]), not merely that `expected` appears as a
+    /// denying leaf somewhere in the trace.
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # tokio_test::block_on(async {
+    /// # let mut checker = PermissionChecker::<(), (), (), ()>::new();
+    /// # checker.add_policy(PolicyBuilder::<(), (), (), ()>::new("AllowAll").build());
+    /// # checker.add_policy(
+    /// #     PolicyBuilder::<(), (), (), ()>::new("GlobalFreeze")
+    /// #         .effect(Effect::Deny)
+    /// #         .build(),
+    /// # );
+    /// # let evaluation = checker.check(&(), &(), &(), &()).await;
+    /// evaluation.assert_forbidden_by("GlobalFreeze");
+    /// # });
+    /// ```
+    #[track_caller]
+    pub fn assert_forbidden_by(&self, expected: &str) {
+        match self {
+            Self::Granted { policy_type, .. } => {
+                panic!(
+                    "expected forbid by policy `{expected}`, but access was granted by `{policy_type}`"
+                );
+            }
+            Self::Denied { .. } => match self.forbidden_by() {
+                Some(actual) => assert_eq!(
+                    actual, expected,
+                    "expected forbid by policy `{expected}`, but the forbid came from `{actual}`"
+                ),
+                None => panic!(
+                    "expected forbid by policy `{expected}`, but the denial was not a forbid; \
+                     got:\n{}",
+                    self.display_trace()
+                ),
+            },
         }
     }
 
@@ -603,6 +707,22 @@ impl PolicyEvalResult {
         }
     }
 
+    /// Builds a forbidden leaf result with no fact provenance.
+    ///
+    /// A forbid is an **active veto**: inside a [`crate::PermissionChecker`]
+    /// it overrides grants from sibling policies. Custom policies returning
+    /// this from [`crate::Policy::evaluate`] should also override
+    /// [`crate::Policy::effect`] to return [`crate::Effect::Deny`] so the
+    /// checker schedules them ahead of the grant short-circuit. Prefer
+    /// [`crate::EvalCtx::forbid`] inside policy bodies.
+    pub fn forbidden(policy_type: impl Into<Cow<'static, str>>, reason: impl Into<String>) -> Self {
+        Self::Forbidden {
+            policy_type: policy_type.into(),
+            reason: reason.into(),
+            provenance: Vec::new(),
+        }
+    }
+
     /// Builds a granted leaf result carrying the facts that informed it.
     pub fn granted_with_facts(
         policy_type: impl Into<Cow<'static, str>>,
@@ -629,13 +749,37 @@ impl PolicyEvalResult {
         }
     }
 
+    /// Builds a forbidden leaf result carrying the facts that informed it.
+    pub fn forbidden_with_facts(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self::Forbidden {
+            policy_type: policy_type.into(),
+            reason: reason.into(),
+            provenance,
+        }
+    }
+
     /// Returns whether this evaluation resulted in access being granted
     pub fn is_granted(&self) -> bool {
         match self {
             Self::Granted { .. } => true,
-            Self::Denied { .. } => false,
+            Self::Denied { .. } | Self::Forbidden { .. } => false,
             Self::Combined { outcome, .. } => *outcome,
         }
+    }
+
+    /// Returns whether this result is an active forbid
+    /// ([`PolicyEvalResult::Forbidden`]).
+    ///
+    /// This is a **leaf check**, deliberately: a `Forbidden` nested inside a
+    /// [`PolicyEvalResult::Combined`] subtree does not make the combined
+    /// result forbidding. [`crate::PermissionChecker`] honors forbids only
+    /// from the policies registered directly on it.
+    pub fn is_forbidden(&self) -> bool {
+        matches!(self, Self::Forbidden { .. })
     }
 
     /// Returns the reason string if available
@@ -650,7 +794,7 @@ impl PolicyEvalResult {
     pub fn reason_str(&self) -> Option<&str> {
         match self {
             Self::Granted { reason, .. } => reason.as_deref(),
-            Self::Denied { reason, .. } => Some(reason),
+            Self::Denied { reason, .. } | Self::Forbidden { reason, .. } => Some(reason),
             Self::Combined { .. } => None,
         }
     }
@@ -660,7 +804,9 @@ impl PolicyEvalResult {
     /// Empty for combinators and for policies that are not fact-backed.
     pub fn provenance(&self) -> &[FactProvenance] {
         match self {
-            Self::Granted { provenance, .. } | Self::Denied { provenance, .. } => provenance,
+            Self::Granted { provenance, .. }
+            | Self::Denied { provenance, .. }
+            | Self::Forbidden { provenance, .. } => provenance,
             Self::Combined { .. } => &[],
         }
     }
@@ -687,6 +833,14 @@ impl PolicyEvalResult {
                 provenance,
             } => {
                 let headline = format!("{}✘ {} DENIED: {}", indent_str, policy_type, reason);
+                Self::append_provenance(headline, &indent_str, provenance)
+            }
+            Self::Forbidden {
+                policy_type,
+                reason,
+                provenance,
+            } => {
+                let headline = format!("{}⛔ {} FORBIDDEN: {}", indent_str, policy_type, reason);
                 Self::append_provenance(headline, &indent_str, provenance)
             }
             Self::Combined {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2988,14 +2988,17 @@ mod core_tests {
     {
         let mut checker = PermissionChecker::new();
         checker.add_policy(AlwaysDenyPolicy("first denial reason"));
-        // A second denying policy with the same `policy_type()` but a
-        // different reason, since AlwaysDenyPolicy is a tuple struct.
-        // (The tree-walker checks policy_type, not reason — what we're
-        // pinning is that it finds *any* matching leaf.)
+        // A second denying policy with a different name and reason. Its
+        // deny-effect predicate never matches, so it lands in the trace as
+        // a not-applicable `Denied` leaf rather than vetoing the whole
+        // evaluation before the first policy is consulted. (The
+        // tree-walker checks policy_type, not reason — what we're pinning
+        // is that it finds *any* matching leaf.)
         let custom = PolicyBuilder::<TestSubject, TestResource, TestAction, TestContext>::new(
             "SupplierBlock",
         )
         .effect(Effect::Deny)
+        .subjects(|_subject| false)
         .build();
         checker.add_policy(custom);
         checker
@@ -3203,13 +3206,83 @@ mod policy_builder_tests {
         );
     }
 
+    /// The headline deny-overrides behavior: a matched `Effect::Deny` policy
+    /// vetoes a sibling grant, regardless of registration order.
     #[tokio::test]
-    async fn test_policy_builder_effect_deny_does_not_override_other_grants() {
+    async fn test_policy_builder_effect_deny_overrides_other_grants() {
+        for deny_registered_first in [true, false] {
+            let deny_policy =
+                PolicyBuilder::<TestSubject, TestResource, TestAction, TestContext>::new(
+                    "BlockAlicePolicy",
+                )
+                .effect(Effect::Deny)
+                .subjects(|subject| subject.name == "Alice")
+                .build();
+
+            let allow_policy =
+                PolicyBuilder::<TestSubject, TestResource, TestAction, TestContext>::new(
+                    "AllowAlicePolicy",
+                )
+                .subjects(|subject| subject.name == "Alice")
+                .build();
+
+            let mut checker = PermissionChecker::new();
+            if deny_registered_first {
+                checker.add_policy(deny_policy);
+                checker.add_policy(allow_policy);
+            } else {
+                checker.add_policy(allow_policy);
+                checker.add_policy(deny_policy);
+            }
+
+            let session = EvaluationSession::empty();
+            let result = checker
+                .evaluate_in_session(
+                    &session,
+                    &TestSubject {
+                        name: "Alice".into(),
+                    },
+                    &TestAction,
+                    &TestResource,
+                    &TestContext,
+                )
+                .await;
+
+            result.assert_forbidden_by("BlockAlicePolicy");
+            assert_eq!(
+                result.denied_reason(),
+                Some("Forbidden by BlockAlicePolicy: Policy forbids access"),
+                "summary reason should name the forbidding policy"
+            );
+
+            // A subject the deny predicate does not match is unaffected:
+            // a non-matching deny policy is "not applicable", never a veto.
+            let bob_result = checker
+                .evaluate_in_session(
+                    &session,
+                    &TestSubject { name: "Bob".into() },
+                    &TestAction,
+                    &TestResource,
+                    &TestContext,
+                )
+                .await;
+            assert!(
+                !bob_result.is_granted(),
+                "Bob has no grant (AllowAlicePolicy does not match him)"
+            );
+            assert_eq!(bob_result.forbidden_by(), None);
+        }
+    }
+
+    /// A non-matching `Effect::Deny` policy contributes nothing: the allow
+    /// set still decides, and the trace root reflects deny-overrides.
+    #[tokio::test]
+    async fn test_non_matching_deny_policy_does_not_block_grants() {
         let deny_policy = PolicyBuilder::<TestSubject, TestResource, TestAction, TestContext>::new(
-            "ExplicitDenyLikePolicy",
+            "BlockNobodyPolicy",
         )
         .effect(Effect::Deny)
-        .subjects(|subject| subject.name == "Alice")
+        .subjects(|_subject| false)
         .build();
 
         let allow_policy =
@@ -3220,8 +3293,8 @@ mod policy_builder_tests {
             .build();
 
         let mut checker = PermissionChecker::new();
-        checker.add_policy(deny_policy);
         checker.add_policy(allow_policy);
+        checker.add_policy(deny_policy);
 
         let session = EvaluationSession::empty();
         let result = checker
@@ -3236,10 +3309,8 @@ mod policy_builder_tests {
             )
             .await;
 
-        assert!(
-            result.is_granted(),
-            "A deny-effect builder policy should not override a later allow under PermissionChecker OR semantics"
-        );
+        result.assert_granted_by("AllowAlicePolicy");
+        result.assert_trace_contains("DENY_OVERRIDES");
     }
 
     // Test that extra conditions (combining multiple inputs) work correctly.

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use gatehouse::{
-    AccessEvaluation, BatchEvalCtx, DelegatingPolicy, EvalCtx, EvaluationSession, FactLoadResult,
-    FactSource, PermissionChecker, Policy, PolicyBatchItem, PolicyBuilder, PolicyEvalResult,
-    RebacPolicy, RelationshipQuery,
+    AccessEvaluation, AndPolicy, BatchEvalCtx, DelegatingPolicy, Effect, EvalCtx,
+    EvaluationSession, FactLoadResult, FactSource, NotPolicy, OrPolicy, PermissionChecker, Policy,
+    PolicyBatchItem, PolicyBuilder, PolicyEvalResult, RebacPolicy, RelationshipQuery,
 };
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -78,6 +78,7 @@ struct RandomStackPolicy {
     name: String,
     grant_percent: u8,
     salt: u16,
+    effect: Effect,
 }
 
 #[async_trait]
@@ -102,15 +103,26 @@ impl Policy<Subject, Resource, Action, Ctx> for RandomStackPolicy {
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Owned(self.name.clone())
     }
+
+    fn effect(&self) -> Effect {
+        self.effect
+    }
 }
 
 impl RandomStackPolicy {
     fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
         let score = ((resource_id as u16 * 37) ^ self.salt).wrapping_add(self.salt / 3) % 100;
-        if score < self.grant_percent as u16 {
-            PolicyEvalResult::granted(self.name.clone(), Some(format!("{resource_id} granted")))
-        } else {
-            PolicyEvalResult::denied(self.name.clone(), format!("{resource_id} denied"))
+        let matched = score < self.grant_percent as u16;
+        match (self.effect, matched) {
+            (Effect::Allow, true) => {
+                PolicyEvalResult::granted(self.name.clone(), Some(format!("{resource_id} granted")))
+            }
+            (Effect::Deny, true) => {
+                PolicyEvalResult::forbidden(self.name.clone(), format!("{resource_id} forbidden"))
+            }
+            (_, false) => {
+                PolicyEvalResult::denied(self.name.clone(), format!("{resource_id} denied"))
+            }
         }
     }
 }
@@ -465,7 +477,7 @@ proptest! {
 
     #[test]
     fn batch_decisions_match_naive_loop_for_random_policy_stacks(
-        policy_specs in prop::collection::vec((0u8..=100, any::<u16>()), 1..=5),
+        policy_specs in prop::collection::vec((0u8..=100, any::<u16>(), any::<bool>()), 1..=5),
         resource_ids in prop::collection::vec(0u8..64, 0..50),
         max_batch_size in prop::option::of(1usize..8),
     ) {
@@ -474,11 +486,12 @@ proptest! {
         } else {
             PermissionChecker::new()
         };
-        for (index, (grant_percent, salt)) in policy_specs.into_iter().enumerate() {
+        for (index, (grant_percent, salt, is_deny)) in policy_specs.into_iter().enumerate() {
             checker.add_policy(RandomStackPolicy {
                 name: format!("random_{index}"),
                 grant_percent,
                 salt,
+                effect: if is_deny { Effect::Deny } else { Effect::Allow },
             });
         }
 
@@ -498,20 +511,28 @@ proptest! {
             |item| (&item.0, &item.1),
         ))
         .into_iter()
-        .map(|(_item, evaluation)| evaluation.is_granted())
+        .map(|(_item, evaluation)| {
+            (
+                evaluation.is_granted(),
+                evaluation.forbidden_by().map(str::to_owned),
+            )
+        })
         .collect::<Vec<_>>();
 
         let mut naive = Vec::new();
         for (resource, context) in &items {
             let session = EvaluationSession::empty();
-            naive.push(tokio_test::block_on(checker.evaluate_in_session(
+            let evaluation = tokio_test::block_on(checker.evaluate_in_session(
                 &session,
                 &subject,
                 &action,
                 resource,
                 context,
-            ))
-            .is_granted());
+            ));
+            naive.push((
+                evaluation.is_granted(),
+                evaluation.forbidden_by().map(str::to_owned),
+            ));
         }
 
         prop_assert_eq!(batch, naive);
@@ -623,4 +644,412 @@ async fn mixed_policy_stack_uses_in_memory_policy_and_rebac_session() {
             },
         ]]
     );
+}
+
+// ---- deny-overrides semantics -------------------------------------
+
+fn allow_everything(name: &str) -> Box<dyn Policy<Subject, Resource, Action, Ctx>> {
+    PolicyBuilder::<Subject, Resource, Action, Ctx>::new(name.to_string()).build()
+}
+
+fn forbid_odd_resources(name: &str) -> Box<dyn Policy<Subject, Resource, Action, Ctx>> {
+    PolicyBuilder::<Subject, Resource, Action, Ctx>::new(name.to_string())
+        .resources(|resource: &Resource| resource.id % 2 == 1)
+        .effect(Effect::Deny)
+        .build()
+}
+
+#[tokio::test]
+async fn batch_forbid_overrides_grants_regardless_of_registration_order() {
+    // The deny policy is registered *after* the allow policy; deny-first
+    // scheduling must still veto before the allow phase grants.
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(allow_everything("AllowAll"));
+    checker.add_policy(forbid_odd_resources("OddBlock"));
+
+    let session = EvaluationSession::empty();
+    let items = (0..4).map(|id| (Resource { id }, Ctx)).collect::<Vec<_>>();
+    let results = checker
+        .evaluate_batch_in_session_by(&session, &Subject, &Action, items, |item| {
+            (&item.0, &item.1)
+        })
+        .await;
+
+    let decisions = results
+        .iter()
+        .map(|((resource, _ctx), evaluation)| {
+            (
+                resource.id,
+                evaluation.is_granted(),
+                evaluation.forbidden_by().map(str::to_owned),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        decisions,
+        vec![
+            (0, true, None),
+            (1, false, Some("OddBlock".to_string())),
+            (2, true, None),
+            (3, false, Some("OddBlock".to_string())),
+        ]
+    );
+
+    // The filter convenience (and therefore the lookup pipeline built on
+    // it) honors the forbid identically.
+    let visible = checker
+        .filter_authorized_in_session_by_resource(
+            &session,
+            &Subject,
+            &Action,
+            (0..4).map(|id| Resource { id }).collect::<Vec<_>>(),
+            &Ctx,
+            |resource| resource,
+        )
+        .await;
+    assert_eq!(
+        visible
+            .iter()
+            .map(|resource| resource.id)
+            .collect::<Vec<_>>(),
+        vec![0, 2]
+    );
+}
+
+#[tokio::test]
+async fn single_and_batch_forbid_decisions_agree() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(allow_everything("AllowAll"));
+    checker.add_policy(forbid_odd_resources("OddBlock"));
+
+    let session = EvaluationSession::empty();
+    for id in 0..4 {
+        let single = checker
+            .evaluate_in_session(&session, &Subject, &Action, &Resource { id }, &Ctx)
+            .await;
+        let batch = checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![(Resource { id }, Ctx)],
+                |item| (&item.0, &item.1),
+            )
+            .await
+            .remove(0)
+            .1;
+        assert_eq!(single.is_granted(), batch.is_granted(), "id {id}");
+        assert_eq!(single.forbidden_by(), batch.forbidden_by(), "id {id}");
+    }
+}
+
+/// Forbids are honored at the checker level only: inside combinators a
+/// `Forbidden` child behaves exactly like `Denied`. Register forbidding
+/// policies directly on the checker.
+#[tokio::test]
+async fn forbid_inside_combinators_acts_as_plain_denial() {
+    let session = EvaluationSession::empty();
+    let blocked = Resource { id: 1 };
+
+    // OR: the allow arm wins; the nested forbid does not veto.
+    let or_gate = OrPolicy::try_new(vec![
+        Arc::from(allow_everything("AllowAll")),
+        Arc::from(forbid_odd_resources("OddBlock")),
+    ])
+    .unwrap();
+    let mut or_checker = PermissionChecker::new();
+    or_checker.add_policy(or_gate);
+    let or_result = or_checker
+        .evaluate_in_session(&session, &Subject, &Action, &blocked, &Ctx)
+        .await;
+    assert!(or_result.is_granted());
+    assert_eq!(or_result.forbidden_by(), None);
+
+    // AND: a forbid is not a grant, so the conjunction fails — but as an
+    // ordinary denial, not a checker-level veto.
+    let and_gate = AndPolicy::try_new(vec![
+        Arc::from(allow_everything("AllowAll")),
+        Arc::from(forbid_odd_resources("OddBlock")),
+    ])
+    .unwrap();
+    let mut and_checker = PermissionChecker::new();
+    and_checker.add_policy(and_gate);
+    let and_result = and_checker
+        .evaluate_in_session(&session, &Subject, &Action, &blocked, &Ctx)
+        .await;
+    assert!(!and_result.is_granted());
+    assert_eq!(and_result.forbidden_by(), None);
+
+    // NOT: inverts not-granted into granted — the pre-Forbidden blocklist
+    // polarity. A forbid that must veto belongs on the checker, not under
+    // NOT.
+    let mut not_checker = PermissionChecker::new();
+    not_checker.add_policy(NotPolicy::new(forbid_odd_resources("OddBlock")));
+    let not_result = not_checker
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    assert!(
+        not_result.is_granted(),
+        "NOT(non-matching deny) is granted, as for any non-granting child"
+    );
+}
+
+/// Identity-mapped delegating policy whose child checker grants everything
+/// except odd resource ids, which it forbids.
+fn delegating_forbid_policy(
+) -> DelegatingPolicy<Subject, Resource, Action, Ctx, Subject, Resource, Action, Ctx> {
+    let mut child: PermissionChecker<Subject, Resource, Action, Ctx> = PermissionChecker::new();
+    child.add_policy(allow_everything("ChildAllow"));
+    child.add_policy(forbid_odd_resources("ChildBlock"));
+    DelegatingPolicy::new(
+        "DelegatedDecision",
+        child,
+        |_subject: &Subject| Subject,
+        |_action: &Action| Action,
+        |_subject: &Subject, resource: &Resource, _action: &Action, _ctx: &Ctx| Resource {
+            id: resource.id,
+        },
+        |_subject: &Subject, _resource: &Resource, _action: &Action, _ctx: &Ctx| Ctx,
+    )
+}
+
+/// A forbid inside a delegated child checker is scoped to that checker:
+/// the parent sees an ordinary denial from the delegating policy, and a
+/// sibling grant in the parent still wins.
+#[tokio::test]
+async fn delegated_child_forbid_is_scoped_to_the_child_checker() {
+    let mut parent = PermissionChecker::new();
+    parent.add_policy(delegating_forbid_policy());
+    parent.add_policy(allow_everything("ParentAllow"));
+
+    let session = EvaluationSession::empty();
+    let result = parent
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 1 }, &Ctx)
+        .await;
+
+    // The child checker forbids id 1, so the delegate denies — but the
+    // veto does not propagate: the parent's own allow still grants.
+    result.assert_granted_by("ParentAllow");
+
+    // Without the parent grant, the delegated denial is an ordinary
+    // denial, not a parent-level forbid.
+    let mut parent_without_allow = PermissionChecker::new();
+    parent_without_allow.add_policy(delegating_forbid_policy());
+    let denied = parent_without_allow
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 1 }, &Ctx)
+        .await;
+    assert!(!denied.is_granted());
+    assert_eq!(denied.forbidden_by(), None);
+}
+
+/// A hand-written policy that declares `Effect::Deny` and forbids via
+/// `ctx.forbid` is honored on both evaluation paths.
+struct SuspendedSubjectPolicy;
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for SuspendedSubjectPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        if ctx.resource.id == 1 {
+            ctx.forbid("resource 1 is frozen")
+        } else {
+            ctx.deny("not applicable")
+        }
+    }
+
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("SuspendedSubjectPolicy")
+    }
+
+    fn effect(&self) -> Effect {
+        Effect::Deny
+    }
+}
+
+#[tokio::test]
+async fn custom_policy_forbid_via_ctx_forbid_is_honored() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(allow_everything("AllowAll"));
+    checker.add_policy(SuspendedSubjectPolicy);
+
+    let session = EvaluationSession::empty();
+    let blocked = checker
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 1 }, &Ctx)
+        .await;
+    blocked.assert_forbidden_by("SuspendedSubjectPolicy");
+
+    let granted = checker
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    granted.assert_granted_by("AllowAll");
+
+    // Default evaluate_batch forwards to evaluate, so the batch path
+    // observes the same forbids.
+    let results = checker
+        .evaluate_batch_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            vec![(Resource { id: 0 }, Ctx), (Resource { id: 1 }, Ctx)],
+            |item| (&item.0, &item.1),
+        )
+        .await;
+    assert!(results[0].1.is_granted());
+    assert_eq!(results[1].1.forbidden_by(), Some("SuspendedSubjectPolicy"));
+}
+
+/// Contract violation: a policy declaring `Effect::Deny` must not grant.
+/// The checker fails closed, treating the grant as not applicable.
+struct MisbehavingDenyPolicy;
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for MisbehavingDenyPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        ctx.grant("grant from a deny-effect policy")
+    }
+
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("MisbehavingDenyPolicy")
+    }
+
+    fn effect(&self) -> Effect {
+        Effect::Deny
+    }
+}
+
+#[tokio::test]
+async fn grant_from_deny_declared_policy_is_treated_as_not_applicable() {
+    // Alone in a checker, the misbehaving grant must not grant access.
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(MisbehavingDenyPolicy);
+    let session = EvaluationSession::empty();
+    let alone = checker
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    assert!(!alone.is_granted());
+    assert_eq!(alone.forbidden_by(), None);
+
+    // Alongside a real allow policy, the sibling grant still decides.
+    checker.add_policy(allow_everything("AllowAll"));
+    let with_allow = checker
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    with_allow.assert_granted_by("AllowAll");
+
+    // Same fail-closed handling on the batch path.
+    let batch = checker
+        .evaluate_batch_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            vec![(Resource { id: 0 }, Ctx)],
+            |item| (&item.0, &item.1),
+        )
+        .await;
+    assert!(batch[0].1.is_granted());
+}
+
+/// An *undeclared* forbid (default `Effect::Allow`) is honored when the
+/// checker observes it, but a sibling grant evaluated earlier can
+/// short-circuit before it is reached — declaring `Effect::Deny` is what
+/// makes a veto order-independent.
+struct UndeclaredForbidPolicy;
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for UndeclaredForbidPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        ctx.forbid("forbid without declaring Effect::Deny")
+    }
+
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("UndeclaredForbidPolicy")
+    }
+}
+
+#[tokio::test]
+async fn undeclared_forbid_is_honored_when_observed_but_not_scheduled_first() {
+    let session = EvaluationSession::empty();
+
+    // Observed before any grant: honored.
+    let mut forbid_first = PermissionChecker::new();
+    forbid_first.add_policy(UndeclaredForbidPolicy);
+    forbid_first.add_policy(allow_everything("AllowAll"));
+    let blocked = forbid_first
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    blocked.assert_forbidden_by("UndeclaredForbidPolicy");
+
+    // Grant short-circuits first: the undeclared forbid is never reached.
+    // This pins the documented contract that forbidding policies must
+    // declare Effect::Deny to veto deterministically.
+    let mut grant_first = PermissionChecker::new();
+    grant_first.add_policy(allow_everything("AllowAll"));
+    grant_first.add_policy(UndeclaredForbidPolicy);
+    let granted = grant_first
+        .evaluate_in_session(&session, &Subject, &Action, &Resource { id: 0 }, &Ctx)
+        .await;
+    granted.assert_granted_by("AllowAll");
+}
+
+/// A deny-effect policy whose batch override returns the wrong number of
+/// results fails closed: affected items are denied, not granted by the
+/// allow phase.
+struct WrongLengthDenyPolicy;
+
+#[async_trait]
+impl Policy<Subject, Resource, Action, Ctx> for WrongLengthDenyPolicy {
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, Subject, Resource, Action, Ctx>,
+    ) -> PolicyEvalResult {
+        ctx.deny("not applicable")
+    }
+
+    async fn evaluate_batch<'item>(
+        &self,
+        _ctx: &BatchEvalCtx<'item, Subject, Resource, Action, Ctx>,
+    ) -> Vec<PolicyEvalResult> {
+        Vec::new()
+    }
+
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("WrongLengthDenyPolicy")
+    }
+
+    fn effect(&self) -> Effect {
+        Effect::Deny
+    }
+}
+
+#[tokio::test]
+async fn wrong_length_batch_from_deny_policy_fails_closed() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(allow_everything("AllowAll"));
+    checker.add_policy(WrongLengthDenyPolicy);
+
+    let session = EvaluationSession::empty();
+    let results = checker
+        .evaluate_batch_in_session_by(
+            &session,
+            &Subject,
+            &Action,
+            vec![(Resource { id: 0 }, Ctx), (Resource { id: 1 }, Ctx)],
+            |item| (&item.0, &item.1),
+        )
+        .await;
+
+    for (_item, evaluation) in &results {
+        assert!(
+            !evaluation.is_granted(),
+            "items touched by a broken deny policy must fail closed"
+        );
+    }
 }

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use gatehouse::{
-    BatchEvalCtx, EvalCtx, EvaluationSession, PermissionChecker, Policy, PolicyEvalResult,
+    BatchEvalCtx, Effect, EvalCtx, EvaluationSession, PermissionChecker, Policy, PolicyBuilder,
+    PolicyEvalResult,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -526,4 +527,55 @@ fn named_checker_records_name_on_batch_span() {
 
     let batch = span(&spans, "evaluate_batch_in_session_by");
     assert_value(batch, "checker.name", "InvoiceItemChecker");
+}
+
+#[test]
+fn tracing_fields_are_recorded_for_forbidden_decisions() {
+    // An allow policy that would grant, vetoed by a deny-effect policy.
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(TracePolicy);
+    checker.add_policy(
+        PolicyBuilder::<Subject, Resource, Action, Ctx>::new("GlobalFreeze")
+            .effect(Effect::Deny)
+            .build(),
+    );
+
+    let session = EvaluationSession::empty();
+    let (result, spans) = capture_async(|| async {
+        checker
+            .evaluate_in_session(
+                &session,
+                &Subject,
+                &Action,
+                &Resource { allowed: true },
+                &Ctx,
+            )
+            .await
+    });
+    assert!(!result.is_granted());
+
+    // The single-evaluation span attributes the denial to the forbid.
+    let single = span(&spans, "evaluate_in_session");
+    assert_value(single, "outcome", "denied");
+    assert_value(single, "policy.type", "GlobalFreeze");
+
+    // The batch policy span carries the declared effect and the forbid count.
+    let (_results, spans) = capture_async(|| async {
+        checker
+            .evaluate_batch_in_session_by(
+                &session,
+                &Subject,
+                &Action,
+                vec![(Resource { allowed: true }, Ctx)],
+                |item| (&item.0, &item.1),
+            )
+            .await
+    });
+
+    // Deny-first scheduling: the first batch_policy span is the deny policy.
+    let policy = span(&spans, "gatehouse.batch_policy");
+    assert_value(policy, "policy.type", "GlobalFreeze");
+    assert_value(policy, "policy.effect", "deny");
+    assert_value(policy, "policy.forbidden_count", "1");
+    assert_value(policy, "policy.granted_count", "0");
 }


### PR DESCRIPTION
Closes #44.

## What

`PermissionChecker` now honors `Effect::Deny` with fixed, Cedar-style deny-overrides semantics:

1. any policy that **forbids** (an `Effect::Deny` policy whose predicate matches, producing the new `PolicyEvalResult::Forbidden`) denies the request, overriding every grant — the trace and summary reason name the forbid;
2. otherwise any granting policy grants (OR, short-circuiting on the first grant, as today);
3. otherwise default deny, as today.

No combining-algorithm knob; the effect travels with the policy, so a policy's behaviour is readable in isolation.

```rust
let suspended = PolicyBuilder::<User, Doc, Action, Ctx>::new("SuspendedAccount")
    .when(|user, _, _, _| user.is_suspended)
    .effect(Effect::Deny)   // matches → forbids. Reads exactly as it behaves.
    .build();

checker.add_policy(admin_override);
checker.add_policy(owner_policy);
checker.add_policy(suspended);  // just a policy; its effect travels with it
```

## Design decisions (refining the issue's open questions)

- **Result shape:** new `Forbidden { policy_type, reason, provenance }` leaf variant rather than recasting non-match as `NotApplicable`. The recast would have broken the issue's own compatibility promise: every existing hand-written policy returns `ctx.deny(...)` for "predicate didn't match", and veto-strength `Denied` would silently turn them all into global vetoes.
- **`Policy::effect()` (new, defaulted to `Effect::Allow`):** the issue's "evaluate deny policies first" assumed the checker could see a policy's effect — it couldn't (`Effect` was private to the builder's internal policy behind `dyn Policy`). The declaration is read once at `add_policy`, which keeps the policy list in deny-first order; evaluation iterates it directly, so **allow-only checkers behave bit-for-bit identically with zero added allocation**, and the ordering — not just an optimization — is what makes the veto independent of registration order. Hand-written policies that can `ctx.forbid(...)` must override `effect()`; an undeclared forbid is still honored when observed, but a grant can short-circuit past it (pinned by test, documented on the method).
- **Evaluation order:** forbids first (the issue's leaning) — required for determinism given the grant short-circuit, per above.
- **Combinator/delegation scoping:** forbids are honored at the checker level only. Inside `And`/`Or`/`Not` a `Forbidden` child behaves exactly like `Denied` (deterministic; `Or`'s grant short-circuit would otherwise make nested vetoes order-dependent), and a child checker's forbid surfaces to a `DelegatingPolicy` parent as a plain denial — the issue's "scoped per checker" leaning, which falls out of the existing delegation code. Scoped exclusion stays expressible as `AndPolicy[grant, NotPolicy(block)]` (kept as an appendix in the example).
- **Fail-closed contract handling:** a deny-declared policy that returns a grant is treated as not applicable with a warning; wrong-length batch results from a deny policy keep denying affected items.

## Surface changes

- `PolicyEvalResult::Forbidden`, `CombineOp::DenyOverrides` (**breaking for exhaustive matches** — 0.x, loud changelog note), `forbidden()`/`forbidden_with_facts()`, `is_forbidden()`.
- `Policy::effect()`, `EvalCtx::forbid`/`forbid_with_facts`; `Effect` moved next to `Policy` (crate-root re-export unchanged) and is now `Copy`.
- Veto denials report `"Forbidden by <policy>: <reason>"`; `AccessEvaluation::forbidden_by()` + `assert_forbidden_by()` expose the vetoing policy structurally (useful for 403-vs-404 style mapping).
- Telemetry: batch `gatehouse.batch_policy` spans gain `policy.effect` / `policy.forbidden_count`; the security event gains `policy.effect`; a misbehaving deny policy warns once per chunk, not per item.
- Batch, filter, and lookup pipelines honor forbids identically (the lookup completeness contract docs now note deny policies never widen what a `LookupSource` must enumerate).
- `examples/deny_override.rs` rewritten around flat `add_policy` registration — the inverted-polarity `NOT(blocklist)` explanation is gone, kept only as the scoped-exclusion appendix.

## Compatibility

Checkers with no `Effect::Deny` policies behave identically (pinned by the unchanged contract/property tests). Anyone who had already registered an `Effect::Deny` policy sees it start working — previously it silently did nothing, which is the trap being fixed. Changelog carries the audit note.

## Testing

- Flipped the old trap-pinning test into the headline test (veto wins in both registration orders).
- New contract tests: batch + filter/lookup vetoes, single/batch parity, combinator scoping (`Or`/`And`/`Not`), delegation scoping, custom `ctx.forbid` policies, deny-declared-returns-grant fail-closed, undeclared-forbid ordering contract, wrong-length batch fail-closed, tracing fields for forbidden decisions.
- The 1000-case batch-vs-naive property test now generates random allow/deny stacks and asserts `forbidden_by` parity.
- `cargo fmt` / `clippy --all-targets --all-features -D warnings` / `cargo test --all-targets --all-features` / `cargo test --doc` all clean; example output verified.