### PR TITLE
Fix permission checker benchmark fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct the `permission_checker_bound_check` fixtures so `trailing_allow/N`
+  and `all_deny/N` genuinely evaluate all `N` policies. The previous forbid
+  fixtures short-circuited after the first policy, so their historical numbers
+  are not comparable with the corrected benchmark.
+
 ## [0.5.1] - 2026-09-01
 
 ### Added

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -31,7 +31,7 @@ fn build_all_deny_checker(policy_count: usize) -> PermissionChecker<UnitDomain> 
 
     for index in 0..policy_count {
         let policy = PolicyBuilder::<UnitDomain>::new(format!("deny_policy_{index}"))
-            .forbid()
+            .when(|_subject, _action, _resource, _context| false)
             .build();
         checker.add_policy(policy);
     }
@@ -46,7 +46,7 @@ fn build_trailing_allow_checker(policy_count: usize) -> PermissionChecker<UnitDo
 
     for index in 0..(policy_count - 1) {
         let policy = PolicyBuilder::<UnitDomain>::new(format!("deny_policy_{index}"))
-            .forbid()
+            .when(|_subject, _action, _resource, _context| false)
             .build();
         checker.add_policy(policy);
     }


### PR DESCRIPTION
## Summary

- make `permission_checker_bound_check/trailing_allow/N` evaluate all policies before the final grant
- make `permission_checker_bound_check/all_deny/N` evaluate all policies before returning the combined denial
- document that historical numbers from these fixtures are not comparable because the previous forbid policies short-circuited after the first result

This keeps the benchmark aligned with the linear-in-policy-count contract documented in `benches/README.md` and gives authorization-checker changes an honest baseline.

## Verification

- `cargo fmt --all -- --check`
- `cargo bench --bench permission_checker -- permission_checker_bound_check --quick`
- corrected 64-policy quick results: `trailing_allow` 20.5-22.5 us; `all_deny` 18.4-18.6 us
- `git diff --check`
