### PR TITLE
Docs and benchmark pass for 0.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,37 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository.
+Notes for coding agents. Assumes you know Rust tooling — this covers only what is specific or non-obvious to this repo.
 
-## Commands
+## Project-specific commands
 
 ```bash
-cargo build                                                    # build
-cargo fmt --all                                                # format
-cargo clippy --all-targets --all-features -- -D warnings       # lint (CI uses -D warnings)
-cargo test --all-targets --all-features                        # all tests
-cargo test <test_name>                                         # single test
+cargo run --example axum        # HTTP server on :8000
+cargo run --example actix_web   # HTTP server on :8080
+
+# Reproduce the PR mutation gate locally (see "CI gates" below)
 git diff origin/main...HEAD -- src/checker.rs src/combinators.rs > mutants.diff
-cargo mutants --in-place --in-diff=mutants.diff --file src/checker.rs --file src/combinators.rs --all-features -- --test checker_contract --test tracing_contract
-cargo bench                                                    # criterion benchmarks
-cargo run --example axum                                       # HTTP server on :8000
-cargo run --example actix_web                                  # HTTP server on :8080
+cargo mutants --in-place --in-diff=mutants.diff \
+  --file src/checker.rs --file src/combinators.rs \
+  --baseline=skip --timeout=60 --build-timeout=300 --all-features
 ```
 
-CI order: build → clippy → doc → test → focused mutation tests. Always `fmt` + `clippy` before committing.
+## CI gates that bite
+
+- Clippy runs with `-D warnings`; any warning fails CI. `fmt` + `clippy` before committing.
+- A **diff-scoped `cargo-mutants` gate** mutates the PR's changes to `src/checker.rs` and `src/combinators.rs` only. Every new/changed line there must be killed by a test or CI fails (~20 min run). When you touch veto/short-circuit logic, add a test that *distinguishes the mutation* (e.g. a case where `&&` vs `||` actually diverge), not just a happy-path assertion — a green test that survives the mutant is the usual failure mode here.
+- `main` is governed by a require-approval ruleset: PRs need an approving review (you cannot self-approve); repo/org admins can bypass.
+- Publishing a GitHub Release for tag `vX.Y.Z` triggers `cargo publish` to crates.io — irreversible. Releases finalize `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] - <date>`) in a small "Release vX.Y.Z" PR; `Cargo.toml`/`Cargo.lock` are bumped in the feature PR.
 
 ## Architecture
 
-Single-crate library split across `src/*.rs` modules and re-exported from
-`src/lib.rs`. Unit tests are in `src/tests.rs`; integration tests in `tests/`
-include examples via `include!(concat!(env!("CARGO_MANIFEST_DIR"), "/examples/..."))`.
+One library crate, split across `src/*.rs` and re-exported from `src/lib.rs`. Unit tests are in `src/tests.rs`; integration tests in `tests/` — and the examples are `include!`d into those tests, so a broken example breaks the test build.
 
-Core abstraction is `Policy<D: PolicyDomain>` (async `evaluate()` →
-`PolicyEvalResult`). `PolicyDomain` names `Subject`, `Action`, `Resource`, and
-`Context`. `PermissionChecker` is bound per request with
-`checker.bind(&session, &subject, &action, &context)`, producing a
-`BoundEvaluator` for `check`, `evaluate`, `evaluate_by`, `filter`, `filter_by`,
-and `lookup_page`.
+`Policy<D: PolicyDomain>` is the core trait: async `evaluate` → `PolicyEvalResult`, plus `evaluate_batch` (must return one result per input, in order). `PolicyDomain` names `Subject`/`Action`/`Resource`/`Context` once. `PermissionChecker<D>` is bound per request — `checker.bind(&session, &subject, &action, &context)` yields a `BoundEvaluator` with `check` / `evaluate` / `evaluate_by` / `filter` / `filter_by` / `lookup_page`.
 
-Built-in policies: `RbacPolicy`, `RebacPolicy`, `DelegatingPolicy`. Use
-`PolicyBuilder::when` for ABAC-style predicates. Combinators: `AndPolicy`,
-`OrPolicy`, `NotPolicy`, plus fluent `PolicyExt`.
+Built-ins: `RbacPolicy`, `RebacPolicy`, `DelegatingPolicy`; `PolicyBuilder::when` for ABAC-style predicates; combinators `AndPolicy` / `OrPolicy` / `NotPolicy` plus fluent `PolicyExt`. Closures are `Send + Sync + 'static`. Decisions are never `Result`: `PolicyEvalResult::{Granted, NotApplicable, Forbidden, Combined}` at the policy level, `AccessEvaluation::{Granted, Denied}` at the top. Public enums are `#[non_exhaustive]`. Telemetry is `tracing` (OpenTelemetry semantic conventions); reason strings and `FactProvenance.detail` reach subscribers — treat them as audit surface, no secrets.
 
-All policy closures require `Send + Sync + 'static`. No `Result` error types
-for decisions: policy outcomes are `PolicyEvalResult` variants (`Granted`,
-`NotApplicable`, `Forbidden`, `Combined`), and final checker outcomes are
-`AccessEvaluation::{Granted, Denied}`. Telemetry uses `tracing` with
-OpenTelemetry semantic conventions.
+## Load-bearing invariants (read before editing `checker.rs` / `combinators.rs`)
+
+- **Deny-overrides via veto-prefix ordering.** Veto-capable policies (`effect().can_forbid()`) are scheduled ahead of allow-only ones, and a grant is never returned until *every* veto-capable policy has been evaluated — so a `Forbidden` is always observed before a grant can short-circuit. `evaluate_one` (single) and `evaluate_batch_by` (batch) implement this independently and **must agree per item**; differential proptests against a deny-overrides oracle in `tests/checker_contract.rs` enforce it.
+- **Forbid detection is whole-tree.** `is_forbidden()` is `forbidden_leaf().is_some()`, which recurses through `Combined` children unconditionally; `is_granted()` on a `Combined` reads only `outcome`. Soundness rests on one invariant: **no combinator returns `outcome: true` while keeping a `Forbidden` leaf in its children.** Preserve it when adding or altering a combinator.
+- **`effect()` is a security contract.** A policy that can return `Forbidden` must declare `Effect::Forbid` or `Effect::AllowOrForbid`, or its veto can be short-circuited by an earlier grant. The checker emits a `WARN` when an `Effect::Allow` policy returns `Forbidden` (it honors the veto where observed, but cannot reorder it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ cargo run --example actix_web   # HTTP server on :8080
 git diff origin/main...HEAD -- src/checker.rs src/combinators.rs > mutants.diff
 cargo mutants --in-place --in-diff=mutants.diff \
   --file src/checker.rs --file src/combinators.rs \
-  --baseline=skip --timeout=60 --build-timeout=300 --all-features
+  --baseline=skip --timeout=60 --build-timeout=300 --all-features \
+  -- --test checker_contract --test tracing_contract
 ```
 
 ## CI gates that bite

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migrating from 0.4 to the next major release
+# Migrating from 0.4 to 0.5
 
-The next major Gatehouse release intentionally breaks the public API to make the authorization surface smaller and harder to misuse. The main changes are:
+Gatehouse 0.5 intentionally breaks the public API to make the authorization surface smaller and harder to misuse. The main changes are:
 
 - policies are parameterized by one `PolicyDomain` instead of four repeated generics;
 - every checker call goes through a session-bound evaluator;

--- a/benches/README.md
+++ b/benches/README.md
@@ -49,9 +49,9 @@ Current (`cargo bench --bench permission_checker -- policy_builder_subject_only_
 
 | N | `builder_overridden` | `manual_dynamic_serial_default` | `manual_static_serial_default` |
 |---|---:|---:|---:|
-| 1   | ~486 ns   | ~558 ns   | ~483 ns  |
-| 10  | ~1.65 µs  | ~2.01 µs  | ~1.33 µs |
-| 25  | ~3.49 µs  | ~3.70 µs  | ~2.64 µs |
-| 100 | ~11.30 µs | ~16.55 µs | ~9.69 µs |
+| 1   | ~484 ns   | ~476 ns   | ~406 ns  |
+| 10  | ~1.46 µs  | ~1.65 µs  | ~1.18 µs |
+| 25  | ~2.85 µs  | ~3.45 µs  | ~2.35 µs |
+| 100 | ~10.31 µs | ~13.07 µs | ~8.30 µs |
 
-The optimization wins 13–32% over the same shape through the serial default, growing with batch size. Static-name hand-written policies remain fastest; adopters who can use a `'static` name table should.
+At batch size 1 the shortcut and the serial default are a wash — there is nothing to amortize across a single item. From N=10 the shortcut pulls ahead, winning ~11–21% over the same shape through the serial default and growing with batch size. Static-name hand-written policies remain fastest; adopters who can use a `'static` name table should.


### PR DESCRIPTION
Follow-up cleanup after the 0.5.0 release. Docs-only — no library changes.

- **MIGRATION.md** — drop the pre-release "next major release" framing (title + intro now refer to 0.5 concretely). Content was already accurate against the released API; verified the symbols it references (`shared_empty`, `assert_denied*`, `FactRegistry::{builder,session,with,with_arc}`, `FactLoadError`, the `#[non_exhaustive]` enums) all exist as named.
- **AGENTS.md** — trim the obvious Rust tooling and keep only what's specific/non-obvious: the diff-scoped `cargo-mutants` gate (aligned to what CI actually runs) and other CI gates, plus the load-bearing veto/forbid invariants in `checker.rs`/`combinators.rs`.
- **benches/README.md** — refresh the `policy_builder_subject_only_batch` numbers on current hardware (`--quick`, matching the footnote). The shortcut wins ~11–21% for N≥10 (was stated 13–32%); at N=1 it's a wash — nothing to amortize across one item, and the old N=1 "win" was noise.