### PR TITLE
Classify fact load errors in provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- `FactLoadErrorKind` and `FactLoadError::kind()` provide stable,
+  machine-readable classifications for unregistered sources, source contract
+  violations, cancelled loaders, and backend failures.
+- `FactProvenance::from_load_result(...)` is the canonical way for fact-backed
+  policies to record a load result. It maps the outcome and diagnostic detail
+  and preserves the error classification in the public `error_kind` field.
+
+### Changed
+
+- **Breaking:** `FactProvenance` gains a public `error_kind` field. Downstream
+  struct literals must initialize it; constructors using `FactProvenance::new`
+  continue to produce unclassified provenance with `error_kind: None`.
+
 ### Fixed
 
 - Correct the `permission_checker_bound_check` fixtures so `trailing_allow/N`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "gatehouse"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -726,6 +726,7 @@ dependencies = [
  "loom",
  "proptest",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-postgres",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehouse"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 # 1.82 is required for `Option::is_none_or` (stabilized 2024-10-17), used
 # in the builder's per-axis predicate evaluation. Other dependencies on
@@ -38,6 +38,7 @@ criterion = { version = "0.8" }
 dashmap = "6"
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,23 @@
+# Migrating from 0.5 to 0.6
+
+Gatehouse 0.6 adds a public `error_kind` field to `FactProvenance`. Code using
+`FactProvenance::new(...)` needs no change, but direct struct literals must
+initialize the new field:
+
+```rust,ignore
+FactProvenance {
+    fact_name: "membership",
+    key: "Member(42)".to_string(),
+    outcome: FactOutcome::Found,
+    detail: None,
+    error_kind: None,
+}
+```
+
+When provenance comes from a fact load, prefer
+`FactProvenance::from_load_result(...)`; it records the outcome, diagnostic
+detail, and structured `FactLoadErrorKind` together.
+
 # Migrating from 0.4 to 0.5
 
 Gatehouse 0.5 intentionally breaks the public API to make the authorization surface smaller and harder to misuse. The main changes are:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ flowchart LR
 
 Denials from `AccessEvaluation` are summary-level. Use `AccessEvaluation::display_trace()` or the attached `EvalTrace` to inspect individual policy reasons and fact provenance. Use `AccessEvaluation::denied_due_to_fact_load_error()` / `fact_load_errors()` when you need to distinguish infrastructure failure (fact load `Error`) from an ordinary denial — authorization remains fail-closed either way.
 
+Fact-backed policies should construct provenance with `FactProvenance::from_load_result(...)` and attach it through the context's `*_with_facts` result helpers. The constructor maps `Found`/`Missing`/`Error`, includes diagnostic error detail, and preserves a machine-readable `FactLoadErrorKind` in `FactProvenance::error_kind`. `FactProvenance::new(...)` remains available for manually constructed or legacy provenance; an error created that way has no structured error kind.
+
 ## Policy Domains
 
 A `PolicyDomain` names the four types involved in one authorization domain:

--- a/examples/factsource_n_plus_one.rs
+++ b/examples/factsource_n_plus_one.rs
@@ -39,7 +39,7 @@
 
 use async_trait::async_trait;
 use gatehouse::{
-    EvalCtx, EvaluationSession, FactKey, FactLoadResult, FactRegistry, FactSource,
+    EvalCtx, EvaluationSession, FactKey, FactLoadResult, FactProvenance, FactRegistry, FactSource,
     PermissionChecker, Policy, PolicyDomain, PolicyEvalResult,
 };
 use std::borrow::Cow;
@@ -199,12 +199,24 @@ impl Policy<SupplierInvoiceDomain> for RightSupplierPolicy {
         // first call inside this request triggers `load_many`; every
         // subsequent call with the same key (e.g. another invoice in
         // the same batch) hits the request-scoped cache.
-        match ctx.session.get(CustomerForOrg(ctx.subject.org_id)).await {
+        let key = CustomerForOrg(ctx.subject.org_id);
+        let result = ctx.session.get(key.clone()).await;
+        let provenance = vec![FactProvenance::from_load_result(
+            CustomerForOrg::NAME,
+            format!("{key:?}"),
+            &result,
+        )];
+
+        match result {
             FactLoadResult::Found(Some(customer_id)) if customer_id == ctx.resource.customer_id => {
-                ctx.grant("subject's supplier org bills under the invoice's customer")
+                ctx.grant_with_facts(
+                    "subject's supplier org bills under the invoice's customer",
+                    provenance,
+                )
             }
-            _ => ctx.not_applicable(
+            _ => ctx.not_applicable_with_facts(
                 "subject's supplier org does not bill under the invoice's customer",
+                provenance,
             ),
         }
     }

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -80,6 +80,28 @@ pub enum FactLoadError {
     Backend(Arc<dyn std::error::Error + Send + Sync>),
 }
 
+/// Stable, value-erased classification of a [`FactLoadError`].
+///
+/// Use this when a machine needs to choose an operational response without
+/// parsing [`FactLoadError`]'s human-readable [`fmt::Display`] output. The
+/// classification deliberately does not promise that every backend error is
+/// transient: callers can distinguish backend failures from Gatehouse source
+/// wiring and contract failures, then apply their own retry policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
+pub enum FactLoadErrorKind {
+    /// No source is registered for the requested fact key type.
+    SourceNotRegistered,
+    /// A source returned the wrong number of results.
+    SourceContractViolation,
+    /// The future driving the load was cancelled.
+    LoaderCancelled,
+    /// The registered source reported a backend error.
+    Backend,
+}
+
 impl FactLoadError {
     /// Wraps a backend error.
     pub fn backend(error: impl std::error::Error + Send + Sync + 'static) -> Self {
@@ -89,6 +111,16 @@ impl FactLoadError {
     /// Wraps a human-readable backend error message.
     pub fn backend_message(message: impl Into<String>) -> Self {
         Self::backend(MessageError(message.into()))
+    }
+
+    /// Returns the stable machine-readable classification of this error.
+    pub fn kind(&self) -> FactLoadErrorKind {
+        match self {
+            Self::SourceNotRegistered { .. } => FactLoadErrorKind::SourceNotRegistered,
+            Self::SourceContractViolation { .. } => FactLoadErrorKind::SourceContractViolation,
+            Self::LoaderCancelled { .. } => FactLoadErrorKind::LoaderCancelled,
+            Self::Backend(_) => FactLoadErrorKind::Backend,
+        }
     }
 }
 
@@ -204,14 +236,31 @@ pub enum FactLoadResult<V> {
 ///     &self,
 ///     ctx: &EvalCtx<'_, InvoiceAccess>,
 /// ) -> PolicyEvalResult {
-///     match ctx.session.get(CustomerForOrg(ctx.subject.org_id)).await {
+///     let key = CustomerForOrg(ctx.subject.org_id);
+///     let result = ctx.session.get(key.clone()).await;
+///     let provenance = vec![FactProvenance::from_load_result(
+///         CustomerForOrg::NAME,
+///         format!("{key:?}"),
+///         &result,
+///     )];
+///
+///     match result {
 ///         FactLoadResult::Found(Some(customer_id)) if customer_id == ctx.resource.customer_id => {
-///             ctx.grant("subject's org bills under the invoice's customer")
+///             ctx.grant_with_facts(
+///                 "subject's org bills under the invoice's customer",
+///                 provenance,
+///             )
 ///         }
-///         _ => ctx.not_applicable("not the billing customer"),
+///         _ => ctx.not_applicable_with_facts("not the billing customer", provenance),
 ///     }
 /// }
 /// ```
+///
+/// Recording provenance is operationally significant: it lets
+/// [`crate::AccessEvaluation::denied_due_to_fact_load_error`] distinguish a
+/// failed load from an ordinary authorization denial. Policies should use
+/// [`FactProvenance::from_load_result`](crate::FactProvenance::from_load_result)
+/// whenever a load result contributes to a decision.
 ///
 /// The built-in [`RebacPolicy`](crate::RebacPolicy) generalises this idiom
 /// for relationship-shaped facts; the same plumbing handles arbitrary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,9 @@ mod session;
 pub use builder::PolicyBuilder;
 pub use checker::{BoundEvaluator, PermissionChecker};
 pub use combinators::{AndPolicy, EmptyPoliciesError, NotPolicy, OrPolicy, PolicyExt};
-pub use facts::{FactKey, FactLoadError, FactLoadResult, FactSource, RelationshipQuery};
+pub use facts::{
+    FactKey, FactLoadError, FactLoadErrorKind, FactLoadResult, FactSource, RelationshipQuery,
+};
 pub use lookup::{Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupPage, LookupSource};
 pub use metadata::SecurityRuleMetadata;
 pub(crate) use metadata::{DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE};

--- a/src/policies/rebac.rs
+++ b/src/policies/rebac.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BatchEvalCtx, EvalCtx, FactKey, FactLoadResult, FactOutcome, FactProvenance, Policy,
-    PolicyDomain, PolicyEvalResult, RelationshipQuery,
+    BatchEvalCtx, EvalCtx, FactKey, FactLoadResult, FactProvenance, Policy, PolicyDomain,
+    PolicyEvalResult, RelationshipQuery,
 };
 use async_trait::async_trait;
 use std::fmt;
@@ -116,12 +116,7 @@ where
         key_repr: &str,
         fact: FactLoadResult<bool>,
     ) -> PolicyEvalResult {
-        let outcome = FactOutcome::from_load_result(&fact);
-        let detail = match &fact {
-            FactLoadResult::Error(error) => Some(error.to_string()),
-            _ => None,
-        };
-        let provenance = vec![FactProvenance::new(fact_name, key_repr, outcome, detail)];
+        let provenance = vec![FactProvenance::from_load_result(fact_name, key_repr, &fact)];
 
         match fact {
             FactLoadResult::Found(true) => PolicyEvalResult::granted_with_facts(

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,3 +1,4 @@
+use crate::{FactLoadErrorKind, FactLoadResult};
 use std::borrow::Cow;
 use std::fmt;
 
@@ -98,10 +99,19 @@ pub struct FactProvenance {
     /// Optional extra detail, such as the backend error message when
     /// `outcome` is [`FactOutcome::Error`].
     pub detail: Option<String>,
+    /// Machine-readable classification when this provenance records a fact
+    /// load error.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub error_kind: Option<FactLoadErrorKind>,
 }
 
 impl FactProvenance {
-    /// Records a consulted fact.
+    /// Records a consulted fact from manually supplied parts.
+    ///
+    /// Prefer [`Self::from_load_result`] when a [`FactLoadResult`] is
+    /// available. Manually constructing [`FactOutcome::Error`] through this
+    /// method produces unclassified error provenance, so
+    /// [`Self::error_kind`] is `None`.
     pub fn new(
         fact_name: &'static str,
         key: impl Into<String>,
@@ -113,6 +123,32 @@ impl FactProvenance {
             key: key.into(),
             outcome,
             detail,
+            error_kind: None,
+        }
+    }
+
+    /// Records a consulted fact directly from its load result.
+    ///
+    /// This is the canonical constructor for fact-backed policies. It records
+    /// the value-erased [`FactOutcome`], preserves a structured
+    /// [`FactLoadErrorKind`], and renders the error message into [`Self::detail`]
+    /// without requiring every policy to repeat that mapping by hand.
+    pub fn from_load_result<V>(
+        fact_name: &'static str,
+        key: impl Into<String>,
+        result: &FactLoadResult<V>,
+    ) -> Self {
+        let (detail, error_kind) = match result {
+            FactLoadResult::Error(error) => (Some(error.to_string()), Some(error.kind())),
+            FactLoadResult::Found(_) | FactLoadResult::Missing => (None, None),
+        };
+
+        Self {
+            fact_name,
+            key: key.into(),
+            outcome: FactOutcome::from_load_result(result),
+            detail,
+            error_kind,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1575,6 +1575,12 @@ mod core_tests {
         let result = policy.evaluate(&ctx).await;
 
         assert!(!result.is_granted());
+        let provenance = result.provenance();
+        assert_eq!(provenance.len(), 1);
+        assert_eq!(
+            provenance[0].error_kind,
+            Some(FactLoadErrorKind::SourceNotRegistered)
+        );
         assert!(result
             .reason()
             .as_deref()
@@ -3088,7 +3094,110 @@ mod core_tests {
         assert_serialize::<PolicyEvalResult>();
         assert_serialize::<FactProvenance>();
         assert_serialize::<FactOutcome>();
+        assert_serialize::<FactLoadErrorKind>();
         assert_serialize::<CombineOp>();
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn fact_provenance_serializes_classified_error_kind_only_when_present() {
+        let classified = FactProvenance::from_load_result(
+            "membership",
+            "IsMember(42)",
+            &FactLoadResult::<bool>::Error(FactLoadError::SourceNotRegistered {
+                fact_name: "membership",
+            }),
+        );
+        let unclassified = FactProvenance::new(
+            "membership",
+            "IsMember(42)",
+            FactOutcome::Error,
+            Some("legacy detail".to_string()),
+        );
+        let found = FactProvenance::from_load_result(
+            "membership",
+            "IsMember(42)",
+            &FactLoadResult::Found(true),
+        );
+
+        let classified = serde_json::to_value(classified).expect("provenance should serialize");
+        let unclassified = serde_json::to_value(unclassified).expect("provenance should serialize");
+        let found = serde_json::to_value(found).expect("provenance should serialize");
+
+        assert_eq!(classified["error_kind"], "source_not_registered");
+        assert!(unclassified.get("error_kind").is_none());
+        assert!(found.get("error_kind").is_none());
+    }
+
+    #[test]
+    fn fact_load_error_kind_preserves_machine_readable_classification() {
+        let errors = [
+            (
+                FactLoadError::SourceNotRegistered {
+                    fact_name: "membership",
+                },
+                FactLoadErrorKind::SourceNotRegistered,
+            ),
+            (
+                FactLoadError::SourceContractViolation {
+                    fact_name: "membership",
+                    expected: 2,
+                    actual: 1,
+                },
+                FactLoadErrorKind::SourceContractViolation,
+            ),
+            (
+                FactLoadError::LoaderCancelled {
+                    fact_name: "membership",
+                },
+                FactLoadErrorKind::LoaderCancelled,
+            ),
+            (
+                FactLoadError::backend_message("database unavailable"),
+                FactLoadErrorKind::Backend,
+            ),
+        ];
+
+        for (error, expected_kind) in errors {
+            assert_eq!(error.kind(), expected_kind);
+        }
+    }
+
+    #[test]
+    fn provenance_from_load_result_records_error_kind_and_detail() {
+        let result = FactLoadResult::<bool>::Error(FactLoadError::SourceNotRegistered {
+            fact_name: "membership",
+        });
+
+        let provenance = FactProvenance::from_load_result("membership", "IsMember(42)", &result);
+
+        assert_eq!(provenance.fact_name, "membership");
+        assert_eq!(provenance.key, "IsMember(42)");
+        assert_eq!(provenance.outcome, FactOutcome::Error);
+        assert_eq!(
+            provenance.error_kind,
+            Some(FactLoadErrorKind::SourceNotRegistered)
+        );
+        assert_eq!(
+            provenance.detail.as_deref(),
+            Some("No fact source registered for 'membership'")
+        );
+    }
+
+    #[test]
+    fn provenance_from_load_result_leaves_non_errors_unclassified() {
+        let found = FactLoadResult::Found(true);
+        let missing = FactLoadResult::<bool>::Missing;
+
+        let found = FactProvenance::from_load_result("membership", "found", &found);
+        let missing = FactProvenance::from_load_result("membership", "missing", &missing);
+
+        assert_eq!(found.outcome, FactOutcome::Found);
+        assert_eq!(found.error_kind, None);
+        assert_eq!(found.detail, None);
+        assert_eq!(missing.outcome, FactOutcome::Missing);
+        assert_eq!(missing.error_kind, None);
+        assert_eq!(missing.detail, None);
     }
 
     #[tokio::test]
@@ -3234,7 +3343,34 @@ mod core_tests {
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].fact_name, "relationship");
         assert_eq!(errors[0].outcome, FactOutcome::Error);
+        assert_eq!(errors[0].error_kind, Some(FactLoadErrorKind::Backend));
         assert!(errors[0].detail.is_some());
+    }
+
+    #[tokio::test]
+    async fn fact_load_errors_distinguish_unregistered_source_from_backend_failure() {
+        let mut checker = PermissionChecker::<TestDomain>::new();
+        checker.add_policy(RebacPolicy::new(
+            |subject: &TestSubject| subject.id,
+            |resource: &TestResource| resource.id,
+            "manager".to_string(),
+        ));
+        let subject = test_subject();
+        let resource = test_resource();
+        let session = EvaluationSession::new();
+
+        let evaluation = checker
+            .bind(&session, &subject, &TestAction, &TestContext)
+            .check(&resource)
+            .await;
+
+        assert!(evaluation.denied_due_to_fact_load_error());
+        let errors = evaluation.fact_load_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].error_kind,
+            Some(FactLoadErrorKind::SourceNotRegistered)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add `FactLoadErrorKind` and `FactLoadError::kind()` for stable machine-readable classification of source registration, source contract, cancellation, and backend failures
- add `FactProvenance::from_load_result(...)` as the canonical mapping from a fact load into outcome, diagnostic detail, and structured error kind
- make `FactProvenance::error_kind` a public `Option<FactLoadErrorKind>`, consistent with the struct's existing public provenance fields
- replace `RebacPolicy`'s hand-written mapping with the canonical constructor and update the fact-source example, README, and migration guide
- bump the crate to 0.6.0 because adding a field to the publicly constructible `FactProvenance` struct is source-breaking

This is the focused classification/constructor portion of #58. The observer-based attempt to reconstruct provenance omitted by a policy has been removed completely: there are no checker, session, thread-local, `Clone`, tracing-warning, or benchmark changes in this PR. The missing structural `Indeterminate`/recording-context design remains follow-up work, so this PR does not close #58.

The benchmark-fixture correction was split into #60 and merged first; this branch is based on that merge and carries no benchmark diff.

## Breaking change

Downstream `FactProvenance { ... }` literals must initialize the new field:

```rust
FactProvenance {
    fact_name: "membership",
    key: "Member(42)".to_string(),
    outcome: FactOutcome::Found,
    detail: None,
    error_kind: None,
}
```

Code using `FactProvenance::new(...)` continues to compile and produces unclassified provenance. Fact-backed policies should prefer `FactProvenance::from_load_result(...)`, which fills `error_kind` for errors and leaves it `None` for found or missing facts.

With the `serde` feature, classified errors serialize `error_kind` using snake-case names. The field is omitted when it is `None`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features`
- `cargo test --all-features` (127 unit tests plus integration/example tests and doctests)
- `cargo test --all-targets --all-features` (including every benchmark and example harness)
- `RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps`
- external downstream compile probe for the 0.6 struct-literal migration
- `cargo publish --dry-run --allow-dirty`
- independent local review: approved with no actionable findings
- GitHub CI: build-and-test, Loom permutation tests, and mutation tests all pass
