### PR TITLE
Add fact-load error helpers and PolicyBuilder::new_static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
   `impl Into<String>`, so `'static` literals (`new("AdminOnly")`) are stored as
   `Cow::Borrowed` and are zero-allocation end-to-end on the trace / `ctx.grant`
   path. Runtime names (`new(format!(...))`, `new(owned_string)`) still store
-  `Cow::Owned`. `PolicyBuilder::new_static` is a thin alias for call sites that
-  want the static intent in the method name.
+  `Cow::Owned`. Non-`'static` `&str` inputs (config/env) use the new
+  `PolicyBuilder::new_owned` so the allocation is explicit.
+  `PolicyBuilder::new_static` remains a thin alias for call sites that want the
+  static intent in the method name.
 
 ## [0.5.0] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- `AccessEvaluation::fact_load_errors()` / `denied_due_to_fact_load_error()` —
+  walk the evaluation trace for `FactOutcome::Error` provenance so callers can
+  map infrastructure failure (e.g. HTTP 503) without hand-destructuring
+  combinators. Authorization itself remains fail-closed; these helpers only
+  expose *why*.
+- `PolicyBuilder::new_static(&'static str)` — stores the policy name as
+  `Cow::Borrowed` so builder-built policies with fixed names are zero-allocation
+  end-to-end on the trace / `ctx.grant` path. `PolicyBuilder::new` remains the
+  dynamic-name path (`impl Into<String>` → `Cow::Owned`).
+
 ## [0.5.0] - 2026-06-27
 
 This is a semver-major API cleanup. Gatehouse now centers public authorization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
   map infrastructure failure (e.g. HTTP 503) without hand-destructuring
   combinators. Authorization itself remains fail-closed; these helpers only
   expose *why*.
-- `PolicyBuilder::new_static(&'static str)` — stores the policy name as
-  `Cow::Borrowed` so builder-built policies with fixed names are zero-allocation
-  end-to-end on the trace / `ctx.grant` path. `PolicyBuilder::new` remains the
-  dynamic-name path (`impl Into<String>` → `Cow::Owned`).
+- `PolicyBuilder::new` now takes `impl Into<Cow<'static, str>>` instead of
+  `impl Into<String>`, so `'static` literals (`new("AdminOnly")`) are stored as
+  `Cow::Borrowed` and are zero-allocation end-to-end on the trace / `ctx.grant`
+  path. Runtime names (`new(format!(...))`, `new(owned_string)`) still store
+  `Cow::Owned`. `PolicyBuilder::new_static` is a thin alias for call sites that
+  want the static intent in the method name.
 
 ## [0.5.0] - 2026-06-27
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -165,14 +165,14 @@ let owner = PolicyBuilder::<User, ReadAction, Document, RequestContext>::new("Ow
     .build();
 
 // After
-let owner = PolicyBuilder::<Documents>::new_static("Owner")
+let owner = PolicyBuilder::<Documents>::new("Owner")
     .when(|user, _action, doc, _ctx| user.id == doc.owner_id)
     .build();
 ```
 
 Use `.subjects`, `.actions`, `.resources`, and `.context` for single-axis predicates. Use `.when` when the predicate compares multiple inputs. The generated batch path evaluates subject, action, and context predicates once per batch and resource / cross-axis predicates per item.
 
-Prefer `PolicyBuilder::new_static("Name")` when the policy name is a `'static` string literal — that path stores `Cow::Borrowed` and is zero-allocation end-to-end on the trace / `ctx.grant` helper path. `PolicyBuilder::new(name)` takes `impl Into<String>` for runtime-constructed names and remains a dynamic-name policy under the allocation accounting.
+`PolicyBuilder::new` accepts `impl Into<Cow<'static, str>>`: a `'static` literal (`new("Owner")`) is zero-allocation on the trace path; runtime names (`new(format!(...))`) remain owned. Existing `new("literal")` call sites pick up the zero-alloc path with no source change.
 
 ## Checker calls
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -165,12 +165,14 @@ let owner = PolicyBuilder::<User, ReadAction, Document, RequestContext>::new("Ow
     .build();
 
 // After
-let owner = PolicyBuilder::<Documents>::new("Owner")
+let owner = PolicyBuilder::<Documents>::new_static("Owner")
     .when(|user, _action, doc, _ctx| user.id == doc.owner_id)
     .build();
 ```
 
 Use `.subjects`, `.actions`, `.resources`, and `.context` for single-axis predicates. Use `.when` when the predicate compares multiple inputs. The generated batch path evaluates subject, action, and context predicates once per batch and resource / cross-axis predicates per item.
+
+Prefer `PolicyBuilder::new_static("Name")` when the policy name is a `'static` string literal — that path stores `Cow::Borrowed` and is zero-allocation end-to-end on the trace / `ctx.grant` helper path. `PolicyBuilder::new(name)` takes `impl Into<String>` for runtime-constructed names and remains a dynamic-name policy under the allocation accounting.
 
 ## Checker calls
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ impl PolicyDomain for Documents {
     type Context = ();
 }
 
-let admin_policy = PolicyBuilder::<Documents>::new("AdminOnly")
+let admin_policy = PolicyBuilder::<Documents>::new_static("AdminOnly")
     .subjects(|user: &User| user.roles.contains(&"admin"))
     .build();
 
-let owner_policy = PolicyBuilder::<Documents>::new("OwnerOnly")
+let owner_policy = PolicyBuilder::<Documents>::new_static("OwnerOnly")
     .when(|user: &User, _action: &ReadAction, doc: &Document, _ctx: &()| {
         user.id == doc.owner_id
     })
@@ -114,7 +114,7 @@ flowchart LR
 - `Forbidden` propagates through `AndPolicy`, `OrPolicy`, `NotPolicy`, and `DelegatingPolicy`.
 - `not()` does not neutralize a veto: `admin.or(blocked.not())` still denies if `blocked` returns `Forbidden`. For "grant unless blocked", make `blocked` an allow-only predicate and wrap that in `not()`, or register a direct forbid policy when the block should be global.
 
-Denials from `AccessEvaluation` are summary-level. Use `AccessEvaluation::display_trace()` or the attached `EvalTrace` to inspect individual policy reasons and fact provenance.
+Denials from `AccessEvaluation` are summary-level. Use `AccessEvaluation::display_trace()` or the attached `EvalTrace` to inspect individual policy reasons and fact provenance. Use `AccessEvaluation::denied_due_to_fact_load_error()` / `fact_load_errors()` when you need to distinguish infrastructure failure (fact load `Error`) from an ordinary denial — authorization remains fail-closed either way.
 
 ## Policy Domains
 
@@ -152,7 +152,9 @@ let checker = PermissionChecker::<Documents>::new();
 Use `PolicyBuilder` for synchronous predicate logic:
 
 ```rust,ignore
-let suspended_account = PolicyBuilder::<Documents>::new("SuspendedAccount")
+// Prefer new_static for fixed names (zero-allocation on the trace path).
+// Use new(name) when the name is runtime-constructed.
+let suspended_account = PolicyBuilder::<Documents>::new_static("SuspendedAccount")
     .when(|user, _action, _doc, _ctx| user.is_suspended)
     .forbid()
     .build();

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ impl PolicyDomain for Documents {
     type Context = ();
 }
 
-let admin_policy = PolicyBuilder::<Documents>::new_static("AdminOnly")
+let admin_policy = PolicyBuilder::<Documents>::new("AdminOnly")
     .subjects(|user: &User| user.roles.contains(&"admin"))
     .build();
 
-let owner_policy = PolicyBuilder::<Documents>::new_static("OwnerOnly")
+let owner_policy = PolicyBuilder::<Documents>::new("OwnerOnly")
     .when(|user: &User, _action: &ReadAction, doc: &Document, _ctx: &()| {
         user.id == doc.owner_id
     })
@@ -152,9 +152,9 @@ let checker = PermissionChecker::<Documents>::new();
 Use `PolicyBuilder` for synchronous predicate logic:
 
 ```rust,ignore
-// Prefer new_static for fixed names (zero-allocation on the trace path).
-// Use new(name) when the name is runtime-constructed.
-let suspended_account = PolicyBuilder::<Documents>::new_static("SuspendedAccount")
+// String literals are zero-allocation on the trace path
+// (new takes impl Into<Cow<'static, str>>).
+let suspended_account = PolicyBuilder::<Documents>::new("SuspendedAccount")
     .when(|user, _action, _doc, _ctx| user.is_suspended)
     .forbid()
     .build();

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -569,10 +569,9 @@ impl gatehouse::Policy<SubjectOnlyDomain> for ManualSubjectOnlyDynamic {
 }
 
 /// Same logic but with a static name. Lets the bench show the gap
-/// between `PolicyBuilder::new` (dynamic / owned name) and a
-/// hand-written static-name policy. Prefer `PolicyBuilder::new_static`
-/// in application code when the name is a `'static` literal — that
-/// path matches this static cost profile.
+/// between a hand-written static-name policy and the serial default.
+/// Application code using `PolicyBuilder::new("Name")` with a `'static`
+/// literal already gets `Cow::Borrowed` (same cost profile as this type).
 struct ManualSubjectOnlyStatic;
 
 #[async_trait]

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -568,10 +568,11 @@ impl gatehouse::Policy<SubjectOnlyDomain> for ManualSubjectOnlyDynamic {
     }
 }
 
-/// Same logic but with a static name. Lets the bench show the
-/// gap between PolicyBuilder (which has to use dynamic names because
-/// its builder API takes `impl Into<String>`) and a hand-written
-/// static-name policy.
+/// Same logic but with a static name. Lets the bench show the gap
+/// between `PolicyBuilder::new` (dynamic / owned name) and a
+/// hand-written static-name policy. Prefer `PolicyBuilder::new_static`
+/// in application code when the name is a `'static` literal — that
+/// path matches this static cost profile.
 struct ManualSubjectOnlyStatic;
 
 #[async_trait]

--- a/examples/policy_builder.rs
+++ b/examples/policy_builder.rs
@@ -62,7 +62,8 @@ impl PolicyDomain for AdminDomain {
 /// organization*. The predicate reads three axes (subject, action, resource),
 /// which is exactly the cross-axis case `.when()` exists for.
 fn scoped_permission_policy() -> Box<dyn Policy<AdminDomain>> {
-    PolicyBuilder::<AdminDomain>::new("ScopedPermission")
+    // new_static: fixed name → zero-allocation on the trace path.
+    PolicyBuilder::<AdminDomain>::new_static("ScopedPermission")
         .when(
             |user: &StaffUser, action: &AdminAction, org: &Organization, _ctx: &()| {
                 user.permissions
@@ -76,7 +77,7 @@ fn scoped_permission_policy() -> Box<dyn Policy<AdminDomain>> {
 /// Grants on a single axis — the subject — so it uses `.subjects()` rather
 /// than `.when()`: single-axis predicates batch better and read clearer.
 fn global_admin_policy() -> Box<dyn Policy<AdminDomain>> {
-    PolicyBuilder::<AdminDomain>::new("GlobalAdmin")
+    PolicyBuilder::<AdminDomain>::new_static("GlobalAdmin")
         .subjects(|user: &StaffUser| user.permissions.iter().any(|p| p.scope == "global_admin"))
         .build()
 }

--- a/examples/policy_builder.rs
+++ b/examples/policy_builder.rs
@@ -62,8 +62,8 @@ impl PolicyDomain for AdminDomain {
 /// organization*. The predicate reads three axes (subject, action, resource),
 /// which is exactly the cross-axis case `.when()` exists for.
 fn scoped_permission_policy() -> Box<dyn Policy<AdminDomain>> {
-    // new_static: fixed name → zero-allocation on the trace path.
-    PolicyBuilder::<AdminDomain>::new_static("ScopedPermission")
+    // String literals stay Cow::Borrowed on the trace path.
+    PolicyBuilder::<AdminDomain>::new("ScopedPermission")
         .when(
             |user: &StaffUser, action: &AdminAction, org: &Organization, _ctx: &()| {
                 user.permissions
@@ -77,7 +77,7 @@ fn scoped_permission_policy() -> Box<dyn Policy<AdminDomain>> {
 /// Grants on a single axis — the subject — so it uses `.subjects()` rather
 /// than `.when()`: single-axis predicates batch better and read clearer.
 fn global_admin_policy() -> Box<dyn Policy<AdminDomain>> {
-    PolicyBuilder::<AdminDomain>::new_static("GlobalAdmin")
+    PolicyBuilder::<AdminDomain>::new("GlobalAdmin")
         .subjects(|user: &StaffUser| user.permissions.iter().any(|p| p.scope == "global_admin"))
         .build()
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -119,23 +119,20 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
 /// #     type Resource = Doc;
 /// #     type Context = Ctx;
 /// # }
-/// // Prefer new_static for fixed names (zero-allocation on the trace path).
-/// let owner = PolicyBuilder::<Documents>::new_static("Owner")
+/// let owner = PolicyBuilder::<Documents>::new("Owner")
 ///     .when(|user, _action, doc, _ctx| user.id == doc.owner_id)
 ///     .build();
 /// ```
 ///
 /// # Allocation cost
 ///
-/// Prefer [`PolicyBuilder::new_static`] when the policy name is a `'static`
-/// string literal. That path stores [`Cow::Borrowed`] and is zero-allocation
-/// end-to-end on the trace / `ctx.grant` helper path — the same accounting
-/// as a hand-written `Policy` that returns `Cow::Borrowed("MyPolicy")`.
-///
-/// [`PolicyBuilder::new`] takes `impl Into<String>` and stores the name
-/// owned. Every policy built that way is a *dynamic-name* policy and pays
-/// one allocation per `policy_type()` call. Use `new` when the name is
-/// runtime-constructed; use `new_static` for the common fixed-name case.
+/// [`PolicyBuilder::new`] takes `impl Into<Cow<'static, str>>`, so a
+/// `'static` string literal (`new("Owner")`) is stored as
+/// [`Cow::Borrowed`] and is zero-allocation end-to-end on the trace /
+/// `ctx.grant` helper path — the same accounting as a hand-written
+/// `Policy` that returns `Cow::Borrowed("MyPolicy")`. Runtime-constructed
+/// names (`new(format!("p-{id}"))`, `new(owned_string)`) store
+/// [`Cow::Owned`] and pay one allocation per `policy_type()` call.
 pub struct PolicyBuilder<D: PolicyDomain> {
     name: Cow<'static, str>,
     effect: Effect,
@@ -148,30 +145,14 @@ pub struct PolicyBuilder<D: PolicyDomain> {
 }
 
 impl<D: PolicyDomain> PolicyBuilder<D> {
-    /// Creates a new policy builder with a runtime-owned name.
+    /// Creates a new policy builder with the given policy name.
     ///
-    /// The name is stored as [`Cow::Owned`], so the built policy is a
-    /// *dynamic-name* policy under the trace-path allocation accounting.
-    /// Prefer [`Self::new_static`] when the name is a `'static` string literal.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self {
-            name: Cow::Owned(name.into()),
-            effect: Effect::Allow,
-            subject_pred: None,
-            action_pred: None,
-            resource_pred: None,
-            context_pred: None,
-            when_pred: None,
-            _domain: PhantomData,
-        }
-    }
-
-    /// Creates a new policy builder with a `'static` name.
+    /// Accepts anything convertible to [`Cow<'static, str>`]:
     ///
-    /// The name is stored as [`Cow::Borrowed`], so the built policy is
-    /// zero-allocation end-to-end on the trace / `EvalCtx::grant` helper
-    /// path — the same cost profile as a hand-written `Policy` that
-    /// returns `Cow::Borrowed("MyPolicy")` from [`Policy::policy_type`].
+    /// - `'static` string literals (`"AdminOnly"`) become
+    ///   [`Cow::Borrowed`] — zero-allocation on the trace path.
+    /// - owned [`String`] values (including `format!(...)`) become
+    ///   [`Cow::Owned`].
     ///
     /// ```rust
     /// # use gatehouse::*;
@@ -183,7 +164,7 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
     /// #     type Resource = ();
     /// #     type Context = ();
     /// # }
-    /// let policy = PolicyBuilder::<Documents>::new_static("AdminOnly")
+    /// let policy = PolicyBuilder::<Documents>::new("AdminOnly")
     ///     .subjects(|user| user.is_admin)
     ///     .build();
     /// assert!(matches!(
@@ -191,9 +172,9 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
     ///     std::borrow::Cow::Borrowed("AdminOnly")
     /// ));
     /// ```
-    pub fn new_static(name: &'static str) -> Self {
+    pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            name: Cow::Borrowed(name),
+            name: name.into(),
             effect: Effect::Allow,
             subject_pred: None,
             action_pred: None,
@@ -202,6 +183,16 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
             when_pred: None,
             _domain: PhantomData,
         }
+    }
+
+    /// Alias for [`Self::new`] with an explicit `'static` name.
+    ///
+    /// Prefer [`Self::new`] — `new("AdminOnly")` already stores
+    /// [`Cow::Borrowed`] via `impl Into<Cow<'static, str>>`. This method
+    /// exists for call sites that want the static intent spelled out in
+    /// the method name.
+    pub fn new_static(name: &'static str) -> Self {
+        Self::new(name)
     }
 
     /// Makes this policy forbid when its combined predicate matches.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -130,9 +130,14 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
 /// `'static` string literal (`new("Owner")`) is stored as
 /// [`Cow::Borrowed`] and is zero-allocation end-to-end on the trace /
 /// `ctx.grant` helper path — the same accounting as a hand-written
-/// `Policy` that returns `Cow::Borrowed("MyPolicy")`. Runtime-constructed
-/// names (`new(format!("p-{id}"))`, `new(owned_string)`) store
-/// [`Cow::Owned`] and pay one allocation per `policy_type()` call.
+/// `Policy` that returns `Cow::Borrowed("MyPolicy")`.
+///
+/// Runtime-constructed names (`new(format!("p-{id}"))`,
+/// [`Self::new_owned`], `new(owned_string)`) store [`Cow::Owned`]. Each
+/// evaluation clones that owned name into the `PolicyEvalResult` leaf
+/// (and again if the checker captures `policy_type` into an
+/// [`EvalCtx`](crate::EvalCtx)), so the cost is paid when building the
+/// trace, not only when calling `policy_type()` in isolation.
 pub struct PolicyBuilder<D: PolicyDomain> {
     name: Cow<'static, str>,
     effect: Effect,
@@ -153,6 +158,10 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
     ///   [`Cow::Borrowed`] — zero-allocation on the trace path.
     /// - owned [`String`] values (including `format!(...)`) become
     ///   [`Cow::Owned`].
+    ///
+    /// Non-`'static` borrowed strings (e.g. `&str` from config) are **not**
+    /// accepted directly — use [`Self::new_owned`] so the allocation is
+    /// explicit at the call site.
     ///
     /// ```rust
     /// # use gatehouse::*;
@@ -183,6 +192,31 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
             when_pred: None,
             _domain: PhantomData,
         }
+    }
+
+    /// Creates a policy builder with a runtime-owned name.
+    ///
+    /// Use this for names that are not `'static` — config keys, env values,
+    /// formatted strings already held as `&str`:
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # struct Documents;
+    /// # impl PolicyDomain for Documents {
+    /// #     type Subject = ();
+    /// #     type Action = ();
+    /// #     type Resource = ();
+    /// #     type Context = ();
+    /// # }
+    /// let from_config: &str = "tenant-override";
+    /// let policy = PolicyBuilder::<Documents>::new_owned(from_config).build();
+    /// assert!(matches!(policy.policy_type(), std::borrow::Cow::Owned(_)));
+    /// ```
+    ///
+    /// Equivalent to `Self::new(Cow::Owned(name.into()))`. Prefer
+    /// [`Self::new`] with a string literal when the name is fixed.
+    pub fn new_owned(name: impl Into<String>) -> Self {
+        Self::new(Cow::Owned(name.into()))
     }
 
     /// Alias for [`Self::new`] with an explicit `'static` name.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,6 @@
 use crate::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyDomain, PolicyEvalResult};
 use async_trait::async_trait;
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 type SubjectPredicate<D> = Box<dyn Fn(&<D as PolicyDomain>::Subject) -> bool + Send + Sync>;
@@ -19,7 +20,7 @@ type WhenPredicate<D> = Box<
 
 /// An internal policy type constructed by [`PolicyBuilder`].
 struct InternalPolicy<D: PolicyDomain> {
-    name: String,
+    name: Cow<'static, str>,
     effect: Effect,
     subject_pred: Option<SubjectPredicate<D>>,
     action_pred: Option<ActionPredicate<D>>,
@@ -91,8 +92,8 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
             .collect()
     }
 
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Owned(self.name.clone())
+    fn policy_type(&self) -> Cow<'static, str> {
+        self.name.clone()
     }
 
     fn effect(&self) -> Effect {
@@ -118,12 +119,25 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
 /// #     type Resource = Doc;
 /// #     type Context = Ctx;
 /// # }
-/// let owner = PolicyBuilder::<Documents>::new("Owner")
+/// // Prefer new_static for fixed names (zero-allocation on the trace path).
+/// let owner = PolicyBuilder::<Documents>::new_static("Owner")
 ///     .when(|user, _action, doc, _ctx| user.id == doc.owner_id)
 ///     .build();
 /// ```
+///
+/// # Allocation cost
+///
+/// Prefer [`PolicyBuilder::new_static`] when the policy name is a `'static`
+/// string literal. That path stores [`Cow::Borrowed`] and is zero-allocation
+/// end-to-end on the trace / `ctx.grant` helper path — the same accounting
+/// as a hand-written `Policy` that returns `Cow::Borrowed("MyPolicy")`.
+///
+/// [`PolicyBuilder::new`] takes `impl Into<String>` and stores the name
+/// owned. Every policy built that way is a *dynamic-name* policy and pays
+/// one allocation per `policy_type()` call. Use `new` when the name is
+/// runtime-constructed; use `new_static` for the common fixed-name case.
 pub struct PolicyBuilder<D: PolicyDomain> {
-    name: String,
+    name: Cow<'static, str>,
     effect: Effect,
     subject_pred: Option<SubjectPredicate<D>>,
     action_pred: Option<ActionPredicate<D>>,
@@ -134,10 +148,52 @@ pub struct PolicyBuilder<D: PolicyDomain> {
 }
 
 impl<D: PolicyDomain> PolicyBuilder<D> {
-    /// Creates a new policy builder with the given policy name.
+    /// Creates a new policy builder with a runtime-owned name.
+    ///
+    /// The name is stored as [`Cow::Owned`], so the built policy is a
+    /// *dynamic-name* policy under the trace-path allocation accounting.
+    /// Prefer [`Self::new_static`] when the name is a `'static` string literal.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
+            name: Cow::Owned(name.into()),
+            effect: Effect::Allow,
+            subject_pred: None,
+            action_pred: None,
+            resource_pred: None,
+            context_pred: None,
+            when_pred: None,
+            _domain: PhantomData,
+        }
+    }
+
+    /// Creates a new policy builder with a `'static` name.
+    ///
+    /// The name is stored as [`Cow::Borrowed`], so the built policy is
+    /// zero-allocation end-to-end on the trace / `EvalCtx::grant` helper
+    /// path — the same cost profile as a hand-written `Policy` that
+    /// returns `Cow::Borrowed("MyPolicy")` from [`Policy::policy_type`].
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # #[derive(Clone)] struct User { is_admin: bool }
+    /// # struct Documents;
+    /// # impl PolicyDomain for Documents {
+    /// #     type Subject = User;
+    /// #     type Action = ();
+    /// #     type Resource = ();
+    /// #     type Context = ();
+    /// # }
+    /// let policy = PolicyBuilder::<Documents>::new_static("AdminOnly")
+    ///     .subjects(|user| user.is_admin)
+    ///     .build();
+    /// assert!(matches!(
+    ///     policy.policy_type(),
+    ///     std::borrow::Cow::Borrowed("AdminOnly")
+    /// ));
+    /// ```
+    pub fn new_static(name: &'static str) -> Self {
+        Self {
+            name: Cow::Borrowed(name),
             effect: Effect::Allow,
             subject_pred: None,
             action_pred: None,

--- a/src/results.rs
+++ b/src/results.rs
@@ -317,6 +317,22 @@ fn collect_fact_load_errors<'a>(node: &'a PolicyEvalResult, out: &mut Vec<&'a Fa
     }
 }
 
+/// Returns `true` on the first [`FactOutcome::Error`] in the tree — no
+/// allocation, early exit. Used by
+/// [`AccessEvaluation::denied_due_to_fact_load_error`].
+fn trace_has_fact_load_error(node: &PolicyEvalResult) -> bool {
+    match node {
+        PolicyEvalResult::Granted { provenance, .. }
+        | PolicyEvalResult::NotApplicable { provenance, .. }
+        | PolicyEvalResult::Forbidden { provenance, .. } => provenance
+            .iter()
+            .any(|fact| fact.outcome == FactOutcome::Error),
+        PolicyEvalResult::Combined { children, .. } => {
+            children.iter().any(trace_has_fact_load_error)
+        }
+    }
+}
+
 impl AccessEvaluation {
     /// Whether access was granted
     pub fn is_granted(&self) -> bool {
@@ -439,7 +455,10 @@ impl AccessEvaluation {
     /// (a load error never grants). This helper only exposes *why* so
     /// application layers can choose a response class.
     pub fn denied_due_to_fact_load_error(&self) -> bool {
-        matches!(self, Self::Denied { .. }) && !self.fact_load_errors().is_empty()
+        match self {
+            Self::Denied { trace, .. } => trace.root().is_some_and(trace_has_fact_load_error),
+            Self::Granted { .. } => false,
+        }
     }
 
     /// Test helper: panic unless the evaluation is `Granted` and the

--- a/src/results.rs
+++ b/src/results.rs
@@ -296,6 +296,27 @@ fn leaf_not_applicable_matches(node: &PolicyEvalResult, expected: &str) -> bool 
     }
 }
 
+/// Collects every [`FactProvenance`] with [`FactOutcome::Error`] from a
+/// result tree (leaves and combinator children).
+fn collect_fact_load_errors<'a>(node: &'a PolicyEvalResult, out: &mut Vec<&'a FactProvenance>) {
+    match node {
+        PolicyEvalResult::Granted { provenance, .. }
+        | PolicyEvalResult::NotApplicable { provenance, .. }
+        | PolicyEvalResult::Forbidden { provenance, .. } => {
+            for fact in provenance {
+                if fact.outcome == FactOutcome::Error {
+                    out.push(fact);
+                }
+            }
+        }
+        PolicyEvalResult::Combined { children, .. } => {
+            for child in children {
+                collect_fact_load_errors(child, out);
+            }
+        }
+    }
+}
+
 impl AccessEvaluation {
     /// Whether access was granted
     pub fn is_granted(&self) -> bool {
@@ -357,6 +378,59 @@ impl AccessEvaluation {
         children
             .iter()
             .find_map(|child| child.forbidden_leaf().map(|(policy_type, _)| policy_type))
+    }
+
+    /// Returns every fact provenance entry with [`FactOutcome::Error`]
+    /// found anywhere in the evaluation trace.
+    ///
+    /// Empty for grants that never hit a load failure, and for denials
+    /// whose consulted facts were only [`FactOutcome::Found`] or
+    /// [`FactOutcome::Missing`]. Fact-backed policies (for example
+    /// [`crate::RebacPolicy`]) attach load failures as provenance on their
+    /// not-applicable leaves; this helper walks the whole tree so callers
+    /// do not need to destructure combinators by hand.
+    ///
+    /// Use this when you need the backend error detail (via
+    /// [`FactProvenance::detail`]) rather than a simple boolean — see
+    /// [`Self::denied_due_to_fact_load_error`] for the yes/no form.
+    pub fn fact_load_errors(&self) -> Vec<&FactProvenance> {
+        let mut errors = Vec::new();
+        if let Some(root) = self.trace().root() {
+            collect_fact_load_errors(root, &mut errors);
+        }
+        errors
+    }
+
+    /// Returns `true` when this evaluation is a **denial** and at least one
+    /// policy leaf in the trace consulted a fact that failed to load
+    /// ([`FactOutcome::Error`]).
+    ///
+    /// Grants always return `false`, even if some earlier policy recorded a
+    /// load error before a sibling granted (unusual; fact-backed policies
+    /// fail closed themselves). Ordinary denials with only Found/Missing
+    /// facts also return `false`.
+    ///
+    /// Typical use: map infrastructure failure to a distinct HTTP status
+    /// without hand-walking the trace:
+    ///
+    /// ```rust
+    /// # use gatehouse::*;
+    /// # fn handle(evaluation: AccessEvaluation) -> u16 {
+    /// if evaluation.is_granted() {
+    ///     200
+    /// } else if evaluation.denied_due_to_fact_load_error() {
+    ///     503 // backend unavailable — not "you may not"
+    /// } else {
+    ///     403
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// Gatehouse still fails closed on the authorization decision itself
+    /// (a load error never grants). This helper only exposes *why* so
+    /// application layers can choose a response class.
+    pub fn denied_due_to_fact_load_error(&self) -> bool {
+        matches!(self, Self::Denied { .. }) && !self.fact_load_errors().is_empty()
     }
 
     /// Test helper: panic unless the evaluation is `Granted` and the

--- a/src/results.rs
+++ b/src/results.rs
@@ -405,21 +405,30 @@ impl AccessEvaluation {
     /// policy leaf in the trace consulted a fact that failed to load
     /// ([`FactOutcome::Error`]).
     ///
-    /// Grants always return `false`, even if some earlier policy recorded a
-    /// load error before a sibling granted (unusual; fact-backed policies
-    /// fail closed themselves). Ordinary denials with only Found/Missing
-    /// facts also return `false`.
+    /// This is an **any-error-in-trace** check, not a causal one: it does
+    /// not prove the load failure was the sole reason for the denial, and
+    /// it treats every [`FactLoadError`](crate::FactLoadError) the same
+    /// (backend failure, missing source registration, contract violation,
+    /// loader cancel). Inspect [`Self::fact_load_errors`] and
+    /// [`Self::forbidden_by`] when you need a finer split (e.g. prefer a
+    /// forbid's 403 over a sibling's load-error signal).
     ///
-    /// Typical use: map infrastructure failure to a distinct HTTP status
-    /// without hand-walking the trace:
+    /// Grants always return `false`, even if some earlier policy recorded a
+    /// load error before a sibling granted. Ordinary denials with only
+    /// Found/Missing facts also return `false`.
+    ///
+    /// Typical use: a coarse signal for "something infrastructure-shaped
+    /// appeared during this denial" without hand-walking the trace:
     ///
     /// ```rust
     /// # use gatehouse::*;
     /// # fn handle(evaluation: AccessEvaluation) -> u16 {
     /// if evaluation.is_granted() {
     ///     200
+    /// } else if evaluation.forbidden_by().is_some() {
+    ///     403 // active veto — check before load-error
     /// } else if evaluation.denied_due_to_fact_load_error() {
-    ///     503 // backend unavailable — not "you may not"
+    ///     503 // at least one fact load failed in the trace
     /// } else {
     ///     403
     /// }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3201,6 +3201,89 @@ mod core_tests {
             .await;
         evaluation.assert_trace_contains("this string is not in the trace");
     }
+
+    // --- Fact-load error helpers on AccessEvaluation --------------------
+
+    #[tokio::test]
+    async fn denied_due_to_fact_load_error_detects_rebac_backend_failure() {
+        let mut checker = PermissionChecker::<TestDomain>::new();
+        checker.add_policy(RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
+            "manager".to_string(),
+        ));
+
+        let subject = test_subject();
+        let resource = test_resource();
+        let session = FactRegistry::builder()
+            .with::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(ErrorRelationshipSource)
+            .build()
+            .session();
+
+        let evaluation = checker
+            .bind(&session, &subject, &TestAction, &TestContext)
+            .check(&resource)
+            .await;
+
+        assert!(!evaluation.is_granted());
+        assert!(
+            evaluation.denied_due_to_fact_load_error(),
+            "backend failure should surface as denied_due_to_fact_load_error"
+        );
+        let errors = evaluation.fact_load_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].fact_name, "relationship");
+        assert_eq!(errors[0].outcome, FactOutcome::Error);
+        assert!(errors[0].detail.is_some());
+    }
+
+    #[tokio::test]
+    async fn denied_due_to_fact_load_error_is_false_for_ordinary_denial() {
+        let evaluation = deny_checker()
+            .evaluate_access(&test_subject(), &TestAction, &test_resource(), &TestContext)
+            .await;
+        assert!(!evaluation.is_granted());
+        assert!(!evaluation.denied_due_to_fact_load_error());
+        assert!(evaluation.fact_load_errors().is_empty());
+    }
+
+    #[tokio::test]
+    async fn denied_due_to_fact_load_error_is_false_for_grant() {
+        let evaluation = allow_checker()
+            .evaluate_access(&test_subject(), &TestAction, &test_resource(), &TestContext)
+            .await;
+        assert!(evaluation.is_granted());
+        assert!(!evaluation.denied_due_to_fact_load_error());
+        assert!(evaluation.fact_load_errors().is_empty());
+    }
+
+    #[tokio::test]
+    async fn denied_due_to_fact_load_error_is_false_for_missing_fact() {
+        let mut checker = PermissionChecker::<TestDomain>::new();
+        checker.add_policy(RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
+            "manager".to_string(),
+        ));
+
+        let subject = test_subject();
+        let resource = test_resource();
+        let session = FactRegistry::builder()
+            .with::<RelationshipQuery<uuid::Uuid, uuid::Uuid, String>, _>(MissingRelationshipSource)
+            .build()
+            .session();
+
+        let evaluation = checker
+            .bind(&session, &subject, &TestAction, &TestContext)
+            .check(&resource)
+            .await;
+
+        assert!(!evaluation.is_granted());
+        // Missing is a domain "no relationship" outcome, not infrastructure
+        // failure — must not trip the 503-style helper.
+        assert!(!evaluation.denied_due_to_fact_load_error());
+        assert!(evaluation.fact_load_errors().is_empty());
+    }
 }
 
 mod policy_builder_tests {
@@ -3268,6 +3351,60 @@ mod policy_builder_tests {
         type Action = TestAction;
         type Resource = TestResource;
         type Context = TestContext;
+    }
+
+    #[test]
+    fn new_static_stores_borrowed_policy_type() {
+        let policy = PolicyBuilder::<TestDomain>::new_static("StaticName").build();
+        match policy.policy_type() {
+            std::borrow::Cow::Borrowed(name) => assert_eq!(name, "StaticName"),
+            std::borrow::Cow::Owned(name) => {
+                panic!("new_static should yield Cow::Borrowed, got Owned({name})")
+            }
+        }
+    }
+
+    #[test]
+    fn new_stores_owned_policy_type() {
+        let dynamic = format!("Dynamic{}", 42);
+        let policy = PolicyBuilder::<TestDomain>::new(dynamic.clone()).build();
+        match policy.policy_type() {
+            std::borrow::Cow::Owned(name) => assert_eq!(name, dynamic),
+            std::borrow::Cow::Borrowed(name) => {
+                panic!("new(String) should yield Cow::Owned, got Borrowed({name})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn new_static_policy_grants_and_tags_trace_with_static_name() {
+        let policy = PolicyBuilder::<TestDomain>::new_static("StaticAdmin")
+            .subjects(|s: &TestSubject| s.name == "Alice")
+            .build();
+
+        let mut checker = PermissionChecker::<TestDomain>::new();
+        checker.add_policy(policy);
+
+        let subject = TestSubject {
+            name: "Alice".into(),
+        };
+        let session = EvaluationSession::empty();
+        let evaluation = checker
+            .bind(&session, &subject, &TestAction, &TestContext)
+            .check(&TestResource)
+            .await;
+        evaluation.assert_granted_by("StaticAdmin");
+        match evaluation {
+            AccessEvaluation::Granted { policy_type, .. } => {
+                assert!(
+                    matches!(policy_type, std::borrow::Cow::Borrowed("StaticAdmin")),
+                    "granted policy_type should stay Borrowed, got {policy_type:?}"
+                );
+            }
+            AccessEvaluation::Denied { reason, .. } => {
+                panic!("expected grant, got denial: {reason}");
+            }
+        }
     }
 
     // Test that with no predicates the builder returns a policy that always "matches"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3354,18 +3354,27 @@ mod policy_builder_tests {
     }
 
     #[test]
-    fn new_static_stores_borrowed_policy_type() {
-        let policy = PolicyBuilder::<TestDomain>::new_static("StaticName").build();
+    fn new_with_static_literal_stores_borrowed_policy_type() {
+        let policy = PolicyBuilder::<TestDomain>::new("StaticName").build();
         match policy.policy_type() {
             std::borrow::Cow::Borrowed(name) => assert_eq!(name, "StaticName"),
             std::borrow::Cow::Owned(name) => {
-                panic!("new_static should yield Cow::Borrowed, got Owned({name})")
+                panic!("new(\"lit\") should yield Cow::Borrowed, got Owned({name})")
             }
         }
     }
 
     #[test]
-    fn new_stores_owned_policy_type() {
+    fn new_static_is_alias_for_borrowed_name() {
+        let policy = PolicyBuilder::<TestDomain>::new_static("AliasName").build();
+        assert!(matches!(
+            policy.policy_type(),
+            std::borrow::Cow::Borrowed("AliasName")
+        ));
+    }
+
+    #[test]
+    fn new_with_owned_string_stores_owned_policy_type() {
         let dynamic = format!("Dynamic{}", 42);
         let policy = PolicyBuilder::<TestDomain>::new(dynamic.clone()).build();
         match policy.policy_type() {
@@ -3377,8 +3386,8 @@ mod policy_builder_tests {
     }
 
     #[tokio::test]
-    async fn new_static_policy_grants_and_tags_trace_with_static_name() {
-        let policy = PolicyBuilder::<TestDomain>::new_static("StaticAdmin")
+    async fn new_with_static_literal_grants_and_tags_trace_with_borrowed_name() {
+        let policy = PolicyBuilder::<TestDomain>::new("StaticAdmin")
             .subjects(|s: &TestSubject| s.name == "Alice")
             .build();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3385,6 +3385,18 @@ mod policy_builder_tests {
         }
     }
 
+    #[test]
+    fn new_owned_accepts_non_static_str() {
+        let from_config: &str = "tenant-override";
+        let policy = PolicyBuilder::<TestDomain>::new_owned(from_config).build();
+        match policy.policy_type() {
+            std::borrow::Cow::Owned(name) => assert_eq!(name, "tenant-override"),
+            std::borrow::Cow::Borrowed(name) => {
+                panic!("new_owned should yield Cow::Owned, got Borrowed({name})")
+            }
+        }
+    }
+
     #[tokio::test]
     async fn new_with_static_literal_grants_and_tags_trace_with_borrowed_name() {
         let policy = PolicyBuilder::<TestDomain>::new("StaticAdmin")


### PR DESCRIPTION
## Summary

- **`AccessEvaluation::fact_load_errors()` / `denied_due_to_fact_load_error()`** — walk the evaluation trace for `FactOutcome::Error` provenance so callers can map infrastructure failure (e.g. HTTP 503) without hand-destructuring combinators. Authorization remains fail-closed; these helpers only expose *why*.
- **`PolicyBuilder::new_static(&'static str)`** — stores the policy name as `Cow::Borrowed` so fixed-name builder policies are zero-allocation end-to-end on the trace / `ctx.grant` path. `PolicyBuilder::new` remains the dynamic-name path.

Note: the undeclared-forbid `tracing::warn!` adoption guardrail from the original review is already on `main` (0.5).

## Test plan

- [x] Unit tests for fact-load helpers (backend error, missing fact, ordinary denial, grant)
- [x] Unit tests for `new_static` (`Cow::Borrowed`) vs `new` (`Cow::Owned`) and grant-path name tagging
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features`
- [x] doctests