### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-27
+
 This is a semver-major API cleanup. Gatehouse now centers public authorization
 APIs around a `PolicyDomain` marker and a session-bound evaluator, removes the
 no-session checker shortcut, and uses explicit policy-level


### PR DESCRIPTION
Finalizes the CHANGELOG for the 0.5.0 release (domain-bound authorization API). `Cargo.toml`/`Cargo.lock` were already bumped to 0.5.0 in #49.

Publishing the GitHub Release for tag `v0.5.0` after merge triggers the crates.io publish.