### PR TITLE
Adopt tag-driven crate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  release:
-    types: [ published ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -99,24 +97,3 @@ jobs:
         with:
           name: mutants-out
           path: mutants.out
-
-  release:
-    name: Release
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    if: github.event.release && github.event.action == 'published'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-      - name: Cache cargo & target directories
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "v2"
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --release --verbose
-      - name: Cargo Login
-        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
-      - name: Publish
-        run: cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  version-check:
+    name: Verify tag and crate version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Require tag to match Cargo.toml
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import sys
+          import tomllib
+
+          with open("Cargo.toml", "rb") as file:
+              crate_version = tomllib.load(file)["package"]["version"]
+
+          tag = os.environ["TAG"]
+          expected_tag = f"v{crate_version}"
+          if tag != expected_tag:
+              print(
+                  f"::error file=Cargo.toml::tag {tag!r} does not match "
+                  f"crate version {crate_version!r}; expected {expected_tag!r}"
+              )
+              sys.exit(1)
+
+          print(f"Verified {tag} matches gatehouse {crate_version}")
+          PY
+
+  candidate-ci:
+    name: Verify exact-candidate CI
+    needs: version-check
+    permissions:
+      actions: read
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful main CI on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          count=$(gh api -X GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f branch=main \
+            -f head_sha="${EXPECTED_SHA}" \
+            -f event=push \
+            -f status=success \
+            -f per_page=100 \
+            --jq '.total_count')
+
+          if [ "$count" -lt 1 ]; then
+            echo "::error::No successful main push CI run exists for ${EXPECTED_SHA}."
+            echo "Merge the release preparation, wait for main CI, then tag that exact commit."
+            exit 1
+          fi
+
+          echo "Found ${count} successful main CI run(s) for ${EXPECTED_SHA}."
+
+  verify-package:
+    name: Audit and verify package
+    needs: candidate-ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "release-v1"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Audit dependencies
+        run: cargo audit
+      - name: Verify publishable crate
+        run: cargo publish --dry-run --locked
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: verify-package
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Authenticate to crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish crate
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+
+  github-release:
+    name: Publish GitHub Release
+    needs: publish-crate
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create release from changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::GitHub Release ${TAG} already exists. Release by pushing the tag only."
+            exit 1
+          fi
+
+          awk -v section="## [${TAG#v}]" '
+            index($0, section) == 1 { inside = 1; next }
+            inside && /^## \[/ { exit }
+            inside { print }
+          ' CHANGELOG.md > release-notes.md
+
+          args=(--verify-tag --title "$TAG" --generate-notes)
+          if [ -s release-notes.md ]; then
+            args+=(--notes-file release-notes.md)
+          fi
+          if [[ "$TAG" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "$TAG" "${args[@]}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing Gatehouse
+
+Gatehouse releases are driven by a version tag. Do not create or publish the
+GitHub Release manually; the release workflow creates it only after crates.io
+publication succeeds.
+
+## One-time setup
+
+Configure `gatehouse` on crates.io with a GitHub Trusted Publisher using:
+
+- repository owner: `thepartly`
+- repository: `gatehouse`
+- workflow: `release.yml`
+- environment: leave blank
+
+The workflow uses GitHub OIDC to obtain a short-lived crates.io token. It does
+not use a long-lived repository secret.
+
+## Release procedure
+
+1. Prepare and merge a release PR that updates `Cargo.toml`, `Cargo.lock`, and
+   `CHANGELOG.md`.
+2. Wait for the `CI` workflow on the exact `main` merge commit to pass.
+3. Fast-forward local `main` and verify the commit and version:
+
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   git status --short --branch
+   cargo audit
+   cargo publish --dry-run --locked
+   ```
+
+4. Tag that exact commit and push the tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+The release workflow refuses to publish unless the tag matches the crate
+version and a successful `main` push CI run exists for the exact tagged commit.
+It then audits and packages the crate, publishes through crates.io Trusted
+Publishing, and creates the GitHub Release as the final step.
+
+If a release fails, inspect the workflow before retrying. Do not move or reuse a
+published version tag, and do not manually create the GitHub Release to bypass a
+failed gate.


### PR DESCRIPTION
## Summary

- replace the public-GitHub-Release trigger with a dedicated `v*` tag workflow
- verify tag/version consistency and successful `main` CI on the exact tagged SHA
- audit and dry-run the package before crates.io publication
- publish with crates.io Trusted Publishing/OIDC and create the GitHub Release last
- document one-time setup and the release operator procedure

## Required before v0.5.1

Configure the `gatehouse` crate on crates.io with a GitHub Trusted Publisher for `thepartly/gatehouse`, workflow `release.yml`, with no environment.

## Validation

- parsed both workflow files as YAML
- exercised tag/version and exact-SHA CI gate scripts locally
- verified changelog extraction
- `cargo audit`
- `cargo publish --dry-run --locked --allow-dirty`
- `git diff --check`