### PR TITLE
Disable generated GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
             inside { print }
           ' CHANGELOG.md > release-notes.md
 
-          args=(--verify-tag --title "$TAG" --generate-notes)
+          args=(--verify-tag --title "$TAG")
           if [ -s release-notes.md ]; then
             args+=(--notes-file release-notes.md)
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,7 +41,9 @@ not use a long-lived repository secret.
 The release workflow refuses to publish unless the tag matches the crate
 version and a successful `main` push CI run exists for the exact tagged commit.
 It then audits and packages the crate, publishes through crates.io Trusted
-Publishing, and creates the GitHub Release as the final step.
+Publishing, and creates the GitHub Release as the final step. The release body
+comes exclusively from the matching `CHANGELOG.md` section; GitHub-generated
+release notes are intentionally disabled.
 
 If a release fails, inspect the workflow before retrying. Do not move or reuse a
 published version tag, and do not manually create the GitHub Release to bypass a


### PR DESCRIPTION
## Summary

- use only the matching `CHANGELOG.md` section as the GitHub Release body
- disable GitHub-generated release notes so the automatic “What’s Changed” section is not appended
- document the intended release-note source

## Validation

- `actionlint .github/workflows/release.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`