### PR TITLE
ci: bump actions/checkout to v6 for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
@@ -61,7 +61,7 @@ jobs:
     if: github.event.release && github.event.action == 'published'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
GitHub forces Node.js 20 actions to run on Node 24 starting **June 16th, 2026** and removes Node 20 from runners in September 2026.

`ci.yml` pins `actions/checkout@v4` (node20) in 3 places; v6 runs node24 natively. The v6 credential-persistence change doesn't affect this repo — no workflow does `git push` after checkout.

Left as-is: `Swatinem/rust-cache@v2` (floating major already resolves to node24 releases) and `dtolnay/rust-toolchain` (composite action, no Node runtime).

Same change as thepartly/reflectapi#172.