### PR TITLE
Prepare 0.6 prerelease: typed policies, strict outcomes, and optional tracing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,2 @@
+# The default metadata method already returns Default::default().
+exclude_re = ['replace VetoPolicy::security_rule -> SecurityRuleMetadata with Default::default\(\)']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           key: "v2"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Check formatting
+        run: cargo fmt --all -- --check
       - name: Build
         run: cargo build --verbose
       - name: Lint
@@ -31,6 +33,51 @@ jobs:
         run: cargo doc --verbose
       - name: Test
         run: cargo test --all-targets --all-features
+
+  feature-contracts:
+    name: Feature contracts (${{ matrix.features.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - name: none
+            args: --no-default-features
+          - name: tracing
+            args: --no-default-features --features tracing
+          - name: serde
+            args: --no-default-features --features serde
+          - name: all
+            args: --all-features
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Check library dependency graph
+        if: matrix.features.name == 'none'
+        run: |
+          cargo tree --edges normal --no-default-features > dependencies.txt
+          if grep -q tracing dependencies.txt; then
+            cat dependencies.txt
+            exit 1
+          fi
+      - name: Lint
+        run: cargo clippy --all-targets ${{ matrix.features.args }} -- -D warnings
+      - name: Test contracts and examples
+        run: cargo test --lib --tests --examples ${{ matrix.features.args }}
+      - name: Test documentation
+        run: cargo test --doc ${{ matrix.features.args }}
+
+  msrv:
+    name: Minimum supported Rust (1.82)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --lib --all-features --locked
+      - run: cargo check --lib --no-default-features --locked
 
   loom-tests:
     name: Loom permutation tests
@@ -57,7 +104,7 @@ jobs:
     needs: build-and-test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -73,15 +120,18 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants
-      - name: Capture checker/combinator diff
-        run: git diff origin/${{ github.base_ref }}...HEAD -- src/checker.rs src/combinators.rs > mutants.diff
+      - name: Capture authorization diff
+        run: git diff origin/${{ github.base_ref }}...HEAD -- src/checker.rs src/combinators.rs src/capability.rs src/policies/delegating.rs > mutants.diff
       - name: Run focused mutation tests
         run: >
           cargo mutants
-          --in-place
+          --jobs=2
+          --jobserver-tasks=2
           --in-diff=mutants.diff
           --file src/checker.rs
           --file src/combinators.rs
+          --file src/capability.rs
+          --file src/policies/delegating.rs
           --baseline=skip
           --timeout=60
           --build-timeout=300
@@ -89,8 +139,7 @@ jobs:
           --
           --test checker_contract
           --test tracing_contract
-        env:
-          PROPTEST_CASES: 128
+          --test outcome_contract
       - name: Upload mutation test report
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           set -euo pipefail
           python3 - <<'PY'
           import os
+          import re
+          from pathlib import Path
           import sys
           import tomllib
 
@@ -43,7 +45,21 @@ jobs:
               )
               sys.exit(1)
 
-          print(f"Verified {tag} matches gatehouse {crate_version}")
+          heading = re.compile(rf"^## \[{re.escape(crate_version)}\](?: - \d{{4}}-\d{{2}}-\d{{2}})?$")
+          notes = []
+          inside = False
+          for line in Path("CHANGELOG.md").read_text().splitlines():
+              if heading.fullmatch(line):
+                  inside = True
+              elif inside and line.startswith("## ["):
+                  break
+              elif inside:
+                  notes.append(line)
+          if not "\n".join(notes).strip():
+              print(f"::error file=CHANGELOG.md::Missing release notes for {crate_version}")
+              sys.exit(1)
+
+          print(f"Verified {tag} matches gatehouse {crate_version} with release notes")
           PY
 
   candidate-ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,31 +9,33 @@ cargo run --example axum        # HTTP server on :8000
 cargo run --example actix_web   # HTTP server on :8080
 
 # Reproduce the PR mutation gate locally (see "CI gates" below)
-git diff origin/main...HEAD -- src/checker.rs src/combinators.rs > mutants.diff
+git diff origin/main...HEAD -- src/checker.rs src/combinators.rs src/capability.rs src/policies/delegating.rs > mutants.diff
 cargo mutants --in-place --in-diff=mutants.diff \
-  --file src/checker.rs --file src/combinators.rs \
+  --file src/checker.rs --file src/combinators.rs --file src/capability.rs \
+  --file src/policies/delegating.rs \
   --baseline=skip --timeout=60 --build-timeout=300 --all-features \
-  -- --test checker_contract --test tracing_contract
+  -- --test checker_contract --test tracing_contract --test outcome_contract
 ```
 
 ## CI gates that bite
 
 - Clippy runs with `-D warnings`; any warning fails CI. `fmt` + `clippy` before committing.
-- A **diff-scoped `cargo-mutants` gate** mutates the PR's changes to `src/checker.rs` and `src/combinators.rs` only. Every new/changed line there must be killed by a test or CI fails (~20 min run). When you touch veto/short-circuit logic, add a test that *distinguishes the mutation* (e.g. a case where `&&` vs `||` actually diverge), not just a happy-path assertion — a green test that survives the mutant is the usual failure mode here.
+- A **diff-scoped `cargo-mutants` gate** covers `src/checker.rs`, `src/combinators.rs`, `src/capability.rs`, and `src/policies/delegating.rs`. When changing decisions or short-circuit logic, add a test that distinguishes the mutation (for example, inputs where `&&` and `||` diverge).
 - `main` is governed by a require-approval ruleset: PRs need an approving review (you cannot self-approve); repo/org admins can bypass.
-- Publishing a GitHub Release for tag `vX.Y.Z` triggers `cargo publish` to crates.io — irreversible. Releases finalize `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] - <date>`) in a small "Release vX.Y.Z" PR; `Cargo.toml`/`Cargo.lock` are bumped in the feature PR.
+- Pushing a `v*` tag triggers irreversible crates.io publication, followed by creation of the GitHub Release. The tag must match the Cargo version and point to a commit with successful main CI. Prepare and validate the exact candidate before requesting publication approval; see `.github/workflows/release.yml`.
 
 ## Architecture
 
 One library crate, split across `src/*.rs` and re-exported from `src/lib.rs`. Unit tests are in `src/tests.rs`; integration tests in `tests/` — and the examples are `include!`d into those tests, so a broken example breaks the test build.
 
-`Policy<D: PolicyDomain>` is the core trait: async `evaluate` → `PolicyEvalResult`, plus `evaluate_batch` (must return one result per input, in order). `PolicyDomain` names `Subject`/`Action`/`Resource`/`Context` once. `PermissionChecker<D>` is bound per request — `checker.bind(&session, &subject, &action, &context)` yields a `BoundEvaluator` with `check` / `evaluate` / `evaluate_by` / `filter` / `filter_by` / `lookup_page`.
+`Policy<D>` returns `GrantResult`; `VetoPolicy<D>` returns `VetoResult`. Both have single and batch evaluation; batches return one result per input in order. `PolicyDomain` names `Subject`/`Action`/`Resource`/`Context`. Bind request inputs once with `checker.bind(...)`. Use `try_filter`, `try_filter_by`, or `try_lookup_page` when an indeterminate item must fail the list operation; the non-fallible variants deliberately omit indeterminate items.
 
-Built-ins: `RbacPolicy`, `RebacPolicy`, `DelegatingPolicy`; `PolicyBuilder::when` for ABAC-style predicates; combinators `AndPolicy` / `OrPolicy` / `NotPolicy` plus fluent `PolicyExt`. Closures are `Send + Sync + 'static`. Decisions are never `Result`: `PolicyEvalResult::{Granted, NotApplicable, Forbidden, Indeterminate, Combined}` at the policy level, `AccessEvaluation::{Granted, Denied, Indeterminate}` at the top. Every node also exposes a `Decision` via `PolicyEvalResult::decision()` (`Combined` stores its aggregate decision). Public enums are `#[non_exhaustive]`. Telemetry is `tracing` (OpenTelemetry semantic conventions); reason strings and `FactProvenance.detail` reach subscribers — treat them as audit surface, no secrets.
+`PolicyEvalResult` is the inspectable audit tree, not a custom policy's return type. Controlled `GrantResult` and `VetoResult` constructors enforce authority boundaries. `AccessEvaluation::{Granted, Denied, Indeterminate}` is the top-level decision; `into_result` preserves denied versus indeterminate in `AccessError`. Context fact-loading helpers record provenance; aggregate nodes retain their own facts. Public enums are `#[non_exhaustive]`. The default-enabled `tracing` feature controls instrumentation independently of returned audit evidence. Reasons and fact details are audit surfaces; exclude secrets.
 
-## Load-bearing invariants (read before editing `checker.rs` / `combinators.rs`)
+## Load-bearing invariants (read before editing evaluator or capability code)
 
-- **Deny-overrides via veto-prefix ordering.** Veto-capable policies (`effect().can_forbid()`) are scheduled ahead of allow-only ones, and a grant is never returned until *every* veto-capable policy has been evaluated — so a `Forbidden` is always observed before a grant can short-circuit. `evaluate_one` (single) and `evaluate_batch_by` (batch) implement this independently and **must agree per item**; differential proptests against a deny-overrides oracle in `tests/checker_contract.rs` enforce it.
-- **Indeterminate is fail-closed and effect-aware.** A node whose decision is `Indeterminate` never grants. In the checker (and inside `AndPolicy`/`OrPolicy`), an `Indeterminate` from the **veto prefix** blocks grants — the failed policy might have forbidden — and resolves at the end of the prefix (a later definite `Forbidden` in the prefix still wins). An `Indeterminate` from an **allow-only** policy never blocks a grant, but with no grant on the table it makes the aggregate `Indeterminate` rather than a plain non-grant. `NotPolicy` maps `Indeterminate` to `Indeterminate` — never to a grant. The oracle in `tests/checker_contract.rs` encodes these rules; keep it in sync.
-- **Forbid detection reads the node decision plus a whole-tree backstop.** `is_forbidden()` is `decision() == Decision::Forbid || forbidden_leaf().is_some()`. The crate's combinators must keep a `Combined` node's `decision` consistent with its children (in particular: **never `Decision::Grant` while a `Forbidden` leaf survives in the children**); the recursive leaf scan is defense-in-depth so a downstream combinator that breaks that rule still fails closed.
-- **`effect()` is a security contract.** A policy that can return `Forbidden` must declare `Effect::Forbid` or `Effect::AllowOrForbid`, or its veto can be short-circuited by an earlier grant. The checker emits a `WARN` when an `Effect::Allow` policy returns `Forbidden` (it honors the veto where observed, but cannot reorder it). The same declaration decides whether a policy's `Indeterminate` blocks sibling grants (veto prefix) or not (allow-only).
+- **Vetoes precede grants.** Every applicable veto must pass before grants can authorize. A definite veto outranks uncertainty; unresolved vetoes block grants. An unresolved grant never defeats an independent grant. Single and batch results must agree per item, including nested delegation.
+- **Authority is typed.** Keep raw audit-tree construction separate from grant/veto return values. A public conversion from an arbitrary `PolicyEvalResult` into a capability result would defeat this boundary.
+- **Aggregate decisions govern audit descendants.** An `AllOfVeto` can pass while retaining a matched child veto in its trace. `is_forbidden()` reads the node decision; veto attribution follows only active veto branches. A recursive search for any forbidden leaf would change authorization semantics.
+- **Delegation is atomic.** `add_delegate` installs both child capabilities. Child grant uncertainty remains grant uncertainty in the parent. Both phases must use the same mapped inputs, and each child policy runs at most once per resource in its phase.
+- **Adversarial validation.** Preserve recursive oracle tests, capability compile-fail tests, malformed-batch tests, and mutation coverage when simplifying code. A shorter evaluator still needs these guarantees.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ cargo mutants --in-place --in-diff=mutants.diff \
 - Clippy runs with `-D warnings`; any warning fails CI. `fmt` + `clippy` before committing.
 - A **diff-scoped `cargo-mutants` gate** covers `src/checker.rs`, `src/combinators.rs`, `src/capability.rs`, and `src/policies/delegating.rs`. When changing decisions or short-circuit logic, add a test that distinguishes the mutation (for example, inputs where `&&` and `||` diverge).
 - `main` is governed by a require-approval ruleset: PRs need an approving review (you cannot self-approve); repo/org admins can bypass.
-- Pushing a `v*` tag triggers irreversible crates.io publication, followed by creation of the GitHub Release. The tag must match the Cargo version and point to a commit with successful main CI. Prepare and validate the exact candidate before requesting publication approval; see `.github/workflows/release.yml`.
+- Pushing a `v*` tag triggers irreversible crates.io publication, followed by creation of the GitHub Release. The tag must match the Cargo version and point to a commit with successful main CI. Before tagging, a release-preparation PR must rename `CHANGELOG.md`'s `[Unreleased]` section to `[X.Y.Z] - <date>` and retain nonempty release notes. Prepare and validate the exact candidate before requesting publication approval; see `.github/workflows/release.yml`.
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,133 +4,77 @@
 
 ### Added
 
-- `FactLoadErrorKind` and `FactLoadError::kind()` provide stable,
-  machine-readable classifications for unregistered sources, source contract
-  violations, cancelled loaders, and backend failures.
-- `FactProvenance::from_load_result(...)` is the canonical way for fact-backed
-  policies to record a load result. It maps the outcome and diagnostic detail
-  and preserves the error classification in the public `error_kind` field.
-- First-class `Indeterminate` outcome (#61). `Decision` is a new
-  four-valued enum (`Grant` / `NotApplicable` / `Forbid` / `Indeterminate`)
-  carried by **every** `PolicyEvalResult` node via the new
-  `PolicyEvalResult::decision()` accessor. New leaf variant
-  `PolicyEvalResult::Indeterminate` (constructors `indeterminate` /
-  `indeterminate_with_facts`) means "this policy consulted an input that was
-  unavailable and could not decide" — fail-closed, never a grant. New
-  top-level variant `AccessEvaluation::Indeterminate` (plus
-  `is_indeterminate()`, `indeterminate_reason()`, `assert_indeterminate()`)
-  is the structural, causal signal for mapping authorization-data outages to
-  a 5xx instead of a 403.
-- Deny-overrides combination rules for `Indeterminate`: a definite
-  `Forbidden` still overrides everything; an indeterminate **veto-capable**
-  policy blocks sibling grants (its unresolved potential veto is never
-  short-circuited); an indeterminate **allow-only** policy never blocks a
-  grant, but if nothing grants the evaluation is `Indeterminate` rather than
-  `"All policies denied access"`. `AndPolicy` / `OrPolicy` apply the same
-  veto-prefix rules; `NotPolicy` maps `Indeterminate` to `Indeterminate`
-  (never a grant); `DelegatingPolicy` propagates a child checker's
-  indeterminate outcome.
-- `gatehouse.batch_policy` spans record `policy.indeterminate_count`, the
-  top-level `evaluate_batch` span records `indeterminate_count` separately
-  from `denied_count`, the `evaluate_one` span can record
-  `outcome = "indeterminate"`, and the `gatehouse::security` event outcome is
-  `"unknown"` for indeterminate policy results.
-- Recording evaluation contexts (#62). `EvalCtx::fact(key)` /
-  `EvalCtx::facts(keys)` and `BatchEvalCtx::facts_by(key_of)` /
-  `BatchEvalCtx::fact(key)` load through the session **and** record each
-  consulted fact as `FactProvenance`; the context result helpers
-  (`ctx.grant`, `ctx.not_applicable`, `ctx.forbid`, the new
-  `ctx.indeterminate`, and the `*_with_facts` variants) attach everything
-  recorded, so provenance is correct by construction instead of opt-in.
-  The checker and combinators merge facts a policy recorded but did not
-  attach (`EvalCtx::finish` / `BatchEvalCtx::finish`, public for callers
-  that drive `Policy::evaluate` directly). `ctx.record(...)` covers facts
-  loaded outside the context; `ctx.session()` is the documented
-  non-recording escape hatch.
-- `ctx.not_applicable(...)` after a **recorded** failed load is upgraded to
-  `PolicyEvalResult::Indeterminate`, closing the silent case where a policy
-  that forgot `*_with_facts` disabled the infrastructure-failure signal
-  (#58 case 3). Explicit provenance passed to `not_applicable_with_facts`
-  never changes the author's variant choice.
+- Separate `GrantResult` and `VetoResult` capabilities, `VetoPolicy`,
+  `PermissionChecker::add_veto`, and `PolicyBuilder::build_veto`. Grant policies
+  cannot return veto authority; veto policies cannot grant.
+- `AllOfVeto`, `AnyOfVeto`, and `VetoPolicyExt` for typed veto composition;
+  `GrantResult::all` / `any` for controlled custom grant aggregates.
+- `PermissionChecker::add_delegate` registers both delegated capabilities
+  atomically, preserving the distinction between child grant and veto failures.
+- First-class `AccessEvaluation::Indeterminate` and four-valued audit
+  `Decision`. Definite vetoes win; unresolved vetoes block grants; independent
+  grants can supersede grant-policy failures.
+- `AccessEvaluation::into_result` and typed `AccessError` retain denial versus
+  indeterminate classification, reasons, complete traces, and fact errors.
+- `try_filter`, `try_filter_by`, and `try_lookup_page` exclude denials and fail
+  on indeterminate evaluations. Errors retain original items and decisions;
+  strict lookup distinguishes evaluation, source, hydration, and contract errors.
+- Recording contexts: `EvalCtx::fact` / `facts`, `BatchEvalCtx::facts_by` /
+  `fact`, and `record` automatically attach consulted facts. `finish` supports
+  callers evaluating policies directly.
+- `FactLoadErrorKind`, `FactLoadError::kind`, and
+  `FactProvenance::from_load_result` expose structured failure classifications.
+- Default-enabled `tracing` feature. Disabling default features removes
+  instrumentation and its dependency while retaining decisions and audit data.
+  The `serde` feature remains independent.
+- CI checks for formatting, MSRV, doctests, and feature combinations; recursive
+  composition properties and compile-fail capability checks.
 
 ### Changed
 
-- **Breaking:** `FactProvenance` gains a public `error_kind` field. Downstream
-  struct literals must initialize it; constructors using `FactProvenance::new`
-  continue to produce unclassified provenance with `error_kind: None`.
-- **Breaking:** `PolicyEvalResult::Combined` replaces `outcome: bool` with
-  `decision: Decision`. `is_forbidden()` now reads the node decision first
-  and keeps the recursive `Forbidden`-leaf scan as a fail-closed backstop
-  for inconsistent custom combinator nodes.
-- **Breaking:** `RebacPolicy` returns `Indeterminate` (previously
-  `NotApplicable`) when a relationship fact load *fails* — backend errors,
-  unregistered sources, contract violations. A checker whose decisive path
-  hits such a failure now yields `AccessEvaluation::Indeterminate` instead of
-  `Denied`. Authoritative `Found(false)` / `Missing` answers remain ordinary
-  non-grants.
-- **Breaking:** a policy whose `evaluate_batch` returns the wrong number of
-  results now fails closed as `Indeterminate` (previously an ordinary
-  denial): the affected items genuinely could not be evaluated. The
-  synthesized indeterminate is combined under the normal rules rather than
-  ending evaluation: a later definite forbid in the veto prefix still wins,
-  and a malformed allow-only policy never suppresses a later grant.
-- `AccessEvaluation::denied_due_to_fact_load_error()` also returns `true`
-  for `Indeterminate` evaluations whose trace carries a fact-load error;
-  prefer the structural `is_indeterminate()` for the 403-vs-5xx split.
-- **Breaking:** `EvalCtx` and `BatchEvalCtx` are no longer constructible by
-  struct literal: `session` is private (use the new `session()` accessor)
-  and both gain a private provenance recorder. Use `EvalCtx::new(...)` /
-  `BatchEvalCtx::new(...)`, and pass results through `finish` when invoking
-  policies directly.
-- **Breaking:** `FactKey` gains a `fmt::Debug` supertrait and a defaulted
-  `render(&self) -> String` hook that produces the provenance key string
-  (defaulting to the `Debug` representation). `RelationshipQuery` overrides
-  `render` to keep its established `subject -[relation]-> resource` audit
-  form, so recorded key strings are unchanged from 0.5; `RebacPolicy` now
-  requires `Relation: fmt::Debug` in addition to `fmt::Display`.
-- **Breaking:** the `FactKey` impl for `RelationshipQuery` now requires
-  `Relation: fmt::Display` (used by its `render` override) in addition to
-  the `fmt::Debug` required on all three id types by the new supertrait.
-  Code that builds `RelationshipQuery` keys and loads them directly —
-  without going through `RebacPolicy`, which always required `Display` —
-  breaks if its relation type only derives `Debug`.
-- A `Combined` node whose decision disagrees with a surviving `Forbidden`
-  leaf is still treated as forbidding (fail closed) and now emits a `WARN`
-  naming the inconsistent node, so a broken custom combinator is visible in
-  logs instead of being silently corrected.
-- When a custom policy returns `Combined` after recording a failed fact load,
-  `EvalCtx::finish` preserves the provenance on a synthetic `Indeterminate`
-  child and downgrades every non-forbid aggregate decision to
-  `Indeterminate`. The outage can no longer disappear because `Combined` has
-  no provenance field.
-- `RebacPolicy` reasons classify load failures without interpolating raw
-  backend error text. Diagnostic detail remains available only through the
-  attached `FactProvenance::detail` in the trace.
-- `NotPolicy` treats an error-bearing `NotApplicable` leaf as
-  `Indeterminate`, preventing explicit failed-load provenance from being
-  inverted into a grant. Loads made through the raw `ctx.session()` escape
-  hatch remain invisible and must not be reported as ordinary non-matches.
-- `filter`, `filter_by`, and `lookup_page` continue to exclude indeterminate
-  items like denials; their docs now make that list-endpoint behavior explicit
-  and direct callers to `evaluate` / `evaluate_by` when they need to surface
-  authorization-data outages.
-- A `Forbid`-effect policy's contract-violating grant is still normalized
-  to `NotApplicable`, now preserving the facts the policy consulted so
-  they stay in the trace.
+- **Breaking:** `Policy::evaluate` / `evaluate_batch` return `GrantResult` /
+  `Vec<GrantResult>`. `Effect`, `Policy::effect`, `add_forbid_policy`, and
+  `PolicyBuilder::forbid` are removed. Register typed vetoes with `add_veto`.
+- **Breaking:** grant combinators accept only grant policies. Veto composition
+  uses its own combinators. `DelegatingPolicy` is registered with `add_delegate`.
+- **Breaking:** `PolicyEvalResult` is an audit representation, not an
+  authority-bearing return type. `Combined` has `decision` instead of `outcome`
+  and a `provenance` field. Typed aggregate constructors determine decisions;
+  arbitrary raw trees cannot be converted into typed policy results.
+- **Breaking:** fact-load failures and malformed policy batches produce
+  indeterminate outcomes instead of ordinary denials. `RebacPolicy` still
+  abstains on `Found(false)` and `Missing`.
+- **Breaking:** `EvalCtx` / `BatchEvalCtx` require constructors; their recorder
+  and session fields are private. Raw access remains through `session()`.
+- **Breaking:** `FactKey` requires `Debug` and supplies `render()` for audit
+  keys. `RelationshipQuery` requires `Debug` on IDs/relations and `Display` on
+  relations. `FactProvenance` gains `error_kind`.
+- Recorded failures upgrade abstention and veto pass to indeterminate. Decisive
+  grants/vetoes retain their decisions. Aggregate provenance follows the same
+  rules as leaves, without synthetic children or lost successful/missing facts.
+- `NotPolicy` preserves uncertainty, including explicit failed-load evidence
+  on an abstaining result. It cannot invert a veto policy.
+- ReBAC reasons classify errors without interpolating backend text; detailed
+  diagnostics remain in fact provenance. HTTP examples distinguish 403 from
+  outages and use strict list APIs with failure-injection coverage.
+- Existing `filter`, `filter_by`, `lookup_page`, and `to_result` retain their
+  deliberately lossy behavior. Prefer their strict or typed alternatives when
+  outages must be surfaced.
+- Indeterminate evaluations have separate telemetry outcomes and counters.
+  Contract warnings are emitted only when the tracing feature is enabled.
 
 ### Deprecated
 
-- `AccessEvaluation::denied_due_to_fact_load_error()`: use the structural
-  `is_indeterminate()` for the 403-vs-5xx split and `fact_load_errors()`
-  to inspect failed loads. The any-error-in-trace scan will be removed in
-  0.7.
+- `AccessEvaluation::denied_due_to_fact_load_error`: classify the final outcome
+  using `is_indeterminate()` / `into_result()` and inspect `fact_load_errors()`
+  for diagnostics. Removal is planned for 0.7.
 
 ### Fixed
 
-- Correct the `permission_checker_bound_check` fixtures so `trailing_allow/N`
-  and `all_deny/N` genuinely evaluate all `N` policies. The previous forbid
-  fixtures short-circuited after the first policy, so their historical numbers
-  are not comparable with the corrected benchmark.
+- Lookup example now enumerates all documents for admins, satisfying the
+  candidate-superset contract across both admin and viewer grant paths.
+- Correct benchmark fixtures so trailing grants and all-abstaining stacks
+  evaluate every intended policy; previous measurements are not comparable.
 
 ## [0.5.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
   `Vec<GrantResult>`. `Effect`, `Policy::effect`, `add_forbid_policy`, and
   `PolicyBuilder::forbid` are removed. Register typed vetoes with `add_veto`.
 - **Breaking:** grant combinators accept only grant policies. Veto composition
-  uses its own combinators. `DelegatingPolicy` is registered with `add_delegate`.
+  uses its own combinators. `DelegatingPolicy` no longer implements `Policy`
+  and cannot be nested in grant combinators; register it with `add_delegate`.
 - **Breaking:** `PolicyEvalResult` is an audit representation, not an
   authority-bearing return type. `Combined` has `decision` instead of `outcome`
   and a `provenance` field. Typed aggregate constructors determine decisions;
@@ -48,12 +49,17 @@
   and session fields are private. Raw access remains through `session()`.
 - **Breaking:** `FactKey` requires `Debug` and supplies `render()` for audit
   keys. `RelationshipQuery` requires `Debug` on IDs/relations and `Display` on
-  relations. `FactProvenance` gains `error_kind`.
+  relations. Its `render()` preserves the 0.5 diagnostic key format
+  (`subject -[relation]-> resource`). `FactProvenance` gains `error_kind`.
 - Recorded failures upgrade abstention and veto pass to indeterminate. Decisive
   grants/vetoes retain their decisions. Aggregate provenance follows the same
   rules as leaves, without synthetic children or lost successful/missing facts.
+  Explicit `*_with_facts` constructors apply the same rule to their own error
+  provenance, preserving the supplied reason and facts.
 - `NotPolicy` preserves uncertainty, including explicit failed-load evidence
-  on an abstaining result. It cannot invert a veto policy.
+  on an abstaining result. It uses the child decision: errors retained in
+  descendants do not make an otherwise settled aggregate uncertain again.
+  It cannot invert a veto policy.
 - ReBAC reasons classify errors without interpolating backend text; detailed
   diagnostics remain in fact provenance. HTTP examples distinguish 403 from
   outages and use strict list APIs with failure-injection coverage.
@@ -75,6 +81,19 @@
   candidate-superset contract across both admin and viewer grant paths.
 - Correct benchmark fixtures so trailing grants and all-abstaining stacks
   evaluate every intended policy; previous measurements are not comparable.
+
+### Rationale
+
+- [#58](https://github.com/thepartly/gatehouse/issues/58) describes the lost
+  error classification and silently omitted provenance that motivated
+  [#59](https://github.com/thepartly/gatehouse/pull/59) and the recording contexts
+  in [#64](https://github.com/thepartly/gatehouse/pull/64). In particular, case 3
+  could turn a failed fact load into an ordinary denial without diagnostic evidence.
+- [#61](https://github.com/thepartly/gatehouse/issues/61) and
+  [#62](https://github.com/thepartly/gatehouse/issues/62) explain structural
+  uncertainty and automatic fact recording;
+  [#63](https://github.com/thepartly/gatehouse/issues/63) motivates enforcing
+  grant/veto authority through types in the same breaking release.
 
 ## [0.5.1] - 2026-09-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "gatehouse"
-version = "0.6.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "actix-web",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatehouse"
-version = "0.6.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 # 1.82 is required for `Option::is_none_or` (stabilized 2024-10-17), used
 # in the builder's per-axis predicate evaluation. Other dependencies on
@@ -10,15 +10,17 @@ rust-version = "1.82"
 license = "MIT"
 repository = "https://github.com/thepartly/gatehouse"
 description = "An in-process authorization engine for Rust with composable policies and request-scoped fact loading."
+include = ["src/**", "tests/**", "examples/**", "benches/**", "Cargo.toml", "Cargo.lock", "README.md", "MIGRATION.md", "CHANGELOG.md", "LICENSE", ".github/logo.svg"]
 
 [dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 async-trait = "0.1"
 futures-channel = "0.3"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
-default = []
+default = ["tracing"]
+tracing = ["dep:tracing"]
 serde = ["dep:serde"]
 
 # Regular dev-deps. Gated on `cfg(not(loom))` because several of them
@@ -50,6 +52,10 @@ loom = "0.7"
 
 [[bench]]
 name = "permission_checker"
+harness = false
+
+[[bench]]
+name = "recording"
 harness = false
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.82"
 license = "MIT"
 repository = "https://github.com/thepartly/gatehouse"
 description = "An in-process authorization engine for Rust with composable policies and request-scoped fact loading."
-include = ["src/**", "tests/**", "examples/**", "benches/**", "Cargo.toml", "Cargo.lock", "README.md", "MIGRATION.md", "CHANGELOG.md", "LICENSE", ".github/logo.svg"]
+include = ["src/**/*.rs", "tests/**/*.rs", "examples/**/*.rs", "benches/**/*.rs", "benches/README.md", "Cargo.toml", "Cargo.lock", "README.md", "MIGRATION.md", "CHANGELOG.md", "LICENSE", ".github/logo.svg"]
 
 [dependencies]
 tracing = { version = "0.1", optional = true }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,195 +1,233 @@
-# Migrating from 0.5 to 0.6
+# Migrating from 0.5.1 to the 0.6 prerelease
 
-Gatehouse 0.6 adds a public `error_kind` field to `FactProvenance`. Code using
-`FactProvenance::new(...)` needs no change, but direct struct literals must
-initialize the new field:
+This guide describes the unreleased 0.6 API, including typed grant and veto
+capabilities. The intended first prerelease is `0.6.0-alpha.1`; it is not yet
+published. Rust 1.82 remains the minimum supported compiler. The historical
+0.4 → 0.5 guide follows at the end and describes that older API only.
 
-```rust,ignore
-FactProvenance {
-    fact_name: "membership",
-    key: "Member(42)".to_string(),
-    outcome: FactOutcome::Found,
-    detail: None,
-    error_kind: None,
+## Separate grants from vetoes
+
+`Policy<D>::evaluate` now returns `GrantResult`, and `evaluate_batch` returns
+`Vec<GrantResult>`. These results can grant, abstain, or be indeterminate;
+they cannot veto. Existing grant policies generally need only to change their
+return type and replace `PolicyEvalResult` constructors with `GrantResult`
+constructors. Context helpers (`ctx.grant`, `ctx.not_applicable`, and
+`ctx.indeterminate`) already return the correct type.
+
+Veto rules implement `VetoPolicy<D>` and return `VetoResult`. Use
+`ctx.forbid`, `ctx.pass`, or `ctx.veto_indeterminate`. Register them with
+`checker.add_veto(...)`. A passing veto never grants access. `Effect`,
+`Policy::effect`, `add_forbid_policy`, and `PolicyBuilder::forbid` are removed.
+For predicates, replace `.forbid().build()` with `.build_veto()`:
+
+```rust
+use gatehouse::*;
+
+struct Account { suspended: bool }
+struct Accounts;
+impl PolicyDomain for Accounts {
+    type Subject = Account;
+    type Action = ();
+    type Resource = ();
+    type Context = ();
+}
+
+let mut checker = PermissionChecker::<Accounts>::new();
+checker.add_policy(PolicyBuilder::<Accounts>::new("Member").build());
+checker.add_veto(
+    PolicyBuilder::<Accounts>::new("Suspended")
+        .subjects(|account| account.suspended)
+        .build_veto(),
+);
+# tokio_test::block_on(async {
+let session = EvaluationSession::empty();
+let evaluation = checker
+    .bind(&session, &Account { suspended: true }, &(), &())
+    .check(&()).await;
+evaluation.assert_forbidden_by("Suspended");
+# });
+```
+
+For a custom rule that previously both granted and vetoed, split it into
+separate grant and veto policies and register both. Share backend inputs
+through a request-scoped fact session. The type checker now rejects a grant
+policy returning a veto, rather than relying on a correctly declared effect.
+
+## Composition and delegation
+
+`PolicyExt::and`, `or`, and `not` accept grant policies only. For a local
+exclusion, use `grant.and(blocked.not())`, where `blocked` is an ordinary
+predicate grant. A veto cannot be embedded in this expression.
+
+Use `AllOfVeto` / `VetoPolicyExt::all_of` when every child must veto to block,
+and `AnyOfVeto` / `VetoPolicyExt::any_of` when any child veto should block.
+A definite pass settles an all-of veto; a definite veto settles an any-of
+veto. Otherwise uncertainty remains indeterminate. There is no veto negation.
+Dynamic policy combinators reject empty collections.
+
+Custom grant result composition uses `GrantResult::all` / `any`. Empty
+result collections abstain. Their aggregate decisions are computed by the
+constructors; compose veto policies with `AllOfVeto` / `AnyOfVeto`. `PolicyEvalResult`
+remains the inspectable audit tree, including `Combined { decision,
+provenance, children, .. }`; policies cannot return it or convert an arbitrary
+raw tree into an authority-bearing result. Use `result.trace()` to inspect
+and `PolicyResult::into_trace()` to consume a typed result into its audit tree.
+
+Register a `DelegatingPolicy` with **`checker.add_delegate(delegate)`**, not
+`add_policy`. That one call installs both capabilities atomically. Child veto
+uncertainty blocks parent grants; a child grant failure does not block an
+independent parent grant after the child's vetoes pass. Each child capability
+phase runs at most once for each parent evaluation; delegation retains batch
+execution and nested evidence.
+
+## Preserve outages at application boundaries
+
+`AccessEvaluation` has three outcomes: `Granted`, `Denied`, and
+`Indeterminate`. A definite veto wins over uncertainty. An unresolved veto
+blocks grants. A failed grant policy can be superseded by an independent
+grant; without a grant, its failure makes the evaluation indeterminate.
+
+Replace reason-only `to_result(...)` conversion or blanket 403 responses with
+`into_result()` and classify `AccessError`:
+
+```rust
+use gatehouse::{AccessError, AccessEvaluation, EvalTrace};
+
+fn status(evaluation: AccessEvaluation) -> u16 {
+    match evaluation.into_result() {
+        Ok(()) => 200,
+        Err(AccessError::Denied { .. }) => 403,
+        Err(_) => 503,
+    }
+}
+assert_eq!(status(AccessEvaluation::Indeterminate {
+    reason: "authorization input unavailable".into(),
+    trace: EvalTrace::new(),
+}), 503);
+```
+
+`AccessError` retains the full trace and exposes `fact_load_errors()` for
+structured classification. Applications can implement `From<AccessError>`
+for their own error type and then use `check(...).await.into_result()?`.
+Inspect `FactProvenance::error_kind` to distinguish backend failures,
+unregistered sources, contract violations, and cancelled loaders. Keep
+trace details in internal diagnostics rather than HTTP response bodies.
+
+For complete lists, migrate:
+
+| Previous call | Strict replacement |
+| --- | --- |
+| `filter(resources).await` | `try_filter(resources).await?` |
+| `filter_by(rows, projection).await` | `try_filter_by(rows, projection).await?` |
+| `lookup_page(...).await?` | `try_lookup_page(...).await?` |
+
+Strict filtering excludes definite denials but returns `FilterError<Item>`
+if any final decision is indeterminate. The error owns **all** original items
+and evaluations in input order; `indeterminate()` selects unresolved items.
+A grant that supersedes an irrelevant failure succeeds normally. No partial
+list is returned as success.
+
+`try_lookup_page` returns `LookupAuthorizedError<LookupErr, HydrateErr,
+Resource>`. Its `Evaluation` variant retains hydrated resources and their
+decisions; source, hydration, and contract errors remain distinct variants.
+An authorization failure returns no next cursor: retry the same input cursor
+with a fresh session after recovery. Previously returned pages cannot be
+retracted, so an endpoint requiring an atomic multi-page response must collect
+all pages before sending it.
+
+The original `filter`, `filter_by`, and `lookup_page` remain deliberately
+lossy: they exclude both denials and indeterminate items. The old `to_result`
+also merges both outcomes into one reason-only error callback.
+`denied_due_to_fact_load_error()` is deprecated; it detects any error in the
+trace, which may be irrelevant to the final decision.
+
+## Record consulted facts
+
+Use `ctx.fact(key)` / `ctx.facts(keys)` instead of raw session loads. Batch
+policies use `ctx.facts_by(key_of)` or `ctx.fact(shared_key)`. These APIs load
+through the session and record successful, missing, and failed facts. The
+checker and built-in combinators attach the recorded evidence automatically.
+
+```rust
+use async_trait::async_trait;
+use gatehouse::*;
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct Membership(u64);
+impl FactKey for Membership {
+    type Value = bool;
+    const NAME: &'static str = "membership";
+}
+struct Documents;
+impl PolicyDomain for Documents {
+    type Subject = u64;
+    type Action = ();
+    type Resource = ();
+    type Context = ();
+}
+struct Member;
+#[async_trait]
+impl Policy<Documents> for Member {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Documents>) -> GrantResult {
+        match ctx.fact(Membership(*ctx.subject)).await {
+            FactLoadResult::Found(true) => ctx.grant("member"),
+            _ => ctx.not_applicable("membership not established"),
+        }
+    }
+    fn policy_type(&self) -> Cow<'static, str> { "Member".into() }
 }
 ```
 
-When provenance comes from a fact load, prefer
-`FactProvenance::from_load_result(...)`; it records the outcome, diagnostic
-detail, and structured `FactLoadErrorKind` together.
+A recorded failure upgrades abstention or veto pass to `Indeterminate`.
+Decisive grants and vetoes retain their decisions even if an optional recorded
+load failed. This rule is the same for leaf and aggregate results. `Combined`
+now stores its own provenance; child evidence remains on child nodes. There
+are no synthetic failure children and no shape-dependent loss of evidence.
 
-## First-class `Indeterminate` decisions
+When invoking a policy directly, call `ctx.finish(result)` or
+`batch_ctx.finish(results)`. Construct contexts with `EvalCtx::new` /
+`BatchEvalCtx::new`; their recorders and session fields are private.
+`ctx.session()` remains an explicit non-recording escape hatch. Use
+`ctx.record(FactProvenance::from_load_result(...))` for externally loaded facts.
 
-0.6 makes "the policy could not be evaluated" a structural outcome instead of
-a convention over provenance:
+Other source and behavior changes:
 
-- `PolicyEvalResult` gains an `Indeterminate` leaf variant (constructors
-  `PolicyEvalResult::indeterminate` / `indeterminate_with_facts`, plus
-  `ctx.indeterminate(...)` inside policy bodies).
-- Every node now carries a four-valued `Decision`, exposed via
-  `PolicyEvalResult::decision()`.
-- `AccessEvaluation` gains an `Indeterminate` variant, with
-  `is_indeterminate()` and `indeterminate_reason()`.
+- `FactKey` requires `Debug` and has a default `render()` for audit keys.
+  `RelationshipQuery` requires `Debug` on IDs and relations, plus `Display`
+  on the relation. Override `render()` to control diagnostic key text.
+- `FactProvenance` gains `error_kind`. Add `error_kind: None` to old struct
+  literals, or prefer `from_load_result`. `new` produces unclassified evidence.
+- `RebacPolicy` returns indeterminate for failed loads. `Missing` and
+  `Found(false)` still abstain. Backend detail stays in provenance.
+- Wrong-length policy batches produce indeterminate results. Veto failures
+  block grants; grant failures can be superseded by a later grant.
+- `NotPolicy` preserves uncertainty, including explicit failed-load evidence
+  on an abstaining result. Never disguise an unrecorded failure as abstention.
+- `assert_denied()` no longer accepts indeterminate evaluations. Use
+  `assert_indeterminate()` for outage tests.
+- Serialized audit nodes gain `decision` and aggregate `provenance` fields;
+  update consumers that previously expected `Combined.outcome`.
 
-### `Combined.outcome` is now `Combined.decision`
+## Optional instrumentation
 
-Code that constructed or matched `PolicyEvalResult::Combined` must switch
-from the boolean to the `Decision` enum:
+`tracing` is a default-enabled Cargo feature. Set `default-features = false`
+to remove tracing instrumentation and its dependency. Decisions, returned
+`EvalTrace`, and fact provenance remain available and have the same semantics;
+telemetry spans, security events, and contract warnings are absent. `serde`
+is independent and can be enabled without tracing.
 
-```rust,ignore
-// Before
-PolicyEvalResult::Combined { policy_type, operation, children, outcome: true }
+Before adopting the prerelease, run custom policy and batch tests, inject fact
+backend failures into single and list endpoints, and check every wildcard
+match on `AccessEvaluation`. Create a fresh session for retries and each
+reauthorization pass so cached failures or stale permissions are not reused.
 
-// After
-PolicyEvalResult::Combined { policy_type, operation, children, decision: Decision::Grant }
-```
+---
 
-Custom combinators must keep `decision` consistent with their children — in
-particular, never report `Decision::Grant` while a `Forbidden` leaf survives
-in `children`. (`is_forbidden()` still runs a recursive leaf scan as a
-fail-closed backstop, so an inconsistent node is treated as forbidding, but
-do not rely on that.)
+# Historical: migrating from 0.4 to 0.5
 
-### HTTP mapping
-
-The 403-vs-5xx split is now structural rather than provenance-scraping:
-
-```rust,ignore
-if evaluation.is_granted() {
-    // 200
-} else if evaluation.forbidden_by().is_some() {
-    // 403: active veto
-} else if evaluation.is_indeterminate() {
-    // 503: authorization inputs unavailable — inspect
-    // evaluation.fact_load_errors() / FactProvenance::error_kind
-} else {
-    // 403: ordinary denial
-}
-```
-
-`denied_due_to_fact_load_error()` remains as the coarser any-error-in-trace
-scan for policies that still record failed loads on `NotApplicable` results.
-
-## Recording evaluation contexts
-
-Fact provenance is no longer opt-in. `EvalCtx` owns a recorder, and fact
-access goes through the context:
-
-```rust,ignore
-// Before: six lines of ceremony per fact, silently wrong if skipped.
-let key = IsMember(ctx.subject.id);
-let result = ctx.session.get(key.clone()).await;
-let provenance = vec![FactProvenance::from_load_result(
-    IsMember::NAME,
-    format!("{key:?}"),
-    &result,
-)];
-match result {
-    FactLoadResult::Found(true) => ctx.grant_with_facts("is a member", provenance),
-    _ => ctx.not_applicable_with_facts("not a member", provenance),
-}
-
-// After: recording is a side effect of the load; the helpers attach it.
-match ctx.fact(IsMember(ctx.subject.id)).await {
-    FactLoadResult::Found(true) => ctx.grant("is a member"),
-    _ => ctx.not_applicable("not a member"),
-}
-```
-
-Batch policies use `ctx.facts_by(|resource| Key(...))` for one key per item
-(one deduplicated `get_many`, provenance recorded against the originating
-item) and `ctx.fact(key)` for a per-subject fact shared by every item.
-
-Mechanical changes:
-
-- `EvalCtx` / `BatchEvalCtx` can no longer be built with struct literals.
-  Use `EvalCtx::new(session, subject, action, resource, context,
-  policy_type)` and `BatchEvalCtx::new(session, subject, action, context,
-  items, policy_type)` — typically only in policy unit tests and custom
-  combinators.
-- `ctx.session` is now a method: `ctx.session()`. Loads made directly on
-  the session are invisible to recording; treat it as an escape hatch.
-- Callers that invoke `Policy::evaluate` / `Policy::evaluate_batch`
-  directly (tests, custom combinators) should pass the results through
-  `ctx.finish(result)` / `batch_ctx.finish(results)` so facts a policy
-  recorded but did not attach still reach the trace. The checker and the
-  built-in combinators do this for you.
-- `FactKey` gains a `fmt::Debug` supertrait and a defaulted
-  `render(&self) -> String` (the provenance key string, defaulting to the
-  `Debug` representation). Every practical key already derives `Debug`;
-  override `render` when the key has an established audit form.
-  `RelationshipQuery` does exactly that, so its recorded key string keeps
-  the pre-0.6 `subject -[relation]-> resource` form unchanged.
-  `RebacPolicy` consequently requires `Relation: fmt::Debug` in addition to
-  `fmt::Display`.
-- The `FactKey` impl for `RelationshipQuery` itself now requires
-  `Relation: fmt::Display` (its `render` override uses it) and `fmt::Debug`
-  on all three id types. Policies that build `RelationshipQuery` keys and
-  load them directly — without `RebacPolicy`, which always required
-  `Display` — need a `Display` impl on relation types that only derived
-  `Debug`.
-- Loading a fact through some other loader? Record it explicitly:
-  `ctx.record(FactProvenance::from_load_result(NAME, key_repr, &result))`.
-- The `*_with_facts` helpers remain for provenance computed from something
-  other than a context load, and now *append* to whatever was recorded.
-
-Because the context witnesses every recorded load,
-`ctx.not_applicable(...)` after a failed load now returns an
-`Indeterminate` result instead of silently looking like an ordinary
-non-match — the 403-vs-503 signal no longer depends on the policy author
-remembering `*_with_facts`.
-
-### Behavior changes to audit
-
-- `filter`, `filter_by`, and `lookup_page` exclude indeterminate items exactly
-  like denials and return a shorter (possibly empty) list inside `Ok`. List
-  endpoints that must distinguish an authorization-data outage from "no rows
-  are authorized" should use `evaluate` / `evaluate_by` and inspect
-  `is_indeterminate()` for each item instead.
-- `RebacPolicy` now returns `Indeterminate` when a relationship fact **load
-  fails** (backend error, unregistered source, source contract violation).
-  A checker that previously answered `Denied` for those cases now answers
-  `AccessEvaluation::Indeterminate`. `Found(false)` and `Missing` are still
-  ordinary non-grants. If your HTTP layer treated every non-grant as 403,
-  add an `Indeterminate` branch (or keep treating it as a denial — it is
-  still fail-closed and `to_result` still maps it to an error).
-- A policy whose `evaluate_batch` returns the wrong number of results now
-  fails closed as `Indeterminate` instead of a plain denial. Evaluation
-  continues under the normal `Indeterminate` rules, so a later definite
-  forbid still wins and a later grant is not suppressed by a malformed
-  allow-only policy.
-- An indeterminate veto-capable policy blocks sibling grants; an
-  indeterminate allow-only policy does not, but with no grant the checker
-  returns `Indeterminate` instead of `"All policies denied access"`.
-- `NotPolicy` fail-closes a `NotApplicable` leaf that carries explicit
-  `FactOutcome::Error` provenance as `Indeterminate` instead of inverting it
-  to a grant. A raw `ctx.session()` load remains invisible; do not return
-  `NotApplicable` after an unrecorded failure inside a negated policy.
-- A custom policy that records facts and returns `Combined` now preserves any
-  failed-load provenance on a synthetic `Indeterminate` child. Unless the
-  aggregate already forbids, its decision becomes `Indeterminate`; previously
-  the recorded failures were dropped because `Combined` has no provenance
-  field.
-- `RebacPolicy` no longer copies raw `FactLoadError` display text into its
-  policy reason (and therefore the top-level indeterminate summary). The
-  reason contains a stable failure classification; inspect
-  `FactProvenance::detail` in the trace when backend diagnostics are needed.
-- With the `serde` feature, `Combined` nodes serialize a `decision` field
-  instead of `outcome`, and the new variants appear in serialized traces —
-  update audit-log consumers.
-- Matches on `AccessEvaluation` / `PolicyEvalResult` with wildcard arms keep
-  compiling (`#[non_exhaustive]`), but review them: treating `Indeterminate`
-  as an ordinary denial is safe (fail-closed), just less informative.
-- **Test suites:** `AccessEvaluation::assert_denied` (and the other
-  `assert_*` helpers) now panic on an `Indeterminate` evaluation instead of
-  accepting it as a denial. Downstream tests that asserted a denial on a
-  `RebacPolicy` (or other fact-backed) load failure will start failing in
-  CI — switch them to the new `assert_indeterminate()`.
-- `denied_due_to_fact_load_error()` is deprecated. Use `is_indeterminate()`
-  for the structural 403-vs-5xx split and `fact_load_errors()` to inspect
-  the failed loads; the any-error-in-trace scan will be removed in 0.7.
-
-# Migrating from 0.4 to 0.5
+This section describes the released 0.5 API. Its Effect declarations, raw policy
+results, and mixed combinators are superseded by the 0.6 guide above.
 
 Gatehouse 0.5 intentionally breaks the public API to make the authorization surface smaller and harder to misuse. The main changes are:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,9 +49,12 @@ evaluation.assert_forbidden_by("Suspended");
 ```
 
 For a custom rule that previously both granted and vetoed, split it into
-separate grant and veto policies and register both. Share backend inputs
-through a request-scoped fact session. The type checker now rejects a grant
-policy returning a veto, rather than relying on a correctly declared effect.
+separate grant and veto policies. Register both directly, or put both in a
+child checker and register it once with `add_delegate` to keep the two halves
+atomic. This is the replacement for an `AllowOrForbid` policy. Share backend
+inputs through a request-scoped fact session in either case. The type checker
+now rejects a grant policy returning a veto, rather than relying on a correctly
+declared effect.
 
 ## Composition and delegation
 
@@ -73,8 +76,15 @@ provenance, children, .. }`; policies cannot return it or convert an arbitrary
 raw tree into an authority-bearing result. Use `result.trace()` to inspect
 and `PolicyResult::into_trace()` to consume a typed result into its audit tree.
 
-Register a `DelegatingPolicy` with **`checker.add_delegate(delegate)`**, not
-`add_policy`. That one call installs both capabilities atomically. Child veto
+`DelegatingPolicy` no longer implements `Policy<D>`. Register it with
+**`checker.add_delegate(delegate)`**, not `add_policy`. It also cannot be passed
+to `and`, `or`, `not`, or `AndPolicy::try_new`. There is no direct replacement
+for a delegate inside a grant combinator: compose the grant rules inside the
+child checker and register the child with `add_delegate`, keeping its vetoes
+separate. Review the intended scope of those vetoes, since a delegated veto
+blocks every parent grant path.
+
+That one registration installs both capabilities atomically. Child veto
 uncertainty blocks parent grants; a child grant failure does not block an
 independent parent grant after the child's vetoes pass. Each child capability
 phase runs at most once for each parent evaluation; delegation retains batch
@@ -180,10 +190,16 @@ impl Policy<Documents> for Member {
 ```
 
 A recorded failure upgrades abstention or veto pass to `Indeterminate`.
+This also applies to explicit `*_with_facts` constructors when the result's
+own provenance contains `FactOutcome::Error`; the reason and facts are retained.
 Decisive grants and vetoes retain their decisions even if an optional recorded
 load failed. This rule is the same for leaf and aggregate results. `Combined`
 now stores its own provenance; child evidence remains on child nodes. There
 are no synthetic failure children and no shape-dependent loss of evidence.
+Negation uses the resulting decision, not errors elsewhere in the audit tree:
+`NOT(AND[indeterminate, definite-abstain])` grants because the conjunction is
+definitely unsatisfied. An irrelevant descendant failure does not make that
+settled aggregate uncertain again.
 
 When invoking a policy directly, call `ctx.finish(result)` or
 `batch_ctx.finish(results)`. Construct contexts with `EvalCtx::new` /

--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ An in-process authorization engine for Rust. Gatehouse keeps policy logic in Rus
 ## Features
 
 - **Typed authorization domains**: Define one `PolicyDomain` per authorization domain and keep subject, action, resource, and context types consistent.
-- **Request-bound evaluation**: Bind session, subject, action, and context once, then call `check`, `evaluate`, `evaluate_by`, `filter`, `filter_by`, or `lookup_page`.
+- **Request-bound evaluation**: Bind session, subject, action, and context once, then check one resource or evaluate, strictly filter, and page through resources.
 - **RBAC, ReBAC, and predicate policies**: Use `RbacPolicy`, `RebacPolicy`, or synchronous `PolicyBuilder::when` predicates.
-- **Deny-overrides semantics**: `PolicyBuilder::forbid()` and custom forbid results veto grants, including through combinators and delegation.
+- **Deny-overrides semantics**: `VetoPolicy` and `VetoResult` keep veto authority separate from grant policies; atomic delegation preserves both capabilities.
 - **Batch-safe list endpoints**: Authorize already-loaded resources or enumerate candidate IDs with `LookupSource` and `Hydrator`.
 - **Evaluation traces and telemetry**: Inspect the policies and fact provenance that were actually evaluated.
+
+This README describes the unreleased 0.6 API. For migration from the published 0.5.1 release, see [MIGRATION.md](MIGRATION.md).
+
+## Cargo features
+
+`tracing` is enabled by default and emits spans and security-rule events, including contract-violation warnings. Set `default-features = false` on the dependency to remove instrumentation and its dependency. Decisions, returned evaluation traces, and recorded fact provenance are unchanged; no telemetry events or warnings are emitted in that configuration. The independent `serde` feature enables serialization of public audit types.
 
 ## Quick Start
 
@@ -83,9 +89,9 @@ let bound = checker.bind(&session, &subject, &action, &request_context);
 
 let decision = bound.check(&resource).await;
 let decisions = bound.evaluate(resources.clone()).await;
-let authorized = bound.filter(resources).await;
-let authorized_rows = bound.filter_by(rows, |row| &row.authz_resource).await;
-let page = bound.lookup_page(&lookup, &hydrator, cursor.as_deref(), limit).await?;
+let authorized = bound.try_filter(resources).await?;
+let authorized_rows = bound.try_filter_by(rows, |row| &row.authz_resource).await?;
+let page = bound.try_lookup_page(&lookup, &hydrator, cursor.as_deref(), limit).await?;
 ```
 
 ```mermaid
@@ -100,25 +106,37 @@ flowchart LR
     Policies --> Decision[AccessEvaluation + EvalTrace]
 ```
 
-`BoundEvaluator::evaluate` preserves input order and returns one `AccessEvaluation` per resource. `BoundEvaluator::filter` keeps only granted resources. Use `evaluate_by` and `filter_by` when the caller owns wider rows and authorization should project each row to an embedded resource. The returned values are still the original rows. `BoundEvaluator::lookup_page` is for list endpoints where the application cannot load every possible candidate first; a `LookupSource` enumerates candidate IDs, a `Hydrator` resolves them, and the full policy stack authorizes the hydrated resources.
+`evaluate` / `evaluate_by` preserve input order and return each item with its complete decision. `try_filter` / `try_filter_by` return the original granted items, exclude definite denials, and fail if any final decision is indeterminate. `FilterError<Item>` retains all original items and decisions; its `indeterminate()` iterator selects unresolved items. The older `filter` / `filter_by` helpers intentionally omit outages as well as denials.
 
-## Decision Semantics
+## Decisions and capabilities
 
-- `PermissionChecker` applies fixed deny-overrides semantics: any evaluated result containing `PolicyEvalResult::Forbidden` denies; otherwise the first grant wins.
-- Policies declaring `Effect::Forbid` or `Effect::AllowOrForbid` are evaluated before allow-only policies, so a veto cannot be skipped by grant short-circuiting.
-- If nothing grants, the checker denies with `"All policies denied access"`.
-- An empty checker denies with `"No policies configured"`.
-- `PolicyEvalResult::NotApplicable` means the policy did not grant. `PolicyEvalResult::Forbidden` means the policy actively vetoed.
-- `PolicyEvalResult::Indeterminate` means the policy could not be evaluated because an input it needed (typically a fact load) was unavailable. It never grants. An indeterminate **veto-capable** policy blocks sibling grants (its unresolved potential veto is never short-circuited) and the evaluation surfaces as `AccessEvaluation::Indeterminate`; an observed `Forbidden` still overrides it. An indeterminate **allow-only** policy never blocks a grant, but if nothing grants the evaluation is `Indeterminate` rather than an ordinary denial.
-- `PolicyBuilder` combines configured predicates with AND logic. `PolicyBuilder::forbid()` makes a matching policy forbid; a non-match remains not applicable and does not block.
-- `AndPolicy` and `OrPolicy` evaluate veto-capable children before allow-only children, then short-circuit normally. `NotPolicy` inverts grants and non-grants, but never turns `Forbidden` or `Indeterminate` into a grant.
-- Inside `AndPolicy`, an indeterminate **allow-only** child is outranked by a definite non-grant: the conjunction is definitely unsatisfied, so the result is `NotApplicable` rather than `Indeterminate`. This is deliberate — it is the one place a definite answer settles the aggregate regardless of the unknown — and only holds for allow-only children; an indeterminate veto-capable child always taints the conjunction because it might have forbidden.
-- `Forbidden` propagates through `AndPolicy`, `OrPolicy`, `NotPolicy`, and `DelegatingPolicy`.
-- `not()` does not neutralize a veto: `admin.or(blocked.not())` still denies if `blocked` returns `Forbidden`. For "grant unless blocked", make `blocked` an allow-only predicate and wrap that in `not()`, or register a direct forbid policy when the block should be global.
+`Policy<D>` returns `GrantResult`: grant, abstention, or indeterminate. `VetoPolicy<D>` returns `VetoResult`: veto, pass, or indeterminate. Register them with `add_policy` and `add_veto`, respectively. Typed results prevent a grant policy from accidentally returning veto authority or a veto policy from granting access.
 
-Denials from `AccessEvaluation` are summary-level. Use `AccessEvaluation::display_trace()` or the attached `EvalTrace` to inspect individual policy reasons and fact provenance. Use `AccessEvaluation::is_indeterminate()` to distinguish infrastructure failure from an ordinary denial (the natural 403-vs-503 split — authorization remains fail-closed either way) and `fact_load_errors()` to classify the failed loads via `FactProvenance::error_kind`. `RebacPolicy` keeps raw backend error text out of summary and policy reasons; diagnostics remain in `FactProvenance::detail` inside the trace. The older `denied_due_to_fact_load_error()` any-error-in-trace scan is deprecated in favor of the structural signal.
+The checker first resolves vetoes. A definite veto denies access even if another veto failed. Unresolved veto uncertainty blocks grants. Once vetoes pass, any grant authorizes; a failed grant policy does not defeat an independent grant. If nothing grants, uncertainty yields `AccessEvaluation::Indeterminate`; otherwise access is `Denied`. An empty checker denies access.
 
-Fact-backed policies load through the evaluation context — `ctx.fact(key)` (single) and `ctx.facts_by(key_of)` (batch) — which records each consulted fact as `FactProvenance` and attaches it to the policy's result automatically, so provenance is correct by construction. A failed load reported through `ctx.not_applicable(...)` is upgraded to an indeterminate result rather than silently looking like an ordinary non-match. `ctx.session()` remains as an escape hatch for loads that must bypass recording, and `FactProvenance::from_load_result(...)` + `ctx.record(...)` cover facts loaded outside the context. The provenance constructor maps `Found`/`Missing`/`Error`, includes diagnostic error detail, and preserves a machine-readable `FactLoadErrorKind` in `FactProvenance::error_kind`.
+At application boundaries, use `evaluation.into_result()`. It returns `Ok(())`, `AccessError::Denied { reason, trace }`, or `AccessError::Indeterminate { reason, trace }`. Map denial to a forbidden response and indeterminate to an appropriate service error. Both the evaluation and typed error expose `fact_load_errors()` with structured `FactProvenance::error_kind`. An error recorded on an otherwise successful decision need not be its cause; classify the final decision first.
+
+```rust
+use gatehouse::{AccessError, AccessEvaluation, EvalTrace};
+
+fn http_status(evaluation: AccessEvaluation) -> u16 {
+    match evaluation.into_result() {
+        Ok(()) => 200,
+        Err(AccessError::Denied { .. }) => 403,
+        Err(_) => 503,
+    }
+}
+assert_eq!(http_status(AccessEvaluation::Indeterminate {
+    reason: "authorization input unavailable".into(),
+    trace: EvalTrace::new(),
+}), 503);
+```
+
+`PolicyEvalResult` is the audit tree, accessed through `GrantResult::trace`, `VetoResult::trace`, or the final `EvalTrace`. It is not a policy return type. Its public nodes support inspection and serialization; arbitrary raw trees cannot be converted into typed policy results.
+
+Fact-backed policies use `ctx.fact(key)` / `ctx.facts(keys)` and batch `ctx.facts_by(key_of)` / `ctx.fact(shared_key)`. These record successful, missing, and failed facts automatically. Recorded failures upgrade abstention or veto pass to indeterminate; decisive grants and vetoes remain decisive. Aggregate nodes retain their own provenance, with child evidence on child nodes. The same rules apply to leaves and aggregates.
+
+When calling policies directly, finish their contexts with `ctx.finish(result)` or `batch_ctx.finish(results)` to attach remaining evidence. The checker and built-in combinators do this for you. `ctx.session()` bypasses recording; `ctx.record(FactProvenance::from_load_result(...))` records externally loaded facts. Backend diagnostics belong in internal traces, not client-facing response bodies.
 
 ## Policy Domains
 
@@ -156,19 +174,17 @@ let checker = PermissionChecker::<Documents>::new();
 Use `PolicyBuilder` for synchronous predicate logic:
 
 ```rust,ignore
-// String literals are zero-allocation on the trace path
-// (new takes impl Into<Cow<'static, str>>).
 let suspended_account = PolicyBuilder::<Documents>::new("SuspendedAccount")
     .when(|user, _action, _doc, _ctx| user.is_suspended)
-    .forbid()
-    .build();
+    .build_veto();
+checker.add_veto(suspended_account);
 ```
 
-Reach for a direct `Policy<D>` implementation when a rule needs async work, custom batching, custom telemetry metadata, or hand-written forbid behavior.
+Implement `Policy<D>` for asynchronous grants or `VetoPolicy<D>` for asynchronous vetoes. Both support custom batching and security-rule metadata.
 
 ```rust
 use async_trait::async_trait;
-use gatehouse::{EvalCtx, Policy, PolicyDomain, PolicyEvalResult};
+use gatehouse::{EvalCtx, Policy, PolicyDomain, GrantResult};
 use std::borrow::Cow;
 
 # #[derive(Debug, Clone)]
@@ -188,7 +204,7 @@ struct OwnerPolicy;
 
 #[async_trait]
 impl Policy<Documents> for OwnerPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Documents>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Documents>) -> GrantResult {
         if ctx.subject.id == ctx.resource.owner_id {
             ctx.grant("subject owns the document")
         } else {
@@ -206,7 +222,7 @@ impl Policy<Documents> for OwnerPolicy {
 
 - `RbacPolicy`: role-based access control. Grants when at least one required role for `(action, resource)` is present in the subject's roles.
 - `RebacPolicy`: relationship-based access control. Extracts subject/resource IDs, builds `RelationshipQuery` keys, and grants when the request session loads `Found(true)` from a registered `FactSource`.
-- `DelegatingPolicy`: maps inputs into another `PolicyDomain` and delegates to a child `PermissionChecker` while preserving batching and trace shape.
+- `DelegatingPolicy`: maps inputs into another `PolicyDomain` and delegates to a child `PermissionChecker`. Register it once with `add_delegate` to install both grant and veto capabilities. Child grant failures do not become veto failures; batching and nested evidence are preserved.
 
 Use `PolicyBuilder::when` for attribute-style predicates that compare subject, action, resource, and context in one closure.
 
@@ -221,9 +237,11 @@ let rule = is_editor.and(not_locked.not()).or(admin_override);
 checker.add_policy(rule);
 ```
 
-`AndPolicy::try_new`, `OrPolicy::try_new`, and `NotPolicy::new` remain available when constructing policies from dynamic collections.
+`AndPolicy::try_new` and `OrPolicy::try_new` build grant combinators from nonempty dynamic collections. `not()` inverts grants and abstentions while retaining uncertainty. For a local exclusion, use `grant.and(blocked.not())` with an ordinary predicate grant for `blocked`.
 
-`forbid()` creates a global veto, not a local negative predicate. In particular, `grant.and(forbid_only)` can never grant because the forbid-only child never satisfies AND's "all children grant" rule. For a local exclusion, build the blocked condition as an ordinary allow-style predicate and compose `grant.and(blocked.not())`.
+Vetoes cannot be mixed into grant combinators. Use `AllOfVeto` / `VetoPolicyExt::all_of` when every child must veto, or `AnyOfVeto` / `VetoPolicyExt::any_of` when any child veto suffices. In an all-of veto, a definite pass settles the result; in an any-of veto, a definite veto settles it. Otherwise uncertainty remains indeterminate. There is no veto negation.
+
+For custom grant aggregates, `GrantResult::all` / `any` compute the decision from typed children. Empty result collections abstain; policy combinators reject empty collections.
 
 ## Request-Scoped Facts
 
@@ -239,20 +257,20 @@ flowchart LR
     Backend --> Result
 ```
 
-`RebacPolicy` is the built-in fact-backed policy. Missing sources, missing facts, backend errors, and source contract violations fail closed to denied ReBAC decisions.
+`RebacPolicy` is the built-in fact-backed policy. `Found(false)` and `Missing` abstain; missing sources, backend errors, and source contract violations produce indeterminate decisions.
 
 Use typed relation enums when the domain has a fixed relation set, even if the backing store uses strings. The `FactSource` owns the backend boundary and can convert `Relation::Viewer` to `"viewer"` when binding SQL parameters.
 
 ## List Endpoints
 
-For lists where the application already has candidate resources, use `BoundEvaluator::filter`:
+For lists where the application already has candidate resources, use `BoundEvaluator::try_filter`:
 
 ```rust,ignore
 let session = registry.session();
 let visible_posts = checker
     .bind(&session, &user, &PostAction::View, &request_context)
-    .filter(posts)
-    .await;
+    .try_filter(posts)
+    .await?;
 ```
 
 If each item is a wide row and the authorization resource is a projection, use the extractor variants:
@@ -260,8 +278,8 @@ If each item is a wide row and the authorization resource is a projection, use t
 ```rust,ignore
 let visible_rows = checker
     .bind(&session, &user, &InvoiceAction::View, &request_context)
-    .filter_by(rows, |row| &row.authz_resource)
-    .await;
+    .try_filter_by(rows, |row| &row.authz_resource)
+    .await?;
 ```
 
 For lists where the candidate set is too large to load first, implement `LookupSource<Domain>` and `Hydrator<Id>`:
@@ -269,17 +287,19 @@ For lists where the candidate set is too large to load first, implement `LookupS
 ```rust,ignore
 let page = checker
     .bind(&session, &user, &PostAction::View, &request_context)
-    .lookup_page(&lookup, &hydrator, cursor.as_deref(), limit)
+    .try_lookup_page(&lookup, &hydrator, cursor.as_deref(), limit)
     .await?;
 ```
 
 A `LookupSource` must enumerate a superset of every resource that any policy could grant for the bound subject/action/context. Lookup narrows candidates; it does not replace the policy stack.
 
+`try_lookup_page` distinguishes source errors, hydration errors, contract violations, and indeterminate evaluations. An evaluation error retains every hydrated resource with its decision and returns no next cursor; retry the same input cursor with a fresh session after recovery. It never returns an incomplete authorized page as success because of an authorization outage. An atomic response spanning several pages must collect them before sending any output.
+
 ## Long-Lived Streams
 
 `EvaluationSession` caches are scoped to one authorization pass. For SSE, WebSocket, and other long-lived streams, do not keep one fact-backed session for the stream lifetime.
 
-If your product contract authorizes once at stream open, create a fresh session, compute the visible ID set with `filter` / `filter_by`, drop the session, and only emit frames for that set. If the stream must observe mid-stream permission revocation, run periodic reauthorization with a fresh `registry.session()` each tick and re-bind the checker for that pass.
+If your product contract authorizes once at stream open, create a fresh session, compute the visible ID set with `try_filter` / `try_filter_by`, drop the session, and only emit frames for that set. If the stream must observe mid-stream permission revocation, run periodic reauthorization with a fresh `registry.session()` each tick and re-bind the checker for that pass.
 
 ## Tracing And Telemetry
 
@@ -322,7 +342,7 @@ Examples to start with:
 - `rbac_policy`: basic role-based access control.
 - `policy_builder`: attribute-style custom policies.
 - `combinator_policy`: fluent `and` / `or` / `not` composition.
-- `deny_override`: global veto policies with `PolicyBuilder::forbid()`.
+- `deny_override`: global veto policies with `PolicyBuilder::build_veto()`.
 - `delegating_policy`: cross-domain checks with `DelegatingPolicy`.
 - `mfa_freshness_context`: request-scoped context inputs.
 - `rebac_policy`: relationship checks through `FactSource`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An in-process authorization engine for Rust. Gatehouse keeps policy logic in Rus
 - **Batch-safe list endpoints**: Authorize already-loaded resources or enumerate candidate IDs with `LookupSource` and `Hydrator`.
 - **Evaluation traces and telemetry**: Inspect the policies and fact provenance that were actually evaluated.
 
-This README describes the unreleased 0.6 API. For migration from the published 0.5.1 release, see [MIGRATION.md](MIGRATION.md).
+Upgrading from 0.5? See [MIGRATION.md](MIGRATION.md).
 
 ## Cargo features
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,7 +2,7 @@
 
 Criterion benches live in `benches/permission_checker.rs`. Run the full suite with `cargo bench`, or one group with `cargo bench --bench permission_checker -- <group_name>`. Use `--quick` for a fast smoke check that skips Criterion's full statistical analysis.
 
-Each bench protects a load-bearing property of the public API. Adding a regression here is the cheapest signal that something we promise in `CHANGELOG.md` or rustdoc no longer holds. The catalogue below names the property each bench locks in, so a future contributor can decide whether a change is expected to move a number.
+Each benchmark measures a property of the public API. The catalogue below describes the intended scaling behavior so contributors can interpret changes in measured timings. A successful smoke run establishes that the workload executes, not that its performance is unchanged.
 
 ## `permission_checker_bound_check`
 
@@ -28,7 +28,7 @@ This group injects a fixed async delay per source call so the gap between per-it
 - **`independent_same_keys_4_tasks / N`** — four parallel tasks each building their own session and requesting the same `N` keys. Models the worst case where coalescing across tasks doesn't help.
 - **`coalesced_same_keys_4_tasks / N`** — four parallel tasks sharing one session, requesting the same `N` keys. Protects: when keys collide, the second loader joins the in-flight load instead of issuing a redundant call.
 
-The expected gap between `naive_per_item_sessions` and `checker_batch_one_session` widens with `N` (the naive shape grows linearly with the per-call overhead; the batched shape grows mostly with the source's `load_many` work). Keep that gap as a CI smoke check, not just a property test.
+The expected gap between `naive_per_item_sessions` and `checker_batch_one_session` widens with `N` (the naive shape grows linearly with the per-call overhead; the batched shape grows mostly with the source's `load_many` work). Compare that gap in measured runs; the CI smoke check does not assert it.
 
 ## `parallel_in_ram_fact_state`
 
@@ -55,3 +55,61 @@ Current (`cargo bench --bench permission_checker -- policy_builder_subject_only_
 | 100 | ~10.31 µs | ~13.07 µs | ~8.30 µs |
 
 At batch size 1 the shortcut and the serial default are a wash — there is nothing to amortize across a single item. From N=10 the shortcut pulls ahead, winning ~11–21% over the same shape through the serial default and growing with batch size. Static-name hand-written policies remain fastest; adopters who can use a `'static` name table should.
+
+## `recording`
+
+`benches/recording.rs` measures successful and failed fact loads through the raw session, recording contexts, and the checker. Cache-hit cases reuse a warmed session; batch cases create a fresh session and evaluate 100, 1,000, or 10,000 distinct resources. The recorded batch policy overrides `evaluate_batch` and uses `facts_by`, so these measurements include provenance construction and per-item decision traces without introducing per-item source calls.
+
+Compare builds with and without instrumentation using:
+
+```bash
+cargo bench --bench recording -- --save-baseline tracing
+cargo bench --bench recording --no-default-features -- --save-baseline disabled
+```
+
+The tracing build measures no subscriber and a registry-only subscriber. The latter tracks spans but performs no event formatting or I/O; it is not an estimate of production logging cost. Returned provenance remains enabled in both builds.
+
+CI runs benchmarks as smoke tests only. It does not compare timing baselines or enforce performance thresholds. Use Criterion measurements on a quiet, consistent host to assess regressions; use deterministic source-call-count contract tests to enforce batching behavior.
+
+### Pre-typed recording measurements
+
+Measured 2026-09-05 on Linux x86_64, Ryzen 9 5900X, Rust 1.95.0, upstream `878b4df` plus the optional-tracing change. Each run used 20 samples, 1 second warm-up, and 1 second measurement (`--sample-size 20 --measurement-time 1 --warm-up-time 1`). Other development builds were active on this host, so these wide confidence intervals are an exploratory baseline, not evidence of a tracing speedup or a release regression threshold. Rerun on an idle host before drawing performance conclusions.
+
+Criterion's reported time intervals:
+
+| Workload | Tracing, no subscriber | Tracing disabled |
+|---|---:|---:|
+| Raw cached fact, found | 255–288 ns | 273–344 ns |
+| Recorded cached fact, found | 530–886 ns | 417–550 ns |
+| Recorded cached fact, error | 673–1,004 ns | 403–548 ns |
+| Checker cached fact, found | 1.49–2.07 µs | 0.84–0.94 µs |
+| Batch 1,000, found | 0.96–1.49 ms | 0.54–0.73 ms |
+| Batch 10,000, found | 50.8–67.1 ms | 15.4–19.2 ms |
+| Batch 10,000, error | 21.7–29.8 ms | 11.8–14.8 ms |
+
+The registry-only subscriber measured 1.37–1.45 µs for a cached successful checker evaluation and 1.59–1.72 µs for a cached failure. These overlap or undercut no-subscriber measurements in this noisy run, reinforcing that these are not controlled subscriber-overhead comparisons. Large-batch scaling deserves a dedicated quiet-host profile; timings here do not establish linear scaling.
+
+
+## Typed scalar evaluation baseline
+
+Measured 2026-09-05 on the same Linux/Ryzen 9 5900X host using Rust 1.95.0, default tracing enabled, no subscriber, 30 samples, 1 second warm-up, and 2 seconds measurement. The original is upstream `878b4df`; the revised implementation uses separate typed grant/veto phases and a scalar evaluation path. The original was rerun immediately after the scalar measurement to check for host-load drift. These are Criterion time intervals, not CI thresholds.
+
+| Single check, trailing grant | Original repeated baseline | Typed scalar evaluator |
+|---|---:|---:|
+| 1 policy | 445–545 ns | 414–434 ns |
+| 4 policies | 1.089–1.289 µs | 824–865 ns |
+| 16 policies | 3.511–4.204 µs | 2.764–2.858 µs |
+| 64 policies | 14.598–17.624 µs | 10.331–11.432 µs |
+
+One-policy all-deny intervals overlap: original 387–440 ns, typed scalar 417–440 ns. An earlier version routed scalar calls through batch vectors and measured 1.385–1.499 µs for a one-policy grant. That regression is removed. Changing host load still prevents a strong speedup claim.
+
+A separate allocation counter used a warmed current-thread runtime/session, static policy names, and a single resource with a trailing grant. The returned evaluation stayed alive until counters were read. Counts include allocation and reallocation requests; requested bytes measure total allocation traffic, not peak live memory.
+
+| Policy count | Original requests / bytes | Typed scalar requests / bytes |
+|---|---:|---:|
+| 1 | 6 / 226 | 7 / 247 |
+| 4 | 21 / 958 | 22 / 979 |
+| 16 | 81 / 3,886 | 82 / 3,907 |
+| 64 | 321 / 15,598 | 322 / 15,619 |
+
+The final scalar path adds one allocation request and 21 requested bytes at these sizes; the discarded vector-based scalar path required 21 requests and 1,289 bytes for one policy. No wall-clock threshold is enforced by CI.

--- a/benches/permission_checker.rs
+++ b/benches/permission_checker.rs
@@ -556,7 +556,7 @@ impl gatehouse::Policy<SubjectOnlyDomain> for ManualSubjectOnlyDynamic {
     async fn evaluate(
         &self,
         ctx: &gatehouse::EvalCtx<'_, SubjectOnlyDomain>,
-    ) -> gatehouse::PolicyEvalResult {
+    ) -> gatehouse::GrantResult {
         if ctx.subject.is_staff {
             ctx.grant("staff")
         } else {
@@ -579,7 +579,7 @@ impl gatehouse::Policy<SubjectOnlyDomain> for ManualSubjectOnlyStatic {
     async fn evaluate(
         &self,
         ctx: &gatehouse::EvalCtx<'_, SubjectOnlyDomain>,
-    ) -> gatehouse::PolicyEvalResult {
+    ) -> gatehouse::GrantResult {
         if ctx.subject.is_staff {
             ctx.grant("staff")
         } else {

--- a/benches/recording.rs
+++ b/benches/recording.rs
@@ -1,0 +1,134 @@
+use async_trait::async_trait;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use gatehouse::{
+    BatchEvalCtx, EvalCtx, FactKey, FactLoadError, FactLoadResult, FactRegistry, FactSource,
+    GrantResult, PermissionChecker, Policy, PolicyDomain,
+};
+use std::borrow::Cow;
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Key(usize);
+impl FactKey for Key {
+    type Value = bool;
+    const NAME: &'static str = "benchmark";
+}
+
+struct Source {
+    fails: bool,
+}
+#[async_trait]
+impl FactSource<Key> for Source {
+    async fn load_many(&self, keys: &[Key]) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|_| {
+                if self.fails {
+                    FactLoadResult::Error(FactLoadError::backend_message("unavailable"))
+                } else {
+                    FactLoadResult::Found(true)
+                }
+            })
+            .collect()
+    }
+}
+struct Domain;
+impl PolicyDomain for Domain {
+    type Subject = ();
+    type Action = ();
+    type Resource = Key;
+    type Context = ();
+}
+struct Recorded;
+#[async_trait]
+impl Policy<Domain> for Recorded {
+    async fn evaluate(&self, context: &EvalCtx<'_, Domain>) -> GrantResult {
+        match context.fact(context.resource.clone()).await {
+            FactLoadResult::Found(true) => context.grant("found"),
+            _ => context.not_applicable("not found"),
+        }
+    }
+    async fn evaluate_batch<'item>(
+        &self,
+        context: &BatchEvalCtx<'item, Domain>,
+    ) -> Vec<GrantResult> {
+        context
+            .facts_by(Clone::clone)
+            .await
+            .into_iter()
+            .map(|result| match result {
+                FactLoadResult::Found(true) => GrantResult::granted("recorded", None),
+                _ => GrantResult::not_applicable("recorded", "not found"),
+            })
+            .collect()
+    }
+    fn policy_type(&self) -> Cow<'static, str> {
+        "recorded".into()
+    }
+}
+
+fn recording(criterion: &mut Criterion) {
+    let runtime = Runtime::new().unwrap();
+    let mut group = criterion.benchmark_group("recording");
+    for fails in [false, true] {
+        let registry = FactRegistry::builder()
+            .with::<Key, _>(Source { fails })
+            .build();
+        let session = registry.session();
+        let _ = runtime.block_on(session.get(Key(0)));
+        let label = if fails { "error" } else { "found" };
+        group.bench_function(format!("raw_cached_{label}"), |bench| {
+            bench.iter(|| black_box(runtime.block_on(session.get(Key(0)))))
+        });
+        group.bench_function(format!("recorded_cached_{label}"), |bench| {
+            bench.iter(|| {
+                let context = EvalCtx::<Domain>::new(&session, &(), &(), &Key(0), &(), "recorded");
+                black_box(runtime.block_on(async {
+                    let result = Recorded.evaluate(&context).await;
+                    context.finish(result)
+                }))
+            })
+        });
+        let mut checker = PermissionChecker::<Domain>::new();
+        checker.add_policy(Recorded);
+        for size in [100, 1000, 10_000] {
+            let resources = (0..size).map(Key).collect::<Vec<_>>();
+            group.bench_with_input(
+                BenchmarkId::new(format!("batch_{label}"), size),
+                &resources,
+                |bench, resources| {
+                    bench.iter(|| {
+                        let session = registry.session();
+                        black_box(
+                            runtime.block_on(
+                                checker
+                                    .bind(&session, &(), &(), &())
+                                    .evaluate(resources.clone()),
+                            ),
+                        )
+                    })
+                },
+            );
+        }
+        group.bench_function(format!("checker_cached_{label}"), |bench| {
+            bench.iter(|| {
+                black_box(runtime.block_on(checker.bind(&session, &(), &(), &()).check(&Key(0))))
+            })
+        });
+        #[cfg(feature = "tracing")]
+        {
+            let subscriber = tracing_subscriber::Registry::default();
+            let _guard = tracing::subscriber::set_default(subscriber);
+            group.bench_function(format!("checker_registry_cached_{label}"), |bench| {
+                bench.iter(|| {
+                    black_box(
+                        runtime.block_on(checker.bind(&session, &(), &(), &()).check(&Key(0))),
+                    )
+                })
+            });
+        }
+    }
+    group.finish();
+}
+criterion_group!(benches, recording);
+criterion_main!(benches);

--- a/examples/actix_web.rs
+++ b/examples/actix_web.rs
@@ -31,7 +31,7 @@
 // Each handler pulls the shared `AppState` from Actix Web's `Data` extractor,
 // builds a request-scoped `EvaluationSession`, and evaluates with
 // `bind(...).check(...)` (single resource) or
-// `bind(...).filter(...)` (the list endpoint).
+// `bind(...).try_filter(...)` (the list endpoint).
 //
 // Note: on denial these handlers echo the evaluation trace back in the HTTP
 // response so you can see the decision from `curl`. That is a demo convenience,
@@ -42,9 +42,8 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use gatehouse::{
-    AccessEvaluation, AndPolicy, EvalTrace, EvaluationSession, FactLoadResult, FactRegistry,
-    FactSource, PermissionChecker, Policy, PolicyBuilder, PolicyDomain, RebacPolicy,
-    RelationshipQuery,
+    AccessError, AndPolicy, EvalTrace, EvaluationSession, FactLoadResult, FactRegistry, FactSource,
+    PermissionChecker, Policy, PolicyBuilder, PolicyDomain, RebacPolicy, RelationshipQuery,
 };
 use serde::Serialize;
 use std::collections::HashSet;
@@ -249,6 +248,17 @@ impl AppState {
         }
     }
 
+    /// Replaces the relationship backend while retaining the demo checker and resources.
+    pub fn with_relationship_source<S: FactSource<PostRelationship> + 'static>(
+        mut self,
+        source: S,
+    ) -> Self {
+        self.fact_registry = FactRegistry::builder()
+            .with::<PostRelationship, _>(source)
+            .build();
+        self
+    }
+
     fn request_session(&self) -> EvaluationSession {
         self.fact_registry.session()
     }
@@ -444,11 +454,17 @@ pub async fn list_posts(
     let context = RequestContext::now();
     let candidates = state.posts.as_ref().clone();
 
-    let visible = state
+    let visible = match state
         .checker
         .bind(&session, &user, &Action::View, &context)
-        .filter(candidates)
-        .await;
+        .try_filter(candidates)
+        .await
+    {
+        Ok(visible) => visible,
+        Err(_) => {
+            return HttpResponse::ServiceUnavailable().body("Authorization temporarily unavailable")
+        }
+    };
 
     let summaries = visible.iter().map(PostSummary::from).collect::<Vec<_>>();
     HttpResponse::Ok().json(summaries)
@@ -469,12 +485,11 @@ pub async fn view_post(
         .bind(&session, &user, &Action::View, &context)
         .check(&post)
         .await
+        .into_result()
     {
-        AccessEvaluation::Granted { .. } => {
-            HttpResponse::Ok().body(format!("Viewing '{}'", post.title))
-        }
-        AccessEvaluation::Denied { reason, trace } => forbidden(&reason, &trace),
-        _ => HttpResponse::Forbidden().body("Access denied"),
+        Ok(()) => HttpResponse::Ok().body(format!("Viewing '{}'", post.title)),
+        Err(AccessError::Denied { reason, trace }) => forbidden(&reason, &trace),
+        Err(_) => HttpResponse::ServiceUnavailable().body("Authorization temporarily unavailable"),
     }
 }
 
@@ -493,10 +508,11 @@ pub async fn edit_post(
         .bind(&session, &user, &Action::Edit, &context)
         .check(&post)
         .await
+        .into_result()
     {
-        AccessEvaluation::Granted { .. } => HttpResponse::Ok().body("Post updated"),
-        AccessEvaluation::Denied { reason, trace } => forbidden(&reason, &trace),
-        _ => HttpResponse::Forbidden().body("Access denied"),
+        Ok(()) => HttpResponse::Ok().body("Post updated"),
+        Err(AccessError::Denied { reason, trace }) => forbidden(&reason, &trace),
+        Err(_) => HttpResponse::ServiceUnavailable().body("Authorization temporarily unavailable"),
     }
 }
 
@@ -515,10 +531,11 @@ pub async fn publish_post(
         .bind(&session, &user, &Action::Publish, &context)
         .check(&post)
         .await
+        .into_result()
     {
-        AccessEvaluation::Granted { .. } => HttpResponse::Ok().body("Post published"),
-        AccessEvaluation::Denied { reason, trace } => forbidden(&reason, &trace),
-        _ => HttpResponse::Forbidden().body("Access denied"),
+        Ok(()) => HttpResponse::Ok().body("Post published"),
+        Err(AccessError::Denied { reason, trace }) => forbidden(&reason, &trace),
+        Err(_) => HttpResponse::ServiceUnavailable().body("Authorization temporarily unavailable"),
     }
 }
 

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -259,6 +259,17 @@ impl AppState {
         }
     }
 
+    /// Replaces the relationship backend while retaining the demo checker and resources.
+    pub fn with_relationship_source<S: FactSource<InvoiceRelationship> + 'static>(
+        mut self,
+        source: S,
+    ) -> Self {
+        self.fact_registry = FactRegistry::builder()
+            .with::<InvoiceRelationship, _>(source)
+            .build();
+        self
+    }
+
     fn request_session(&self) -> EvaluationSession {
         self.fact_registry.session()
     }
@@ -368,7 +379,7 @@ fn invoice_editing_policy() -> Box<dyn Policy<InvoiceDomain>> {
 }
 
 /// (D) Combine the policies into a single `PermissionChecker`. With no
-/// forbid-effect policies registered, deny-overrides reduces to OR semantics:
+/// veto policies registered, deny-overrides reduces to OR semantics:
 /// if any policy grants, access is allowed (and evaluation short-circuits).
 pub fn build_permission_checker() -> PermissionChecker<InvoiceDomain> {
     let mut checker = PermissionChecker::named("InvoiceChecker");
@@ -382,6 +393,17 @@ pub fn build_permission_checker() -> PermissionChecker<InvoiceDomain> {
 // 4) Using in Axum Route Handlers
 // ---------------------------------
 
+fn authorization_error_response(error: AccessError) -> axum::response::Response {
+    match error {
+        AccessError::Denied { .. } => (StatusCode::FORBIDDEN, "Access denied").into_response(),
+        _ => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Authorization temporarily unavailable",
+        )
+            .into_response(),
+    }
+}
+
 pub async fn view_invoice_handler(
     Path(invoice_id): Path<Uuid>,
     State(state): State<AppState>,
@@ -393,20 +415,15 @@ pub async fn view_invoice_handler(
     let session = state.request_session();
     let context = RequestContext::now();
 
-    if state
+    match state
         .checker
         .bind(&session, &user, &Action::View, &context)
         .check(&invoice)
         .await
-        .is_granted()
+        .into_result()
     {
-        (StatusCode::OK, format!("{invoice:?}")).into_response()
-    } else {
-        (
-            StatusCode::FORBIDDEN,
-            "You are not authorized to view this invoice",
-        )
-            .into_response()
+        Ok(()) => (StatusCode::OK, format!("{invoice:?}")).into_response(),
+        Err(error) => authorization_error_response(error),
     }
 }
 
@@ -421,11 +438,22 @@ pub async fn list_invoices_handler(
     // The session is request-scoped: app state owns the source, this request
     // registers it, and the batch authorization call uses it for every invoice
     // — relationship loads are batched and deduplicated.
-    let visible = state
+    let visible = match state
         .checker
         .bind(&session, &user, &Action::View, &context)
-        .filter(candidates)
+        .try_filter(candidates)
         .await
+    {
+        Ok(visible) => visible,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Authorization temporarily unavailable",
+            )
+                .into_response()
+        }
+    };
+    let visible = visible
         .into_iter()
         .map(InvoiceSummary::from)
         .collect::<Vec<_>>();
@@ -443,20 +471,15 @@ pub async fn edit_invoice_handler(
     let session = state.request_session();
     let context = RequestContext::now();
 
-    if state
+    match state
         .checker
         .bind(&session, &user, &Action::Edit, &context)
         .check(&invoice)
         .await
-        .is_granted()
+        .into_result()
     {
-        (StatusCode::OK, "Invoice edited successfully").into_response()
-    } else {
-        (
-            StatusCode::FORBIDDEN,
-            "You are not authorized to edit this invoice",
-        )
-            .into_response()
+        Ok(()) => (StatusCode::OK, "Invoice edited successfully").into_response(),
+        Err(error) => authorization_error_response(error),
     }
 }
 

--- a/examples/combinator_policy.rs
+++ b/examples/combinator_policy.rs
@@ -56,7 +56,7 @@ struct CountingPolicy {
 
 #[async_trait]
 impl Policy<DocumentDomain> for CountingPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> GrantResult {
         // Increment evaluation counter
         self.counter.fetch_add(1, Ordering::SeqCst);
         println!("Evaluating policy: {}", self.name);

--- a/examples/delegating_policy.rs
+++ b/examples/delegating_policy.rs
@@ -18,8 +18,8 @@
 
 use async_trait::async_trait;
 use gatehouse::{
-    DelegatingPolicy, EvalCtx, EvaluationSession, PermissionChecker, Policy, PolicyBuilder,
-    PolicyDomain, PolicyEvalResult,
+    DelegatingPolicy, EvalCtx, EvaluationSession, GrantResult, PermissionChecker, Policy,
+    PolicyBuilder, PolicyDomain,
 };
 use std::borrow::Cow;
 use uuid::Uuid;
@@ -99,7 +99,7 @@ struct AuthorCanEditComment;
 
 #[async_trait]
 impl Policy<CommentDomain> for AuthorCanEditComment {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, CommentDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, CommentDomain>) -> GrantResult {
         if ctx.subject.user_id == ctx.resource.author_id {
             ctx.grant("subject is the comment author")
         } else {
@@ -133,7 +133,7 @@ fn comment_checker() -> PermissionChecker<CommentDomain> {
 
     let mut checker = PermissionChecker::named("CommentChecker");
     checker.add_policy(AuthorCanEditComment);
-    checker.add_policy(inherit_from_document);
+    checker.add_delegate(inherit_from_document);
     checker
 }
 

--- a/examples/deny_override.rs
+++ b/examples/deny_override.rs
@@ -3,17 +3,17 @@
 //! Almost every real authorization system eventually needs a rule that
 //! overrides all the others: a suspended account is locked out regardless of
 //! role, a document under legal hold is frozen even for its owner and for
-//! admins. In gatehouse this is exactly what [`Effect::Forbid`] does: a policy
-//! built with `.forbid()` **forbids** the request when its
+//! admins. In gatehouse this is exactly what [`VetoPolicy`] does: a policy
+//! built with `.build_veto()` **forbids** the request when its
 //! predicate matches, and [`PermissionChecker`] honors a forbid over any
 //! grant from sibling policies — deny-overrides semantics, in the style of
 //! Cedar and AWS IAM.
 //!
-//! The shape is flat: block rules are ordinary policies registered with
-//! `add_policy`, in natural polarity (predicate matches ⇒ forbidden), in any
+//! The shape is flat: block rules are veto policies registered with
+//! `add_veto`, in natural polarity (predicate matches ⇒ forbidden), in any
 //! order. The decision rule is fixed:
 //!
-//! 1. any matching `Effect::Forbid` policy ⇒ **denied** (the trace names it);
+//! 1. any matching `VetoPolicy` policy ⇒ **denied** (the trace names it);
 //! 2. otherwise any granting policy ⇒ **granted**;
 //! 3. otherwise ⇒ **denied** (default deny).
 //!
@@ -29,7 +29,8 @@
 //! ```
 
 use gatehouse::{
-    AndPolicy, EvaluationSession, NotPolicy, PermissionChecker, Policy, PolicyBuilder, PolicyDomain,
+    AndPolicy, EvaluationSession, PermissionChecker, Policy, PolicyBuilder, PolicyDomain,
+    PolicyExt, VetoPolicy,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -86,33 +87,28 @@ fn document_owner() -> DocPolicy {
 // ---- the block rules -----------------------------------------------
 
 /// Account suspension: predicate matches ⇒ the request is forbidden. The
-/// effect travels with the policy, so this reads exactly as it behaves —
-/// no inverted polarity, no special registration call.
-fn account_suspended() -> DocPolicy {
+/// distinct return type requires registration with `add_veto`.
+fn account_suspended() -> Box<dyn VetoPolicy<DocumentDomain>> {
     PolicyBuilder::<DocumentDomain>::new("AccountSuspended")
         .subjects(|user| user.suspended)
-        .forbid()
-        .build()
+        .build_veto()
 }
 
 /// Legal hold: a frozen document is blocked for everyone, owner and admin
 /// included.
-fn legal_hold() -> DocPolicy {
+fn legal_hold() -> Box<dyn VetoPolicy<DocumentDomain>> {
     PolicyBuilder::<DocumentDomain>::new("LegalHold")
         .resources(|document| document.legal_hold)
-        .forbid()
-        .build()
+        .build_veto()
 }
 
 fn document_checker() -> PermissionChecker<DocumentDomain> {
     let mut checker = PermissionChecker::named("DocumentChecker");
-    // Flat registration, any order: the deny policies' effect is declared
-    // on the policies themselves, and the checker evaluates forbid-effect
-    // policies first so a veto can never be raced by a grant.
+    // Vetoes are evaluated before any grant can short-circuit.
     checker.add_policy(admin_override());
     checker.add_policy(document_owner());
-    checker.add_policy(account_suspended());
-    checker.add_policy(legal_hold());
+    checker.add_veto(account_suspended());
+    checker.add_veto(legal_hold());
     checker
 }
 
@@ -212,7 +208,7 @@ async fn main() {
     stranger_decision.assert_denied();
     assert_eq!(stranger_decision.forbidden_by(), None);
 
-    // Show the mechanism on the headline case: the forbid-effect policy is
+    // Show the mechanism on the headline case: the veto policy is
     // evaluated first and ends the evaluation; the allow set is never
     // consulted.
     println!("\nWhy 'admin, LEGAL-HOLD doc' is blocked:");
@@ -227,12 +223,12 @@ async fn main() {
 
 // ---- scoped exclusion: a deny that gates only one grant path --------
 
-/// `Effect::Forbid` is a *global* veto: it blocks every grant path in the
+/// `VetoPolicy` is a *global* veto: it blocks every grant path in the
 /// checker. When a block rule should only gate one grant path — here,
 /// muted users lose collaborator access but owners and admins keep
 /// theirs — scope it with combinators instead:
 /// `AndPolicy[ grant_arm, NotPolicy(block) ]`. The block policy in this local
-/// shape should be an ordinary grant-style predicate, not `.forbid()`;
+/// shape should be an ordinary grant-style predicate, not `.build_veto()`;
 /// `Forbidden` is active and would still veto globally.
 async fn scoped_exclusion_demo() {
     #[derive(Debug, Clone)]
@@ -263,16 +259,16 @@ async fn scoped_exclusion_demo() {
     );
     // The block rule for the scoped case *grants when it matches* so that
     // `NotPolicy` can invert it into a local gate. Compare with the
-    // checker-level rules above, where `Effect::Forbid` keeps natural
+    // checker-level rules above, where `VetoPolicy` keeps natural
     // polarity — this inversion is the price of scoping, which is why a
-    // global block should prefer `Effect::Forbid`.
+    // global block should prefer `VetoPolicy`.
     let muted = PolicyBuilder::<ThreadDomain>::new("Muted")
         .subjects(|member| member.muted)
         .build();
 
     let collaborator_unless_muted = AndPolicy::try_new(vec![
         collaborator_policy,
-        Arc::new(NotPolicy::new(muted)) as Arc<dyn Policy<ThreadDomain>>,
+        Arc::new(muted.not()) as Arc<dyn Policy<ThreadDomain>>,
     ])
     .expect("gate has the grant arm and the guard");
 
@@ -301,7 +297,7 @@ async fn scoped_exclusion_demo() {
         .check(&Thread)
         .await
         .assert_denied();
-    // ...the owner path is untouched, which a global Effect::Forbid mute
+    // ...the owner path is untouched, which a global VetoPolicy mute
     // could not express.
     checker
         .bind(&session, &muted_owner, &action, &context)

--- a/examples/factsource_n_plus_one.rs
+++ b/examples/factsource_n_plus_one.rs
@@ -39,8 +39,8 @@
 
 use async_trait::async_trait;
 use gatehouse::{
-    EvalCtx, EvaluationSession, FactKey, FactLoadResult, FactRegistry, FactSource,
-    PermissionChecker, Policy, PolicyDomain, PolicyEvalResult,
+    EvalCtx, EvaluationSession, FactKey, FactLoadResult, FactRegistry, FactSource, GrantResult,
+    PermissionChecker, Policy, PolicyDomain,
 };
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -129,7 +129,7 @@ struct WrongSupplierPolicy {
 
 #[async_trait]
 impl Policy<SupplierInvoiceDomain> for WrongSupplierPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, SupplierInvoiceDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, SupplierInvoiceDomain>) -> GrantResult {
         // N+1: every item in a batch re-asks the hierarchy for the
         // same org -> customer mapping.
         let resolved = self.hierarchy.resolve_customer(ctx.subject.org_id).await;
@@ -194,7 +194,7 @@ struct RightSupplierPolicy;
 
 #[async_trait]
 impl Policy<SupplierInvoiceDomain> for RightSupplierPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, SupplierInvoiceDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, SupplierInvoiceDomain>) -> GrantResult {
         // Ask the context, not the backend service directly. The first
         // call inside this request triggers `load_many`; every subsequent
         // call with the same key (e.g. another invoice in the same batch)
@@ -247,8 +247,9 @@ async fn main() {
     let session = EvaluationSession::empty();
     let visible = wrong_checker
         .bind(&session, &supplier, &ViewAction, &())
-        .filter(invoices.clone())
-        .await;
+        .try_filter(invoices.clone())
+        .await
+        .expect("authorization must complete");
     let wrong_calls = hierarchy.calls();
     println!(
         "[wrong] {} invoices -> {} hierarchy lookups (N+1, redundant)",
@@ -279,8 +280,9 @@ async fn main() {
         .session();
     let visible = right_checker
         .bind(&session, &supplier, &ViewAction, &())
-        .filter(invoices)
-        .await;
+        .try_filter(invoices)
+        .await
+        .expect("authorization must complete");
     let right_calls = hierarchy.calls();
     let batch_calls = load_many_calls.load(Ordering::SeqCst);
     println!(

--- a/examples/in_ram_rebac.rs
+++ b/examples/in_ram_rebac.rs
@@ -129,8 +129,9 @@ async fn main() {
     let first_request = request_session(&registry);
     let visible = checker
         .bind(&first_request, &user, &View, &context)
-        .filter(documents.clone())
-        .await;
+        .try_filter(documents.clone())
+        .await
+        .expect("authorization must complete");
     println!(
         "batch list — visible documents: {:?}",
         visible
@@ -169,8 +170,9 @@ async fn main() {
                 let context = ();
                 checker
                     .bind(&session, &user, &View, &context)
-                    .filter(documents)
+                    .try_filter(documents)
                     .await
+                    .expect("authorization must complete")
                     .len()
             })
         })

--- a/examples/lookup_in_ram.rs
+++ b/examples/lookup_in_ram.rs
@@ -1,6 +1,6 @@
 //! Lookup-style authorization with an in-memory backend.
 //!
-//! Demonstrates `BoundEvaluator::lookup_page` against an in-RAM
+//! Demonstrates `BoundEvaluator::try_lookup_page` against an in-RAM
 //! `LookupSource` and a `Hydrator`, composed with a non-lookup policy
 //! (admin override) — the production shape #24 was scoped to enable.
 //!
@@ -9,16 +9,14 @@
 //!   - the user is a registered viewer (a relationship, enumerable per user)
 //!   - the user is a global admin (a non-lookup grant axis)
 //!
-//! The `LookupSource` enumerates the viewer relationship only. Admin
-//! overrides are still authorized through the policy stack: an admin's
-//! lookup-driven listing returns the viewer-visible subset, while a point
-//! check on any document returns Granted by the admin axis. The example
-//! prints both so the difference is visible.
+//! The `LookupSource` enumerates a complete candidate set for every grant
+//! path: viewer documents for ordinary users, all documents for admins.
+//! The checker then authorizes each candidate after hydration.
 
 use async_trait::async_trait;
 use gatehouse::{
-    EvalCtx, EvaluationSession, LookupPage, LookupSource, PermissionChecker, Policy, PolicyDomain,
-    PolicyEvalResult,
+    EvalCtx, EvaluationSession, GrantResult, LookupPage, LookupSource, PermissionChecker, Policy,
+    PolicyDomain,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -59,7 +57,7 @@ struct AdminPolicy;
 
 #[async_trait]
 impl Policy<DocumentDomain> for AdminPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> GrantResult {
         if ctx.subject.is_admin {
             ctx.grant("admin override")
         } else {
@@ -79,7 +77,7 @@ struct ViewerPolicy {
 
 #[async_trait]
 impl Policy<DocumentDomain> for ViewerPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, DocumentDomain>) -> GrantResult {
         let granted = self
             .viewers
             .get(&ctx.resource.id)
@@ -98,14 +96,15 @@ impl Policy<DocumentDomain> for ViewerPolicy {
 
 // --- LookupSource ------------------------------------------------------
 
-/// Enumerates the documents `user` is registered as a viewer of, in a
-/// stable per-subject order. Pages by offset; cursor is the next offset
+/// Enumerates all documents for admins and viewer documents for other users,
+/// in a stable order. Pages by offset; cursor is the next offset
 /// rendered as ASCII bytes.
 ///
 /// In a real backend this would be `SELECT doc_id FROM viewers WHERE
 /// user_id = $1 ORDER BY doc_id LIMIT $2 OFFSET decode($3)`.
 struct InMemoryViewerLookup {
     per_user: HashMap<Uuid, Vec<Uuid>>,
+    all_documents: Vec<Uuid>,
 }
 
 #[derive(Debug)]
@@ -142,7 +141,14 @@ impl LookupSource<DocumentDomain> for InMemoryViewerLookup {
             .transpose()?
             .unwrap_or(0);
 
-        let all = self.per_user.get(&subject.id).cloned().unwrap_or_default();
+        let all = if subject.is_admin {
+            self.all_documents.as_slice()
+        } else {
+            self.per_user
+                .get(&subject.id)
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+        };
 
         if offset >= all.len() {
             return Ok(LookupPage {
@@ -166,7 +172,7 @@ async fn collect_authorized<H>(
     lookup: &InMemoryViewerLookup,
     page_size: NonZeroUsize,
     hydrator: &H,
-) -> Result<Vec<Document>, gatehouse::LookupAuthorizedError<ViewerLookupError, H::Error>>
+) -> Result<Vec<Document>, gatehouse::LookupAuthorizedError<ViewerLookupError, H::Error, Document>>
 where
     H: gatehouse::Hydrator<Uuid, Resource = Document>,
 {
@@ -175,7 +181,7 @@ where
     let bound = checker.bind(session, subject, &View, &());
     loop {
         let page = bound
-            .lookup_page(lookup, hydrator, cursor.as_deref(), page_size)
+            .try_lookup_page(lookup, hydrator, cursor.as_deref(), page_size)
             .await?;
         authorized.extend(page.resources);
         match page.next_cursor {
@@ -226,6 +232,7 @@ async fn main() {
 
     let lookup = InMemoryViewerLookup {
         per_user: viewer_lookup_index,
+        all_documents: docs.iter().map(|document| document.id).collect(),
     };
 
     // Hydrator closure: maps a slice of ids to `Vec<Option<Document>>`.
@@ -244,9 +251,7 @@ async fn main() {
         }
     };
 
-    // Compose policies: admin override OR viewer relation. The lookup
-    // source only enumerates the viewer axis — admin overrides apply only
-    // to point checks.
+    // The lookup source covers both grant paths: admin and viewer.
     let mut checker = PermissionChecker::<DocumentDomain>::new();
     checker.add_policy(AdminPolicy);
     checker.add_policy(ViewerPolicy { viewers });
@@ -269,25 +274,18 @@ async fn main() {
         "the lookup + policy stack should authorize exactly the viewer-granted documents, in source order"
     );
 
-    // (2) Admin lists "their visible documents" via the same lookup.
-    // The viewer lookup does not enumerate documents for the admin (no
-    // viewer relation), so this listing returns empty — correctly,
-    // because lookup is bounded by what it enumerates. To enumerate
-    // "everything an admin can see", the production code would either
-    // route admin requests to a different source or simply skip the
-    // lookup path and list directly.
+    // (2) Admin lists all documents through the same complete candidate source.
     let admin_via_lookup =
         collect_authorized(&checker, &session, &admin, &lookup, page_size, &hydrator)
             .await
             .expect("lookup ok");
-    println!(
-        "\nAdmin via the viewer-lookup sees {} document(s) — this is bounded \
-         by what the source enumerates; admin grants still apply at point checks.",
-        admin_via_lookup.len()
-    );
-    assert!(
-        admin_via_lookup.is_empty(),
-        "the viewer lookup enumerates nothing for the admin, so the listing is empty"
+    println!("\nAdmin sees {} document(s).", admin_via_lookup.len());
+    assert_eq!(
+        admin_via_lookup
+            .iter()
+            .map(|document| document.id)
+            .collect::<Vec<_>>(),
+        docs.iter().map(|document| document.id).collect::<Vec<_>>(),
     );
 
     // (3) Point check confirms the admin policy is alive: pick a document
@@ -318,9 +316,9 @@ async fn main() {
     let alice_bound = checker.bind(&session, &alice, &View, &());
     loop {
         let page = alice_bound
-            .lookup_page(&lookup, &hydrator, cursor.as_deref(), page_size)
+            .try_lookup_page(&lookup, &hydrator, cursor.as_deref(), page_size)
             .await
-            .expect("lookup_page ok");
+            .expect("lookup and authorization must complete");
         println!("  page {page_index}: {} authorized", page.resources.len());
         page_index += 1;
         streamed_total += page.resources.len();

--- a/examples/mfa_freshness_context.rs
+++ b/examples/mfa_freshness_context.rs
@@ -13,15 +13,15 @@
 //!
 //! That last bit is what `Context` is for. We carry `mfa_verified_at`
 //! and the request's wall-clock time on `ApprovalContext`. The
-//! high-value rule is a forbid-effect policy that **forbids** the approval
+//! high-value rule is a veto policy that **forbids** the approval
 //! when MFA freshness has lapsed; the role policy ignores the field
 //! entirely. Same subject, same resource, different calls → different
 //! decisions.
 
 use async_trait::async_trait;
 use gatehouse::{
-    AccessEvaluation, Effect, EvalCtx, EvaluationSession, PermissionChecker, Policy, PolicyDomain,
-    PolicyEvalResult,
+    AccessEvaluation, EvalCtx, EvaluationSession, GrantResult, PermissionChecker, Policy,
+    PolicyDomain, VetoPolicy, VetoResult,
 };
 use std::borrow::Cow;
 use std::time::{Duration, SystemTime};
@@ -77,7 +77,7 @@ struct FinanceCanApproveRefunds;
 
 #[async_trait]
 impl Policy<RefundApprovalDomain> for FinanceCanApproveRefunds {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, RefundApprovalDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, RefundApprovalDomain>) -> GrantResult {
         if ctx.subject.roles.iter().any(|r| r == "finance") {
             ctx.grant("subject has the finance role")
         } else {
@@ -92,10 +92,10 @@ impl Policy<RefundApprovalDomain> for FinanceCanApproveRefunds {
 /// Deny rule: a high-value refund without fresh MFA is **forbidden**.
 ///
 /// This is the policy that *does* care about `Context`, and it is a
-/// forbid-effect policy in natural polarity: it matches exactly when the
+/// veto policy in natural polarity: it matches exactly when the
 /// approval must be blocked, and returns `ctx.forbid(...)` for that
 /// case. Everything else — small refunds, fresh MFA — is "not
-/// applicable" (`ctx.not_applicable`), which never blocks and never grants.
+/// applicable" (`ctx.pass`), which never blocks and never grants.
 ///
 /// Registered flat on the [`PermissionChecker`], the forbid overrides
 /// every grant under deny-overrides semantics. That is the right
@@ -103,21 +103,20 @@ impl Policy<RefundApprovalDomain> for FinanceCanApproveRefunds {
 /// service-account grant path is added later, a stale session still
 /// cannot approve a high-value refund through it.
 ///
-/// Note the [`Policy::effect`] override below — a hand-written policy
-/// that can forbid must declare [`Effect::Forbid`] so the checker
-/// schedules it ahead of the grant short-circuit.
+/// The separate [`VetoPolicy`] capability prevents grants from bypassing
+/// this requirement; registration uses [`PermissionChecker::add_veto`].
 struct HighValueRequiresFreshMfa {
     threshold_cents: u64,
     max_age: Duration,
 }
 
 #[async_trait]
-impl Policy<RefundApprovalDomain> for HighValueRequiresFreshMfa {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, RefundApprovalDomain>) -> PolicyEvalResult {
+impl VetoPolicy<RefundApprovalDomain> for HighValueRequiresFreshMfa {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, RefundApprovalDomain>) -> VetoResult {
         // Rule doesn't apply below the threshold: not applicable, and a
-        // non-matching forbid-effect policy blocks nothing.
+        // passing veto policy blocks nothing.
         if ctx.resource.amount_cents < self.threshold_cents {
-            return ctx.not_applicable("amount below high-value threshold; rule not applicable");
+            return ctx.pass("amount below high-value threshold; rule not applicable");
         }
 
         let Some(verified_at) = ctx.context.mfa_verified_at else {
@@ -133,7 +132,7 @@ impl Policy<RefundApprovalDomain> for HighValueRequiresFreshMfa {
             .duration_since(verified_at)
             .unwrap_or_default();
         if age <= self.max_age {
-            ctx.not_applicable(format!(
+            ctx.pass(format!(
                 "MFA reasserted {}s ago, within freshness window; rule not applicable",
                 age.as_secs(),
             ))
@@ -148,9 +147,6 @@ impl Policy<RefundApprovalDomain> for HighValueRequiresFreshMfa {
     fn policy_type(&self) -> Cow<'static, str> {
         Cow::Borrowed("HighValueRequiresFreshMfa")
     }
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
 }
 
 fn build_checker() -> PermissionChecker<RefundApprovalDomain> {
@@ -159,7 +155,7 @@ fn build_checker() -> PermissionChecker<RefundApprovalDomain> {
     // wins, otherwise any grant wins, otherwise default deny.
     let mut checker = PermissionChecker::named("RefundApprovalChecker");
     checker.add_policy(FinanceCanApproveRefunds);
-    checker.add_policy(HighValueRequiresFreshMfa {
+    checker.add_veto(HighValueRequiresFreshMfa {
         threshold_cents: 1_000_000, // $10,000
         max_age: Duration::from_secs(5 * 60),
     });

--- a/examples/postgres_bulk_rebac.rs
+++ b/examples/postgres_bulk_rebac.rs
@@ -334,8 +334,9 @@ async fn main() {
             let session = session_with(&source);
             checker
                 .bind(&session, &subject, &View, &())
-                .filter(sample.clone())
+                .try_filter(sample.clone())
                 .await
+                .unwrap_or_else(|error| panic!("{error}"))
                 .len()
         })
         .await;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,7 @@
-use crate::{BatchEvalCtx, EvalCtx, GrantResult, Policy, PolicyDomain, VetoPolicy, VetoResult};
+use crate::{
+    BatchEvalCtx, EvalCtx, GrantResult, Policy, PolicyDomain, PolicyEvalResult, VetoPolicy,
+    VetoResult,
+};
 use async_trait::async_trait;
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -306,8 +309,15 @@ impl<D: PolicyDomain> VetoPolicy<D> for PredicateVeto<D> {
     }
 }
 fn predicate_veto_result(result: GrantResult) -> VetoResult {
-    let policy_type = result.policy_type().to_owned();
-    if result.is_granted() {
+    let matched = result.is_granted();
+    let policy_type = match result.0 {
+        PolicyEvalResult::Granted { policy_type, .. }
+        | PolicyEvalResult::NotApplicable { policy_type, .. }
+        | PolicyEvalResult::Forbidden { policy_type, .. }
+        | PolicyEvalResult::Indeterminate { policy_type, .. }
+        | PolicyEvalResult::Combined { policy_type, .. } => policy_type,
+    };
+    if matched {
         VetoResult::forbid(policy_type, "Policy forbids access")
     } else {
         VetoResult::pass(policy_type, "Policy predicate did not match")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyDomain, PolicyEvalResult};
+use crate::{BatchEvalCtx, EvalCtx, GrantResult, Policy, PolicyDomain, VetoPolicy, VetoResult};
 use async_trait::async_trait;
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -21,7 +21,6 @@ type WhenPredicate<D> = Box<
 /// An internal policy type constructed by [`PolicyBuilder`].
 struct InternalPolicy<D: PolicyDomain> {
     name: Cow<'static, str>,
-    effect: Effect,
     subject_pred: Option<SubjectPredicate<D>>,
     action_pred: Option<ActionPredicate<D>>,
     resource_pred: Option<ResourcePredicate<D>>,
@@ -31,26 +30,18 @@ struct InternalPolicy<D: PolicyDomain> {
 }
 
 impl<D: PolicyDomain> InternalPolicy<D> {
-    fn build_result(&self, all_axes_pass: bool) -> PolicyEvalResult {
+    fn build_result(&self, all_axes_pass: bool) -> GrantResult {
         if all_axes_pass {
-            match self.effect {
-                Effect::Allow | Effect::AllowOrForbid => PolicyEvalResult::granted(
-                    self.name.clone(),
-                    Some("Policy allowed access".into()),
-                ),
-                Effect::Forbid => {
-                    PolicyEvalResult::forbidden(self.name.clone(), "Policy forbids access")
-                }
-            }
+            GrantResult::granted(self.name.clone(), Some("Policy allowed access".into()))
         } else {
-            PolicyEvalResult::not_applicable(self.name.clone(), "Policy predicate did not match")
+            GrantResult::not_applicable(self.name.clone(), "Policy predicate did not match")
         }
     }
 }
 
 #[async_trait]
 impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
         let pass = self.subject_pred.as_ref().is_none_or(|f| f(ctx.subject))
             && self.action_pred.as_ref().is_none_or(|f| f(ctx.action))
             && self.resource_pred.as_ref().is_none_or(|f| f(ctx.resource))
@@ -62,7 +53,7 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
         self.build_result(pass)
     }
 
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
         let n = ctx.items.len();
 
         let subject_ok = self.subject_pred.as_ref().is_none_or(|f| f(ctx.subject));
@@ -95,13 +86,13 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
     fn policy_type(&self) -> Cow<'static, str> {
         self.name.clone()
     }
-
-    fn effect(&self) -> Effect {
-        self.effect
-    }
 }
 
 /// Fluent builder for synchronous predicate policies.
+///
+/// [`Self::build`] creates a grant policy. [`Self::build_veto`] creates a
+/// veto policy: a matching predicate vetoes and a non-match passes. Register
+/// the latter with [`crate::PermissionChecker::add_veto`].
 ///
 /// The builder is parameterized by one [`PolicyDomain`], so call sites name the
 /// domain once:
@@ -128,19 +119,17 @@ impl<D: PolicyDomain> Policy<D> for InternalPolicy<D> {
 ///
 /// [`PolicyBuilder::new`] takes `impl Into<Cow<'static, str>>`, so a
 /// `'static` string literal (`new("Owner")`) is stored as
-/// [`Cow::Borrowed`] and is zero-allocation end-to-end on the trace /
-/// `ctx.grant` helper path — the same accounting as a hand-written
-/// `Policy` that returns `Cow::Borrowed("MyPolicy")`.
+/// [`Cow::Borrowed`] and does not allocate when the name is copied into a
+/// result. Reasons, evidence, and trace storage may allocate independently.
 ///
 /// Runtime-constructed names (`new(format!("p-{id}"))`,
 /// [`Self::new_owned`], `new(owned_string)`) store [`Cow::Owned`]. Each
-/// evaluation clones that owned name into the `PolicyEvalResult` leaf
+/// evaluation clones that owned name into the `GrantResult` leaf
 /// (and again if the checker captures `policy_type` into an
 /// [`EvalCtx`](crate::EvalCtx)), so the cost is paid when building the
 /// trace, not only when calling `policy_type()` in isolation.
 pub struct PolicyBuilder<D: PolicyDomain> {
     name: Cow<'static, str>,
-    effect: Effect,
     subject_pred: Option<SubjectPredicate<D>>,
     action_pred: Option<ActionPredicate<D>>,
     resource_pred: Option<ResourcePredicate<D>>,
@@ -184,7 +173,6 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
     pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
         Self {
             name: name.into(),
-            effect: Effect::Allow,
             subject_pred: None,
             action_pred: None,
             resource_pred: None,
@@ -227,12 +215,6 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
     /// the method name.
     pub fn new_static(name: &'static str) -> Self {
         Self::new(name)
-    }
-
-    /// Makes this policy forbid when its combined predicate matches.
-    pub fn forbid(mut self) -> Self {
-        self.effect = Effect::Forbid;
-        self
     }
 
     /// Adds a predicate that tests the subject.
@@ -285,11 +267,15 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
         self
     }
 
+    /// Builds a veto that forbids when the predicate matches.
+    pub fn build_veto(self) -> Box<dyn VetoPolicy<D>> {
+        Box::new(PredicateVeto(self.build()))
+    }
+
     /// Builds the policy.
     pub fn build(self) -> Box<dyn Policy<D>> {
         Box::new(InternalPolicy {
             name: self.name,
-            effect: self.effect,
             subject_pred: self.subject_pred,
             action_pred: self.action_pred,
             resource_pred: self.resource_pred,
@@ -297,5 +283,33 @@ impl<D: PolicyDomain> PolicyBuilder<D> {
             when_pred: self.when_pred,
             _domain: PhantomData,
         })
+    }
+}
+
+struct PredicateVeto<D: PolicyDomain>(Box<dyn Policy<D>>);
+
+#[async_trait]
+impl<D: PolicyDomain> VetoPolicy<D> for PredicateVeto<D> {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> VetoResult {
+        predicate_veto_result(self.0.evaluate(ctx).await)
+    }
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<VetoResult> {
+        self.0
+            .evaluate_batch(ctx)
+            .await
+            .into_iter()
+            .map(predicate_veto_result)
+            .collect()
+    }
+    fn policy_type(&self) -> Cow<'static, str> {
+        self.0.policy_type()
+    }
+}
+fn predicate_veto_result(result: GrantResult) -> VetoResult {
+    let policy_type = result.policy_type().to_owned();
+    if result.is_granted() {
+        VetoResult::forbid(policy_type, "Policy forbids access")
+    } else {
+        VetoResult::pass(policy_type, "Policy predicate did not match")
     }
 }

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -1,0 +1,295 @@
+use crate::{
+    BatchEvalCtx, CombineOp, Decision, EvalCtx, FactProvenance, PolicyDomain, PolicyEvalResult,
+    SecurityRuleMetadata,
+};
+use async_trait::async_trait;
+use std::{borrow::Cow, sync::Arc};
+
+/// A grant policy's authority-bearing result. Its audit tree is read-only.
+///
+/// ```compile_fail
+/// use gatehouse::{GrantResult, PolicyEvalResult};
+/// let result: GrantResult = PolicyEvalResult::forbidden("blocked", "disabled").into();
+/// ```
+#[derive(Clone, Debug)]
+pub struct GrantResult(pub(crate) PolicyEvalResult);
+
+/// A veto policy's authority-bearing result. It cannot grant access.
+#[derive(Clone, Debug)]
+pub struct VetoResult(pub(crate) PolicyEvalResult);
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::GrantResult {}
+    impl Sealed for super::VetoResult {}
+    impl Sealed for crate::PolicyEvalResult {}
+}
+
+/// Results accepted by recording contexts. Implementations are sealed.
+pub trait PolicyResult: sealed::Sealed {
+    /// Consumes the result into its audit tree.
+    fn into_trace(self) -> PolicyEvalResult;
+    /// Attaches context-recorded evidence without changing the result capability.
+    fn attach_recorded(self, recorded: Vec<FactProvenance>) -> Self;
+}
+
+impl PolicyResult for PolicyEvalResult {
+    fn into_trace(self) -> PolicyEvalResult {
+        self
+    }
+    fn attach_recorded(self, recorded: Vec<FactProvenance>) -> Self {
+        crate::policy::attach_recorded(self, recorded)
+    }
+}
+
+macro_rules! shared_result {
+    ($name:ident) => {
+        impl $name {
+            /// Returns the immutable audit tree.
+            pub fn trace(&self) -> &PolicyEvalResult {
+                &self.0
+            }
+            /// Returns the aggregate decision.
+            pub fn decision(&self) -> Decision {
+                self.0.decision()
+            }
+            /// Returns the policy name.
+            pub fn policy_type(&self) -> &str {
+                self.0.policy_type()
+            }
+            /// Returns the reason attached to the result.
+            pub fn reason(&self) -> Option<String> {
+                self.0.reason()
+            }
+            /// Returns facts attached to this node.
+            pub fn provenance(&self) -> &[FactProvenance] {
+                self.0.provenance()
+            }
+            /// Creates an indeterminate result.
+            pub fn indeterminate(
+                policy_type: impl Into<Cow<'static, str>>,
+                reason: impl Into<String>,
+            ) -> Self {
+                Self(PolicyEvalResult::indeterminate(policy_type, reason))
+            }
+            /// Creates an indeterminate result with explicit evidence.
+            pub fn indeterminate_with_facts(
+                policy_type: impl Into<Cow<'static, str>>,
+                reason: impl Into<String>,
+                provenance: Vec<FactProvenance>,
+            ) -> Self {
+                Self(PolicyEvalResult::indeterminate_with_facts(
+                    policy_type,
+                    reason,
+                    provenance,
+                ))
+            }
+        }
+    };
+}
+shared_result!(GrantResult);
+shared_result!(VetoResult);
+
+impl PolicyResult for GrantResult {
+    fn into_trace(self) -> PolicyEvalResult {
+        self.0
+    }
+    fn attach_recorded(self, recorded: Vec<FactProvenance>) -> Self {
+        Self(crate::policy::attach_recorded(self.0, recorded))
+    }
+}
+impl PolicyResult for VetoResult {
+    fn into_trace(self) -> PolicyEvalResult {
+        self.0
+    }
+    fn attach_recorded(self, recorded: Vec<FactProvenance>) -> Self {
+        Self(crate::policy::attach_recorded(self.0, recorded))
+    }
+}
+impl GrantResult {
+    /// Creates a grant.
+    pub fn granted(policy_type: impl Into<Cow<'static, str>>, reason: Option<String>) -> Self {
+        Self(PolicyEvalResult::granted(policy_type, reason))
+    }
+    /// Creates a grant with explicit evidence.
+    pub fn granted_with_facts(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: Option<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self(PolicyEvalResult::granted_with_facts(
+            policy_type,
+            reason,
+            provenance,
+        ))
+    }
+    /// Creates an abstention.
+    pub fn not_applicable(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self(PolicyEvalResult::not_applicable(policy_type, reason))
+    }
+    /// Creates an abstention with explicit evidence.
+    pub fn not_applicable_with_facts(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self(PolicyEvalResult::not_applicable_with_facts(
+            policy_type,
+            reason,
+            provenance,
+        ))
+    }
+    /// Whether this policy granted.
+    pub fn is_granted(&self) -> bool {
+        self.0.is_granted()
+    }
+    /// Combines grant results with AND semantics. An empty conjunction abstains.
+    pub fn all(policy_type: impl Into<Cow<'static, str>>, children: Vec<Self>) -> Self {
+        let decision = if children.is_empty()
+            || children
+                .iter()
+                .any(|child| child.decision() == Decision::NotApplicable)
+        {
+            Decision::NotApplicable
+        } else if children
+            .iter()
+            .any(|child| child.decision() == Decision::Indeterminate)
+        {
+            Decision::Indeterminate
+        } else {
+            Decision::Grant
+        };
+        Self(combined(
+            policy_type,
+            CombineOp::And,
+            children.into_iter().map(|child| child.0).collect(),
+            decision,
+        ))
+    }
+    /// Combines grant results with OR semantics. An empty disjunction abstains.
+    pub fn any(policy_type: impl Into<Cow<'static, str>>, children: Vec<Self>) -> Self {
+        let decision = if children.iter().any(Self::is_granted) {
+            Decision::Grant
+        } else if children
+            .iter()
+            .any(|child| child.decision() == Decision::Indeterminate)
+        {
+            Decision::Indeterminate
+        } else {
+            Decision::NotApplicable
+        };
+        Self(combined(
+            policy_type,
+            CombineOp::Or,
+            children.into_iter().map(|child| child.0).collect(),
+            decision,
+        ))
+    }
+}
+impl VetoResult {
+    /// Creates a definite veto.
+    pub fn forbid(policy_type: impl Into<Cow<'static, str>>, reason: impl Into<String>) -> Self {
+        Self(PolicyEvalResult::forbidden(policy_type, reason))
+    }
+    /// Creates a definite veto with explicit evidence.
+    pub fn forbid_with_facts(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self(PolicyEvalResult::forbidden_with_facts(
+            policy_type,
+            reason,
+            provenance,
+        ))
+    }
+    /// Passes without granting any authority.
+    pub fn pass(policy_type: impl Into<Cow<'static, str>>, reason: impl Into<String>) -> Self {
+        Self(PolicyEvalResult::not_applicable(policy_type, reason))
+    }
+    /// Passes with explicit evidence.
+    pub fn pass_with_facts(
+        policy_type: impl Into<Cow<'static, str>>,
+        reason: impl Into<String>,
+        provenance: Vec<FactProvenance>,
+    ) -> Self {
+        Self(PolicyEvalResult::not_applicable_with_facts(
+            policy_type,
+            reason,
+            provenance,
+        ))
+    }
+    /// Whether this policy vetoed.
+    pub fn is_forbidden(&self) -> bool {
+        self.decision() == Decision::Forbid
+    }
+}
+
+pub(crate) fn combined(
+    policy_type: impl Into<Cow<'static, str>>,
+    operation: CombineOp,
+    children: Vec<PolicyEvalResult>,
+    decision: Decision,
+) -> PolicyEvalResult {
+    PolicyEvalResult::Combined {
+        provenance: Vec::new(),
+        policy_type: policy_type.into(),
+        operation,
+        children,
+        decision,
+    }
+}
+
+/// A policy that can veto or pass, but cannot grant.
+#[async_trait]
+pub trait VetoPolicy<D: PolicyDomain>: Send + Sync {
+    /// Evaluates the veto for one resource.
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> VetoResult;
+    /// Returns one result per input, in the same order.
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<VetoResult> {
+        let mut results = Vec::with_capacity(ctx.items.len());
+        for item in ctx.items {
+            let inner = EvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                item.resource,
+                ctx.context,
+                ctx.policy_type.clone(),
+            );
+            let result = self.evaluate(&inner).await;
+            results.push(inner.finish(result));
+        }
+        results
+    }
+    /// Name for audit trees and telemetry.
+    fn policy_type(&self) -> Cow<'static, str>;
+    /// Security-rule metadata.
+    fn security_rule(&self) -> SecurityRuleMetadata {
+        SecurityRuleMetadata::default()
+    }
+}
+macro_rules! forward_veto {
+    ($container:ident) => {
+        #[async_trait]
+        impl<D: PolicyDomain> VetoPolicy<D> for $container<dyn VetoPolicy<D>> {
+            async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> VetoResult {
+                (**self).evaluate(ctx).await
+            }
+            async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<VetoResult> {
+                (**self).evaluate_batch(ctx).await
+            }
+            fn policy_type(&self) -> Cow<'static, str> {
+                (**self).policy_type()
+            }
+            fn security_rule(&self) -> SecurityRuleMetadata {
+                (**self).security_rule()
+            }
+        }
+    };
+}
+forward_veto!(Box);
+forward_veto!(Arc);

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -130,7 +130,8 @@ impl GrantResult {
     ) -> Self {
         Self(PolicyEvalResult::not_applicable(policy_type, reason))
     }
-    /// Creates an abstention with explicit evidence.
+    /// Creates an abstention with explicit evidence. Failed facts produce an
+    /// indeterminate result, preserving the reason and evidence.
     pub fn not_applicable_with_facts(
         policy_type: impl Into<Cow<'static, str>>,
         reason: impl Into<String>,
@@ -210,7 +211,8 @@ impl VetoResult {
     pub fn pass(policy_type: impl Into<Cow<'static, str>>, reason: impl Into<String>) -> Self {
         Self(PolicyEvalResult::not_applicable(policy_type, reason))
     }
-    /// Passes with explicit evidence.
+    /// Passes with explicit evidence. Failed facts produce an indeterminate
+    /// result, preserving the reason and evidence.
     pub fn pass_with_facts(
         policy_type: impl Into<Cow<'static, str>>,
         reason: impl Into<String>,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,168 +1,174 @@
+use crate::capability::combined;
+#[cfg(feature = "tracing")]
+use crate::DEFAULT_SECURITY_RULE_CATEGORY;
 use crate::{
-    AccessEvaluation, BatchEvalCtx, CombineOp, Decision, Effect, EvalCtx, EvalTrace,
-    EvaluationSession, Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupSource, Policy,
-    PolicyBatchItem, PolicyDomain, PolicyEvalResult, DEFAULT_SECURITY_RULE_CATEGORY,
-    PERMISSION_CHECKER_POLICY_TYPE,
+    AccessEvaluation, BatchEvalCtx, CombineOp, Decision, DelegatingPolicy, EvalCtx, EvalTrace,
+    EvaluationSession, FilterError, Hydrator, LookupAuthorizedError, LookupAuthorizedPage,
+    LookupSource, Policy, PolicyBatchItem, PolicyDomain, PolicyEvalResult, SecurityRuleMetadata,
+    VetoPolicy, PERMISSION_CHECKER_POLICY_TYPE,
 };
+use async_trait::async_trait;
+use std::any::Any;
 use std::borrow::{Borrow, Cow};
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+#[cfg(feature = "tracing")]
 use tracing::Instrument;
 
-fn forbid_summary(policy_type: &str, reason: Option<&str>) -> String {
-    match reason {
-        Some(reason) => format!("Forbidden by {policy_type}: {reason}"),
-        None => format!("Forbidden by {policy_type}"),
+#[derive(Clone, Copy)]
+pub(crate) enum Phase {
+    Veto,
+    Grant,
+}
+
+impl Phase {
+    fn decisive(self) -> Decision {
+        match self {
+            Self::Veto => Decision::Forbid,
+            Self::Grant => Decision::Grant,
+        }
     }
-}
-
-fn indeterminate_summary(policy_type: &str, reason: &str) -> String {
-    format!("Could not evaluate {policy_type}: {reason}")
-}
-
-const MISSING_INDETERMINATE_LEAF_REASON: &str =
-    "indeterminate result did not contain an indeterminate leaf";
-
-/// Extracts `(policy_type, reason)` attribution for an indeterminate policy
-/// result, falling back to the policy's own name when the tree has no
-/// indeterminate leaf (e.g. a custom node without one).
-fn indeterminate_attribution(result: &PolicyEvalResult, policy_type: &str) -> (String, String) {
-    result
-        .indeterminate_leaf()
-        .map(|(leaf_type, reason)| (leaf_type.to_string(), reason.to_string()))
-        .unwrap_or_else(|| {
-            (
-                policy_type.to_string(),
-                result
-                    .reason()
-                    .unwrap_or_else(|| MISSING_INDETERMINATE_LEAF_REASON.to_string()),
-            )
-        })
-}
-
-const FORBID_EFFECT_GRANT_REASON: &str =
-    "Forbid-effect policy returned a grant; treated as not applicable";
-
-const ALLOW_EFFECT_FORBID_REASON: &str =
-    "Allow-effect policy returned a forbid; the veto is honored but only where observed, so declare Effect::Forbid or Effect::AllowOrForbid to schedule it ahead of grants";
-
-/// Normalizes the contract-violating grant of a `Forbid`-effect policy to
-/// `NotApplicable`, preserving the facts the policy consulted so they stay
-/// in the trace.
-fn forbid_effect_grant_to_not_applicable(
-    policy_type: Cow<'static, str>,
-    result: &PolicyEvalResult,
-) -> PolicyEvalResult {
-    PolicyEvalResult::not_applicable_with_facts(
-        policy_type,
-        FORBID_EFFECT_GRANT_REASON,
-        result.provenance().to_vec(),
-    )
-}
-
-fn checker_root(children: Vec<PolicyEvalResult>, decision: Decision) -> PolicyEvalResult {
-    PolicyEvalResult::Combined {
-        policy_type: std::borrow::Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE),
-        operation: CombineOp::DenyOverrides,
-        children,
-        decision,
-    }
-}
-
-/// A policy stack for one [`PolicyDomain`].
-pub struct PermissionChecker<D: PolicyDomain> {
-    name: Option<std::borrow::Cow<'static, str>>,
-    policies: Vec<Arc<dyn Policy<D>>>,
-    effects: Vec<Effect>,
-    veto_capable_count: usize,
-    max_batch_size: Option<NonZeroUsize>,
-}
-
-impl<D: PolicyDomain> Clone for PermissionChecker<D> {
-    fn clone(&self) -> Self {
-        Self {
-            name: self.name.clone(),
-            policies: self.policies.clone(),
-            effects: self.effects.clone(),
-            veto_capable_count: self.veto_capable_count,
-            max_batch_size: self.max_batch_size,
+    fn reduce(self, previous: Decision, next: Decision) -> Decision {
+        if next == self.decisive()
+            || (next == Decision::Indeterminate && previous != self.decisive())
+        {
+            next
+        } else {
+            previous
         }
     }
 }
 
+#[derive(Default)]
+pub(crate) struct EvaluationState {
+    pub(crate) delegates: HashMap<Vec<usize>, Box<dyn Any + Send + Sync>>,
+}
+pub(crate) struct PhaseScope<'a> {
+    pub(crate) state: &'a mut EvaluationState,
+    pub(crate) item_indices: &'a [usize],
+    pub(crate) path: &'a [usize],
+}
+
+#[async_trait]
+pub(crate) trait PhasePolicy<D: PolicyDomain>: Send + Sync {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>, scope: &mut PhaseScope<'_>) -> PolicyEvalResult;
+    async fn evaluate_batch<'item>(
+        &self,
+        ctx: &BatchEvalCtx<'item, D>,
+        scope: &mut PhaseScope<'_>,
+    ) -> Vec<PolicyEvalResult>;
+    fn policy_type(&self) -> Cow<'static, str>;
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
+    fn security_rule(&self) -> SecurityRuleMetadata;
+}
+struct GrantAdapter<P>(P);
+struct VetoAdapter<P>(P);
+macro_rules! adapter {
+    ($adapter:ident, $policy:ident) => {
+        #[async_trait]
+        impl<D: PolicyDomain, P: $policy<D>> PhasePolicy<D> for $adapter<P> {
+            async fn evaluate(
+                &self,
+                ctx: &EvalCtx<'_, D>,
+                _scope: &mut PhaseScope<'_>,
+            ) -> PolicyEvalResult {
+                self.0.evaluate(ctx).await.0
+            }
+            async fn evaluate_batch<'item>(
+                &self,
+                ctx: &BatchEvalCtx<'item, D>,
+                _scope: &mut PhaseScope<'_>,
+            ) -> Vec<PolicyEvalResult> {
+                self.0
+                    .evaluate_batch(ctx)
+                    .await
+                    .into_iter()
+                    .map(|result| result.0)
+                    .collect()
+            }
+            fn policy_type(&self) -> Cow<'static, str> {
+                self.0.policy_type()
+            }
+            fn security_rule(&self) -> SecurityRuleMetadata {
+                self.0.security_rule()
+            }
+        }
+    };
+}
+adapter!(GrantAdapter, Policy);
+adapter!(VetoAdapter, VetoPolicy);
+
+/// Grant and veto policies for one authorization domain.
+pub struct PermissionChecker<D: PolicyDomain> {
+    name: Option<Cow<'static, str>>,
+    grants: Vec<Arc<dyn PhasePolicy<D>>>,
+    vetoes: Vec<Arc<dyn PhasePolicy<D>>>,
+    max_batch_size: Option<NonZeroUsize>,
+    next_delegate_id: usize,
+}
+impl<D: PolicyDomain> Clone for PermissionChecker<D> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            grants: self.grants.clone(),
+            vetoes: self.vetoes.clone(),
+            max_batch_size: self.max_batch_size,
+            next_delegate_id: self.next_delegate_id,
+        }
+    }
+}
 impl<D: PolicyDomain> Default for PermissionChecker<D> {
     fn default() -> Self {
         Self::new()
     }
 }
-
 impl<D: PolicyDomain> PermissionChecker<D> {
-    /// Creates a new checker with no policies and no name.
+    /// Creates an empty checker, which denies every request.
     pub fn new() -> Self {
         Self {
             name: None,
-            policies: Vec::new(),
-            effects: Vec::new(),
-            veto_capable_count: 0,
+            grants: Vec::new(),
+            vetoes: Vec::new(),
             max_batch_size: None,
+            next_delegate_id: 0,
         }
     }
-
-    /// Creates a new checker tagged with a name for telemetry.
-    pub fn named(name: impl Into<std::borrow::Cow<'static, str>>) -> Self {
+    /// Creates a checker named for telemetry.
+    pub fn named(name: impl Into<Cow<'static, str>>) -> Self {
         Self {
             name: Some(name.into()),
-            policies: Vec::new(),
-            effects: Vec::new(),
-            veto_capable_count: 0,
-            max_batch_size: None,
+            ..Self::new()
         }
     }
-
-    /// Returns the checker name if set.
+    /// Returns the telemetry name.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
-
-    /// Sets the maximum number of pending items passed to one policy batch.
+    /// Limits the number of resources passed to each policy batch.
     pub fn with_max_batch_size(mut self, max_batch_size: NonZeroUsize) -> Self {
         self.max_batch_size = Some(max_batch_size);
         self
     }
-
-    /// Adds a policy to the checker.
-    ///
-    /// Veto-capable policies are scheduled ahead of allow-only policies so a
-    /// forbid is always observed before the grant short-circuit.
+    /// Adds a policy that can grant or abstain.
     pub fn add_policy<P: Policy<D> + 'static>(&mut self, policy: P) {
-        let effect = policy.effect();
-        if effect.can_forbid() {
-            self.policies
-                .insert(self.veto_capable_count, Arc::new(policy));
-            self.effects.insert(self.veto_capable_count, effect);
-            self.veto_capable_count += 1;
-        } else {
-            self.policies.push(Arc::new(policy));
-            self.effects.push(effect);
-        }
+        self.grants.push(Arc::new(GrantAdapter(policy)));
     }
-
-    /// Adds a hand-written policy that can actively forbid access even if it
-    /// does not override [`Policy::effect`].
-    pub fn add_forbid_policy<P: Policy<D> + 'static>(&mut self, policy: P) {
-        self.policies
-            .insert(self.veto_capable_count, Arc::new(policy));
-        self.effects
-            .insert(self.veto_capable_count, Effect::AllowOrForbid);
-        self.veto_capable_count += 1;
+    /// Adds a policy that can veto or pass. Vetoes always run before grants.
+    pub fn add_veto<P: VetoPolicy<D> + 'static>(&mut self, policy: P) {
+        self.vetoes.push(Arc::new(VetoAdapter(policy)));
     }
-
-    /// Binds a request-scoped evaluation session and shared inputs to this
-    /// checker.
+    /// Atomically installs both capabilities of a child checker.
     ///
-    /// All evaluations require an explicit session. Fact-free callers can pass
-    /// [`EvaluationSession::empty`], while fact-backed paths should pass a
-    /// request session created from [`crate::FactRegistry::session`].
+    /// Child vetoes run during the parent's veto phase and child grants during
+    /// its grant phase. No child policy is evaluated twice per resource.
+    pub fn add_delegate<ChildD: PolicyDomain>(&mut self, delegate: DelegatingPolicy<D, ChildD>) {
+        let (veto, grant) = delegate.into_phases(self.next_delegate_id);
+        self.next_delegate_id += 1;
+        self.vetoes.push(veto);
+        self.grants.push(grant);
+    }
+    /// Binds request inputs and the request-scoped fact session.
     pub fn bind<'a>(
         &'a self,
         session: &'a EvaluationSession,
@@ -179,20 +185,167 @@ impl<D: PolicyDomain> PermissionChecker<D> {
         }
     }
 
-    fn declared_effect(&self, policy_index: usize) -> Effect {
-        self.effects
-            .get(policy_index)
-            .copied()
-            .unwrap_or(Effect::Allow)
+    pub(crate) async fn evaluate_phase<'item>(
+        &self,
+        phase: Phase,
+        ctx: &BatchEvalCtx<'item, D>,
+        scope: &mut PhaseScope<'_>,
+    ) -> Vec<PolicyEvalResult> {
+        let policies = match phase {
+            Phase::Veto => &self.vetoes,
+            Phase::Grant => &self.grants,
+        };
+        let mut children = vec![Vec::new(); ctx.items.len()];
+        let mut decisions = vec![Decision::NotApplicable; ctx.items.len()];
+        let mut pending: Vec<usize> = (0..ctx.items.len()).collect();
+        let decisive = phase.decisive();
+        for policy in policies {
+            let chunk_size = self
+                .max_batch_size
+                .map(NonZeroUsize::get)
+                .unwrap_or(usize::MAX);
+            #[cfg_attr(not(feature = "tracing"), allow(clippy::unused_enumerate_index))]
+            for (_chunk_index, indices) in pending.chunks(chunk_size).enumerate() {
+                let items: Vec<_> = indices
+                    .iter()
+                    .map(|&index| PolicyBatchItem {
+                        resource: ctx.items[index].resource,
+                    })
+                    .collect();
+                let item_indices: Vec<_> = indices
+                    .iter()
+                    .map(|&index| scope.item_indices[index])
+                    .collect();
+                let mut child_scope = PhaseScope {
+                    state: scope.state,
+                    item_indices: &item_indices,
+                    path: scope.path,
+                };
+                let policy_type = policy.policy_type();
+                #[cfg(feature = "tracing")]
+                let policy_span = tracing::debug_span!(
+                    "gatehouse.batch_policy",
+                    policy.type = policy_type.as_ref(),
+                    policy.effect = phase_effect(phase),
+                    policy.pending_count = indices.len(),
+                    policy.chunk_index = _chunk_index,
+                    policy.chunk_count = pending.len().div_ceil(chunk_size),
+                    policy.granted_count = tracing::field::Empty,
+                    policy.denied_count = tracing::field::Empty,
+                    policy.forbidden_count = tracing::field::Empty,
+                    policy.indeterminate_count = tracing::field::Empty,
+                );
+                let results = {
+                    let inner = BatchEvalCtx::new(
+                        ctx.session(),
+                        ctx.subject,
+                        ctx.action,
+                        ctx.context,
+                        &items,
+                        policy_type.clone(),
+                    );
+                    let results = policy.evaluate_batch(&inner, &mut child_scope);
+                    #[cfg(feature = "tracing")]
+                    let results = results.instrument(policy_span.clone());
+                    let results = results.await;
+                    inner.finish(results)
+                };
+                let results = if results.len() == indices.len() {
+                    results
+                } else {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(policy.type = policy_type.as_ref(), expected = indices.len(), actual = results.len(), "Policy batch result count did not match input count");
+                    indices
+                        .iter()
+                        .map(|_| {
+                            PolicyEvalResult::indeterminate(
+                                policy_type.clone(),
+                                "Policy batch result count did not match input count",
+                            )
+                        })
+                        .collect()
+                };
+                #[cfg(feature = "tracing")]
+                {
+                    let count = |decision| {
+                        results
+                            .iter()
+                            .filter(|result| result.decision() == decision)
+                            .count()
+                    };
+                    policy_span.record("policy.granted_count", count(Decision::Grant));
+                    policy_span.record("policy.denied_count", count(Decision::NotApplicable));
+                    policy_span.record("policy.forbidden_count", count(Decision::Forbid));
+                    policy_span
+                        .record("policy.indeterminate_count", count(Decision::Indeterminate));
+                }
+                for (&index, result) in indices.iter().zip(results) {
+                    let decision = result.decision();
+                    #[cfg(feature = "tracing")]
+                    emit_policy_event(policy.as_ref(), &result, phase);
+                    decisions[index] = phase.reduce(decisions[index], decision);
+                    children[index].push(result);
+                }
+            }
+            pending.retain(|&index| decisions[index] != decisive);
+            if pending.is_empty() {
+                break;
+            }
+        }
+        children
+            .into_iter()
+            .zip(decisions)
+            .map(|(children, decision)| {
+                combined(
+                    PERMISSION_CHECKER_POLICY_TYPE,
+                    CombineOp::DenyOverrides,
+                    children,
+                    decision,
+                )
+            })
+            .collect()
     }
 
-    pub(crate) fn aggregate_effect(&self) -> Effect {
-        let can_grant = self.effects.iter().any(|effect| effect.can_grant());
-        let can_forbid = self.effects.iter().any(|effect| effect.can_forbid());
-        Effect::from_capabilities(can_grant, can_forbid)
+    pub(crate) async fn evaluate_phase_one(
+        &self,
+        phase: Phase,
+        ctx: &EvalCtx<'_, D>,
+        scope: &mut PhaseScope<'_>,
+    ) -> PolicyEvalResult {
+        let policies = match phase {
+            Phase::Veto => &self.vetoes,
+            Phase::Grant => &self.grants,
+        };
+        let mut children = Vec::with_capacity(policies.len());
+        let mut decision = Decision::NotApplicable;
+        for policy in policies {
+            let inner = EvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                ctx.resource,
+                ctx.context,
+                policy.policy_type(),
+            );
+            let result = policy.evaluate(&inner, scope).await;
+            let result = inner.finish(result);
+            #[cfg(feature = "tracing")]
+            emit_policy_event(policy.as_ref(), &result, phase);
+            decision = phase.reduce(decision, result.decision());
+            children.push(result);
+            if decision == phase.decisive() {
+                break;
+            }
+        }
+        combined(
+            PERMISSION_CHECKER_POLICY_TYPE,
+            CombineOp::DenyOverrides,
+            children,
+            decision,
+        )
     }
 
-    #[tracing::instrument(skip_all, fields(checker.name = tracing::field::Empty, policy_count = self.policies.len(), outcome = tracing::field::Empty, policy.type = tracing::field::Empty))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(checker.name = self.name(), policy_count = self.grants.len() + self.vetoes.len(), outcome, policy.type)))]
     async fn evaluate_one(
         &self,
         session: &EvaluationSession,
@@ -201,187 +354,172 @@ impl<D: PolicyDomain> PermissionChecker<D> {
         resource: &D::Resource,
         context: &D::Context,
     ) -> AccessEvaluation {
-        if let Some(name) = self.name.as_deref() {
-            tracing::Span::current().record("checker.name", name);
-        }
-        if self.policies.is_empty() {
-            tracing::Span::current().record("outcome", "denied");
-            let result = PolicyEvalResult::not_applicable(
-                PERMISSION_CHECKER_POLICY_TYPE,
-                "No policies configured",
-            );
-
-            return AccessEvaluation::Denied {
-                trace: EvalTrace::with_root(result),
-                reason: "No policies configured".to_string(),
+        let mut state = EvaluationState::default();
+        let mut scope = PhaseScope {
+            state: &mut state,
+            item_indices: &[0],
+            path: &[],
+        };
+        let ctx = EvalCtx::new(
+            session,
+            subject,
+            action,
+            resource,
+            context,
+            PERMISSION_CHECKER_POLICY_TYPE,
+        );
+        let veto = self.evaluate_phase_one(Phase::Veto, &ctx, &mut scope).await;
+        let root = if veto.decision() == Decision::NotApplicable {
+            let grant = self
+                .evaluate_phase_one(Phase::Grant, &ctx, &mut scope)
+                .await;
+            let decision = grant.decision();
+            let mut children = match veto {
+                PolicyEvalResult::Combined { children, .. } => children,
+                _ => unreachable!(),
             };
-        }
-
-        let mut policy_results = Vec::with_capacity(self.policies.len());
-        let mut first_grant: Option<(Cow<'static, str>, Option<String>)> = None;
-        // First indeterminate result from the veto prefix. Blocks grants:
-        // the failed policy might have forbidden this request.
-        let mut veto_indeterminate: Option<(String, String)> = None;
-        // First indeterminate result from an allow-only policy. Harmless to
-        // grants (the failed policy could only have granted), but if nothing
-        // grants the evaluation is indeterminate rather than denied.
-        let mut allow_indeterminate: Option<(String, String)> = None;
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            let declared_effect = self.declared_effect(policy_index);
-            let policy_type = policy.policy_type();
-            let ctx = EvalCtx::new(
-                session,
-                subject,
-                action,
-                resource,
-                context,
-                policy_type.clone(),
-            );
-            let result = policy.evaluate(&ctx).await;
-            // Merge facts the policy recorded on the context but did not
-            // attach itself (hand-built results); may upgrade a
-            // NotApplicable with a recorded load failure to Indeterminate.
-            let mut result = ctx.finish(result);
-            if declared_effect == Effect::Forbid && result.is_granted() {
-                tracing::warn!(
-                    policy.type = policy_type.as_ref(),
-                    "{FORBID_EFFECT_GRANT_REASON}"
-                );
-                result = forbid_effect_grant_to_not_applicable(policy_type.clone(), &result);
-            }
-
-            let result_passes = result.is_granted();
-            let result_forbids = result.is_forbidden();
-            let result_indeterminate = result.decision() == Decision::Indeterminate;
-            if declared_effect == Effect::Allow && result_forbids {
-                tracing::warn!(
-                    policy.type = policy_type.as_ref(),
-                    "{ALLOW_EFFECT_FORBID_REASON}"
-                );
-            }
-            let policy_type_str: &str = policy_type.as_ref();
-            let metadata = policy.security_rule();
-            let reason = result.reason();
-            let reason_str = reason.as_deref();
-            let rule_name = metadata.name().unwrap_or(policy_type_str);
-            let category = metadata
-                .category()
-                .unwrap_or(DEFAULT_SECURITY_RULE_CATEGORY);
-            let ruleset_name = metadata
-                .ruleset_name()
-                .unwrap_or(PERMISSION_CHECKER_POLICY_TYPE);
-            let event_outcome = if result_passes {
-                "success"
-            } else if result_indeterminate {
-                "unknown"
+            let grant_children = match grant {
+                PolicyEvalResult::Combined { children, .. } => children,
+                _ => unreachable!(),
+            };
+            if children.is_empty() {
+                children = grant_children;
             } else {
-                "failure"
+                children.extend(grant_children);
+            }
+            combined(
+                PERMISSION_CHECKER_POLICY_TYPE,
+                CombineOp::DenyOverrides,
+                children,
+                decision,
+            )
+        } else {
+            veto
+        };
+        let evaluation = evaluation_from_tree(root);
+        #[cfg(feature = "tracing")]
+        {
+            let (outcome, policy_type) = match &evaluation {
+                AccessEvaluation::Granted { policy_type, .. } => {
+                    ("granted", Some(policy_type.as_ref()))
+                }
+                AccessEvaluation::Denied { trace, .. } => (
+                    "denied",
+                    trace
+                        .root()
+                        .and_then(PolicyEvalResult::forbidden_leaf)
+                        .map(|(name, _)| name),
+                ),
+                AccessEvaluation::Indeterminate { trace, .. } => (
+                    "indeterminate",
+                    trace
+                        .root()
+                        .and_then(PolicyEvalResult::indeterminate_leaf)
+                        .map(|(name, _)| name),
+                ),
             };
-            let policy_effect = declared_effect.telemetry_label();
-
-            tracing::trace!(
-                target: "gatehouse::security",
-                {
-                    security_rule.name = rule_name,
-                    security_rule.category = category,
-                    security_rule.description = metadata.description(),
-                    security_rule.reference = metadata.reference(),
-                    security_rule.ruleset.name = ruleset_name,
-                    security_rule.uuid = metadata.uuid(),
-                    security_rule.version = metadata.version(),
-                    security_rule.license = metadata.license(),
-                    event.outcome = event_outcome,
-                    policy.type = policy_type_str,
-                    policy.effect = policy_effect,
-                    policy.result.reason = reason_str,
-                },
-                "Security rule evaluated"
-            );
-
-            let forbidden = result_forbids.then(|| {
-                result
-                    .forbidden_leaf()
-                    .map(|(policy_type, reason)| {
-                        (policy_type.to_string(), reason.map(str::to_owned))
-                    })
-                    .unwrap_or_else(|| (policy_type_str.to_string(), reason.clone()))
-            });
-
-            if result_indeterminate {
-                let attribution = indeterminate_attribution(&result, policy_type.as_ref());
-                if policy_index < self.veto_capable_count {
-                    veto_indeterminate.get_or_insert(attribution);
-                } else {
-                    allow_indeterminate.get_or_insert(attribution);
-                }
-            }
-
-            policy_results.push(result);
-
-            if let Some((forbid_policy_type, forbid_reason)) = forbidden {
-                tracing::Span::current().record("outcome", "denied");
-                tracing::Span::current().record("policy.type", forbid_policy_type.as_str());
-                let combined = checker_root(policy_results, Decision::Forbid);
-                return AccessEvaluation::Denied {
-                    trace: EvalTrace::with_root(combined),
-                    reason: forbid_summary(&forbid_policy_type, forbid_reason.as_deref()),
-                };
-            }
-
-            if result_passes {
-                first_grant.get_or_insert_with(|| (policy_type.clone(), reason));
-            }
-
-            if policy_index + 1 >= self.veto_capable_count {
-                // Every veto-capable policy has now been evaluated and none
-                // forbade. If one of them was indeterminate its potential
-                // veto is unresolved, so no grant may be released; the
-                // remaining allow-only policies cannot change that.
-                if let Some((policy_type, reason)) = veto_indeterminate.take() {
-                    tracing::Span::current().record("outcome", "indeterminate");
-                    tracing::Span::current().record("policy.type", policy_type.as_str());
-                    let combined = checker_root(policy_results, Decision::Indeterminate);
-                    return AccessEvaluation::Indeterminate {
-                        trace: EvalTrace::with_root(combined),
-                        reason: indeterminate_summary(&policy_type, &reason),
-                    };
-                }
-                if let Some((policy_type, reason)) = first_grant.take() {
-                    tracing::Span::current().record("outcome", "granted");
-                    tracing::Span::current().record("policy.type", policy_type.as_ref());
-                    let combined = checker_root(policy_results, Decision::Grant);
-                    return AccessEvaluation::Granted {
-                        policy_type,
-                        reason,
-                        trace: EvalTrace::with_root(combined),
-                    };
-                }
+            tracing::Span::current().record("outcome", outcome);
+            if let Some(policy_type) = policy_type {
+                tracing::Span::current().record("policy.type", policy_type);
             }
         }
-
-        // Nothing granted and no veto fired. If an allow-only policy was
-        // indeterminate it might have granted, so the evaluation cannot
-        // claim the policies denied the request.
-        if let Some((policy_type, reason)) = allow_indeterminate.take() {
-            tracing::Span::current().record("outcome", "indeterminate");
-            tracing::Span::current().record("policy.type", policy_type.as_str());
-            let combined = checker_root(policy_results, Decision::Indeterminate);
-            return AccessEvaluation::Indeterminate {
-                trace: EvalTrace::with_root(combined),
-                reason: indeterminate_summary(&policy_type, &reason),
-            };
-        }
-
-        tracing::Span::current().record("outcome", "denied");
-        let combined = checker_root(policy_results, Decision::NotApplicable);
-        AccessEvaluation::Denied {
-            trace: EvalTrace::with_root(combined),
-            reason: "All policies denied access".to_string(),
-        }
+        evaluation
     }
 
-    #[tracing::instrument(name = "evaluate_batch", skip_all, fields(checker.name = tracing::field::Empty, item_count, granted_count, denied_count, indeterminate_count, max_batch_size, policy_count = self.policies.len()))]
+    async fn evaluate_resources<'item>(
+        &self,
+        session: &EvaluationSession,
+        subject: &D::Subject,
+        action: &D::Action,
+        context: &D::Context,
+        items: &[PolicyBatchItem<'item, D>],
+    ) -> Vec<AccessEvaluation> {
+        if items.is_empty() {
+            return Vec::new();
+        }
+        let batch = BatchEvalCtx::new(
+            session,
+            subject,
+            action,
+            context,
+            items,
+            PERMISSION_CHECKER_POLICY_TYPE,
+        );
+        let mut state = EvaluationState::default();
+        let item_indices: Vec<_> = (0..items.len()).collect();
+        let mut scope = PhaseScope {
+            state: &mut state,
+            item_indices: &item_indices,
+            path: &[],
+        };
+        let veto_results = self.evaluate_phase(Phase::Veto, &batch, &mut scope).await;
+        let grant_indices: Vec<_> = veto_results
+            .iter()
+            .enumerate()
+            .filter_map(|(index, result)| {
+                (result.decision() == Decision::NotApplicable).then_some(index)
+            })
+            .collect();
+        let grant_items: Vec<_> = grant_indices
+            .iter()
+            .map(|&index| PolicyBatchItem {
+                resource: items[index].resource,
+            })
+            .collect();
+        let grant_ctx = BatchEvalCtx::new(
+            session,
+            subject,
+            action,
+            context,
+            &grant_items,
+            PERMISSION_CHECKER_POLICY_TYPE,
+        );
+        let mut scope = PhaseScope {
+            state: &mut state,
+            item_indices: &grant_indices,
+            path: &[],
+        };
+        let grant_results = self
+            .evaluate_phase(Phase::Grant, &grant_ctx, &mut scope)
+            .await;
+        let mut grants = grant_indices.into_iter().zip(grant_results).peekable();
+        veto_results
+            .into_iter()
+            .enumerate()
+            .map(|(index, veto)| {
+                let decision = veto.decision();
+                let mut children = match veto {
+                    PolicyEvalResult::Combined { children, .. } => children,
+                    _ => unreachable!(),
+                };
+                let decision = if grants
+                    .peek()
+                    .is_some_and(|(grant_index, _)| *grant_index == index)
+                {
+                    let (_, grant) = grants.next().expect("matching grant index");
+                    let decision = grant.decision();
+                    if let PolicyEvalResult::Combined {
+                        children: grant_children,
+                        ..
+                    } = grant
+                    {
+                        children.extend(grant_children);
+                    }
+                    decision
+                } else {
+                    decision
+                };
+                evaluation_from_tree(combined(
+                    PERMISSION_CHECKER_POLICY_TYPE,
+                    CombineOp::DenyOverrides,
+                    children,
+                    decision,
+                ))
+            })
+            .collect()
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "evaluate_batch", skip_all, fields(checker.name = self.name(), policy_count = self.grants.len() + self.vetoes.len(), max_batch_size, item_count, granted_count, denied_count, indeterminate_count)))]
     async fn evaluate_batch_by<I, F>(
         &self,
         session: &EvaluationSession,
@@ -395,320 +533,37 @@ impl<D: PolicyDomain> PermissionChecker<D> {
         I: IntoIterator,
         F: for<'item> Fn(&'item I::Item) -> &'item D::Resource,
     {
-        let items: Vec<I::Item> = resources.into_iter().collect();
-        let item_count = items.len();
-        if let Some(name) = self.name.as_deref() {
-            tracing::Span::current().record("checker.name", name);
-        }
-        tracing::Span::current().record("item_count", item_count);
-        if let Some(max_batch_size) = self.max_batch_size {
-            tracing::Span::current().record("max_batch_size", max_batch_size.get());
-        }
-
-        let mut traces = vec![Vec::new(); item_count];
-        let mut evaluations: Vec<Option<AccessEvaluation>> = vec![None; item_count];
-
-        if self.policies.is_empty() {
-            let results = items
-                .into_iter()
-                .map(|item| {
-                    let result = PolicyEvalResult::not_applicable(
-                        PERMISSION_CHECKER_POLICY_TYPE,
-                        "No policies configured",
-                    );
-                    (
-                        item,
-                        AccessEvaluation::Denied {
-                            trace: EvalTrace::with_root(result),
-                            reason: "No policies configured".to_string(),
-                        },
-                    )
-                })
-                .collect();
-            tracing::Span::current().record("granted_count", 0usize);
-            tracing::Span::current().record("denied_count", item_count);
-            tracing::Span::current().record("indeterminate_count", 0usize);
-            return results;
-        }
-
-        let item_parts = items
+        let resources: Vec<_> = resources.into_iter().collect();
+        let items: Vec<_> = resources
             .iter()
-            .map(|item| PolicyBatchItem::<D> {
+            .map(|item| PolicyBatchItem {
                 resource: resource_of(item),
             })
-            .collect::<Vec<_>>();
-
-        let mut pending: Vec<usize> = (0..item_count).collect();
-        let mut first_grants: Vec<Option<(Cow<'static, str>, Option<String>)>> =
-            vec![None; item_count];
-        // Per-item indeterminate bookkeeping, allocated only when an
-        // indeterminate result is actually observed so the common
-        // all-definite path pays nothing. `notes` holds the attribution for
-        // the first indeterminate policy result (any position); `veto`
-        // marks items whose veto prefix contained one (which blocks their
-        // grants).
-        struct IndeterminateState {
-            notes: Vec<Option<(String, String)>>,
-            veto: Vec<bool>,
-        }
-        let mut indeterminate: Option<IndeterminateState> = None;
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            if pending.is_empty() {
-                break;
+            .collect();
+        let evaluations = self
+            .evaluate_resources(session, subject, action, context, &items)
+            .await;
+        #[cfg(feature = "tracing")]
+        {
+            if let Some(size) = self.max_batch_size {
+                tracing::Span::current().record("max_batch_size", size.get());
             }
-
-            let declared_effect = self.declared_effect(policy_index);
-            let policy_type = policy.policy_type();
-            let policy_type_str: &str = policy_type.as_ref();
-            let mut still_pending = Vec::new();
-            let chunk_size = self
-                .max_batch_size
-                .map_or(pending.len(), NonZeroUsize::get)
-                .max(1);
-            let chunk_count = pending.len().div_ceil(chunk_size);
-
-            for (chunk_index, pending_chunk) in pending.chunks(chunk_size).enumerate() {
-                let policy_span = tracing::debug_span!(
-                    "gatehouse.batch_policy",
-                    policy.type = policy_type_str,
-                    policy.effect = declared_effect.telemetry_label(),
-                    policy.pending_count = pending_chunk.len(),
-                    policy.chunk_index = chunk_index,
-                    policy.chunk_count = chunk_count,
-                    policy.granted_count = tracing::field::Empty,
-                    policy.denied_count = tracing::field::Empty,
-                    policy.forbidden_count = tracing::field::Empty,
-                    policy.indeterminate_count = tracing::field::Empty,
-                );
-                let mut policy_granted_count = 0usize;
-                let mut policy_denied_count = 0usize;
-                let mut policy_forbidden_count = 0usize;
-                let mut policy_indeterminate_count = 0usize;
-                let mut contract_violation_count = 0usize;
-                let mut allow_forbid_violation_count = 0usize;
-                let batch_items = pending_chunk
-                    .iter()
-                    .map(|&index| PolicyBatchItem {
-                        resource: item_parts[index].resource,
-                    })
-                    .collect::<Vec<_>>();
-
-                let batch_ctx = BatchEvalCtx::new(
-                    session,
-                    subject,
-                    action,
-                    context,
-                    &batch_items,
-                    policy_type.clone(),
-                );
-                let policy_results = policy
-                    .evaluate_batch(&batch_ctx)
-                    .instrument(policy_span.clone())
-                    .await;
-                // Merge per-item recorded facts into the per-item results
-                // (no-op for wrong-length results, which are replaced below).
-                let policy_results = batch_ctx.finish(policy_results);
-
-                // A wrong-length result breaks the one-result-per-item
-                // contract, so this policy evaluated none of these items.
-                // Synthesize an indeterminate result per item and feed it
-                // through the ordinary effect-aware bookkeeping below rather
-                // than sealing the items here: a veto-capable policy's
-                // indeterminate still yields to a later definite forbid in
-                // the prefix, and an allow-only policy's indeterminate never
-                // suppresses a later grant.
-                let policy_results = if policy_results.len() == pending_chunk.len() {
-                    policy_results
-                } else {
-                    pending_chunk
-                        .iter()
-                        .map(|_| {
-                            PolicyEvalResult::indeterminate(
-                                policy_type.clone(),
-                                "Policy batch result count did not match input count",
-                            )
-                        })
-                        .collect()
-                };
-
-                for (&index, result) in pending_chunk.iter().zip(policy_results) {
-                    let mut result = result;
-                    if declared_effect == Effect::Forbid && result.is_granted() {
-                        contract_violation_count += 1;
-                        result =
-                            forbid_effect_grant_to_not_applicable(policy_type.clone(), &result);
-                    }
-                    let result_passes = result.is_granted();
-                    let result_forbids = result.is_forbidden();
-                    let result_indeterminate = result.decision() == Decision::Indeterminate;
-                    if declared_effect == Effect::Allow && result_forbids {
-                        allow_forbid_violation_count += 1;
-                    }
-                    let reason = result.reason();
-                    let forbidden = result_forbids.then(|| {
-                        result
-                            .forbidden_leaf()
-                            .map(|(policy_type, reason)| {
-                                (policy_type.to_string(), reason.map(str::to_owned))
-                            })
-                            .unwrap_or_else(|| (policy_type_str.to_string(), reason.clone()))
-                    });
-
-                    if result_indeterminate {
-                        let attribution = indeterminate_attribution(&result, policy_type_str);
-                        let state = indeterminate.get_or_insert_with(|| IndeterminateState {
-                            notes: vec![None; item_count],
-                            veto: vec![false; item_count],
-                        });
-                        state.notes[index].get_or_insert(attribution);
-                        if policy_index < self.veto_capable_count {
-                            state.veto[index] = true;
-                        }
-                    }
-
-                    traces[index].push(result);
-
-                    if let Some((forbid_policy_type, forbid_reason)) = forbidden {
-                        policy_forbidden_count += 1;
-                        let combined =
-                            checker_root(std::mem::take(&mut traces[index]), Decision::Forbid);
-                        evaluations[index] = Some(AccessEvaluation::Denied {
-                            trace: EvalTrace::with_root(combined),
-                            reason: forbid_summary(&forbid_policy_type, forbid_reason.as_deref()),
-                        });
-                    } else {
-                        if result_passes {
-                            policy_granted_count += 1;
-                            first_grants[index]
-                                .get_or_insert_with(|| (policy_type.clone(), reason));
-                        } else if result_indeterminate {
-                            policy_indeterminate_count += 1;
-                        } else {
-                            policy_denied_count += 1;
-                        }
-
-                        if policy_index + 1 >= self.veto_capable_count {
-                            // Mirrors `evaluate_one`: after the full veto
-                            // prefix, an unresolved potential veto blocks
-                            // any grant for this item.
-                            if indeterminate
-                                .as_ref()
-                                .is_some_and(|state| state.veto[index])
-                            {
-                                let (note_policy_type, note_reason) = indeterminate
-                                    .as_mut()
-                                    .and_then(|state| state.notes[index].take())
-                                    .unwrap_or_else(|| {
-                                        (policy_type_str.to_string(), String::new())
-                                    });
-                                let combined = checker_root(
-                                    std::mem::take(&mut traces[index]),
-                                    Decision::Indeterminate,
-                                );
-                                evaluations[index] = Some(AccessEvaluation::Indeterminate {
-                                    trace: EvalTrace::with_root(combined),
-                                    reason: indeterminate_summary(&note_policy_type, &note_reason),
-                                });
-                            } else if let Some((grant_policy_type, grant_reason)) =
-                                first_grants[index].take()
-                            {
-                                let combined = checker_root(
-                                    std::mem::take(&mut traces[index]),
-                                    Decision::Grant,
-                                );
-                                evaluations[index] = Some(AccessEvaluation::Granted {
-                                    policy_type: grant_policy_type,
-                                    reason: grant_reason,
-                                    trace: EvalTrace::with_root(combined),
-                                });
-                            } else {
-                                still_pending.push(index);
-                            }
-                        } else {
-                            still_pending.push(index);
-                        }
-                    }
-                }
-                if contract_violation_count > 0 {
-                    tracing::warn!(
-                        policy.type = policy_type_str,
-                        item_count = contract_violation_count,
-                        "{FORBID_EFFECT_GRANT_REASON}"
-                    );
-                }
-                if allow_forbid_violation_count > 0 {
-                    tracing::warn!(
-                        policy.type = policy_type_str,
-                        item_count = allow_forbid_violation_count,
-                        "{ALLOW_EFFECT_FORBID_REASON}"
-                    );
-                }
-                policy_span.record("policy.granted_count", policy_granted_count);
-                policy_span.record("policy.denied_count", policy_denied_count);
-                policy_span.record("policy.forbidden_count", policy_forbidden_count);
-                policy_span.record("policy.indeterminate_count", policy_indeterminate_count);
-            }
-            pending = still_pending;
+            let granted = evaluations
+                .iter()
+                .filter(|result| result.is_granted())
+                .count();
+            let indeterminate = evaluations
+                .iter()
+                .filter(|result| result.is_indeterminate())
+                .count();
+            tracing::Span::current().record("item_count", evaluations.len());
+            tracing::Span::current().record("granted_count", granted);
+            tracing::Span::current().record("indeterminate_count", indeterminate);
+            tracing::Span::current()
+                .record("denied_count", evaluations.len() - granted - indeterminate);
         }
-
-        for index in pending {
-            // Mirrors `evaluate_one`: nothing granted and no veto fired.
-            // An allow-only indeterminate policy might have granted, so the
-            // item is indeterminate rather than denied.
-            if let Some((note_policy_type, note_reason)) = indeterminate
-                .as_mut()
-                .and_then(|state| state.notes[index].take())
-            {
-                let combined =
-                    checker_root(std::mem::take(&mut traces[index]), Decision::Indeterminate);
-                evaluations[index] = Some(AccessEvaluation::Indeterminate {
-                    trace: EvalTrace::with_root(combined),
-                    reason: indeterminate_summary(&note_policy_type, &note_reason),
-                });
-            } else {
-                let combined =
-                    checker_root(std::mem::take(&mut traces[index]), Decision::NotApplicable);
-                evaluations[index] = Some(AccessEvaluation::Denied {
-                    trace: EvalTrace::with_root(combined),
-                    reason: "All policies denied access".to_string(),
-                });
-            }
-        }
-
-        drop(item_parts);
-
-        let mut granted_count = 0usize;
-        let mut indeterminate_count = 0usize;
-        let results = items
-            .into_iter()
-            .zip(evaluations.into_iter())
-            .map(|(item, evaluation)| {
-                let evaluation = evaluation.unwrap_or_else(|| {
-                    let result = PolicyEvalResult::not_applicable(
-                        PERMISSION_CHECKER_POLICY_TYPE,
-                        "Batch item was not evaluated",
-                    );
-                    AccessEvaluation::Denied {
-                        trace: EvalTrace::with_root(result),
-                        reason: "Batch item was not evaluated".to_string(),
-                    }
-                });
-                if evaluation.is_granted() {
-                    granted_count += 1;
-                } else if evaluation.is_indeterminate() {
-                    indeterminate_count += 1;
-                }
-                (item, evaluation)
-            })
-            .collect::<Vec<_>>();
-        let denied_count = item_count - granted_count - indeterminate_count;
-        tracing::Span::current().record("granted_count", granted_count);
-        tracing::Span::current().record("denied_count", denied_count);
-        tracing::Span::current().record("indeterminate_count", indeterminate_count);
-        results
+        resources.into_iter().zip(evaluations).collect()
     }
-
     async fn evaluate_batch<I>(
         &self,
         session: &EvaluationSession,
@@ -833,6 +688,48 @@ impl<'a, D: PolicyDomain> BoundEvaluator<'a, D> {
             .collect()
     }
 
+    /// Returns granted resources, or all input evaluations if any is indeterminate.
+    ///
+    /// Definite denials are excluded. A failure that is superseded by a decisive
+    /// grant does not fail the batch. No partial authorized list is returned.
+    pub async fn try_filter<I>(&self, resources: I) -> Result<Vec<I::Item>, FilterError<I::Item>>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<D::Resource>,
+    {
+        Self::collect_authorized(self.evaluate(resources).await)
+    }
+
+    /// Like [`Self::try_filter`], projecting caller-owned items to their resources.
+    ///
+    /// On error, all original items and evaluations are retained in input order.
+    pub async fn try_filter_by<I, F>(
+        &self,
+        items: I,
+        resource_of: F,
+    ) -> Result<Vec<I::Item>, FilterError<I::Item>>
+    where
+        I: IntoIterator,
+        F: for<'item> Fn(&'item I::Item) -> &'item D::Resource,
+    {
+        Self::collect_authorized(self.evaluate_by(items, resource_of).await)
+    }
+
+    fn collect_authorized<T>(
+        evaluations: Vec<(T, AccessEvaluation)>,
+    ) -> Result<Vec<T>, FilterError<T>> {
+        if evaluations
+            .iter()
+            .any(|(_, evaluation)| evaluation.is_indeterminate())
+        {
+            return Err(FilterError { evaluations });
+        }
+        Ok(evaluations
+            .into_iter()
+            .filter_map(|(item, evaluation)| evaluation.is_granted().then_some(item))
+            .collect())
+    }
+
     /// Looks up one candidate page, hydrates it, and returns authorized
     /// resources from that page.
     ///
@@ -852,16 +749,67 @@ impl<'a, D: PolicyDomain> BoundEvaluator<'a, D> {
         L: LookupSource<D>,
         H: Hydrator<L::Id, Resource = D::Resource>,
     {
+        let page = self
+            .lookup_candidates(lookup, hydrator, cursor, limit)
+            .await?;
+        Ok(LookupAuthorizedPage {
+            resources: self.filter(page.resources).await,
+            next_cursor: page.next_cursor,
+        })
+    }
+
+    /// Looks up and hydrates one candidate page, failing if authorization is indeterminate.
+    ///
+    /// Definite denials are excluded. On authorization failure, the error retains
+    /// all hydrated resources and evaluations. No next cursor is returned: retry
+    /// the same input cursor after recovery rather than silently skipping a page.
+    pub async fn try_lookup_page<L, H>(
+        &self,
+        lookup: &L,
+        hydrator: &H,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+    ) -> Result<
+        LookupAuthorizedPage<D::Resource>,
+        LookupAuthorizedError<L::Error, H::Error, D::Resource>,
+    >
+    where
+        L: LookupSource<D>,
+        H: Hydrator<L::Id, Resource = D::Resource>,
+    {
+        let page = self
+            .lookup_candidates(lookup, hydrator, cursor, limit)
+            .await?;
+        Ok(LookupAuthorizedPage {
+            resources: self
+                .try_filter(page.resources)
+                .await
+                .map_err(LookupAuthorizedError::Evaluation)?,
+            next_cursor: page.next_cursor,
+        })
+    }
+
+    async fn lookup_candidates<L, H, R>(
+        &self,
+        lookup: &L,
+        hydrator: &H,
+        cursor: Option<&[u8]>,
+        limit: NonZeroUsize,
+    ) -> Result<LookupAuthorizedPage<D::Resource>, LookupAuthorizedError<L::Error, H::Error, R>>
+    where
+        L: LookupSource<D>,
+        H: Hydrator<L::Id, Resource = D::Resource>,
+    {
+        #[cfg(feature = "tracing")]
         let lookup_span = tracing::debug_span!(
             "gatehouse.lookup",
             lookup.limit = limit.get(),
             lookup.has_cursor = cursor.is_some(),
         );
-        let page = lookup
-            .lookup_page(self.subject, self.action, self.context, cursor, limit)
-            .instrument(lookup_span)
-            .await
-            .map_err(LookupAuthorizedError::Lookup)?;
+        let page = lookup.lookup_page(self.subject, self.action, self.context, cursor, limit);
+        #[cfg(feature = "tracing")]
+        let page = page.instrument(lookup_span);
+        let page = page.await.map_err(LookupAuthorizedError::Lookup)?;
 
         if cursor.is_some() && page.next_cursor.as_deref() == cursor {
             return Err(LookupAuthorizedError::LookupCursorStuck);
@@ -874,15 +822,15 @@ impl<'a, D: PolicyDomain> BoundEvaluator<'a, D> {
             });
         }
 
+        #[cfg(feature = "tracing")]
         let hydrate_span = tracing::debug_span!(
             "gatehouse.hydrate",
             hydrate.candidate_count = page.ids.len()
         );
-        let hydrated = hydrator
-            .hydrate(&page.ids)
-            .instrument(hydrate_span)
-            .await
-            .map_err(LookupAuthorizedError::Hydrate)?;
+        let hydrated = hydrator.hydrate(&page.ids);
+        #[cfg(feature = "tracing")]
+        let hydrated = hydrated.instrument(hydrate_span);
+        let hydrated = hydrated.await.map_err(LookupAuthorizedError::Hydrate)?;
 
         if hydrated.len() != page.ids.len() {
             return Err(LookupAuthorizedError::HydratorContractViolation {
@@ -892,11 +840,106 @@ impl<'a, D: PolicyDomain> BoundEvaluator<'a, D> {
         }
 
         let resources = hydrated.into_iter().flatten().collect::<Vec<_>>();
-        let authorized = self.filter(resources).await;
-
         Ok(LookupAuthorizedPage {
-            resources: authorized,
+            resources,
             next_cursor: page.next_cursor,
         })
+    }
+}
+
+fn evaluation_from_tree(tree: PolicyEvalResult) -> AccessEvaluation {
+    let decision = tree.decision();
+    match decision {
+        Decision::Grant => {
+            let (policy_type, reason) = winning_grant(&tree)
+                .unwrap_or((Cow::Borrowed(PERMISSION_CHECKER_POLICY_TYPE), None));
+            AccessEvaluation::Granted {
+                policy_type,
+                reason,
+                trace: EvalTrace::with_root(tree),
+            }
+        }
+        Decision::Forbid => {
+            let reason = tree
+                .forbidden_leaf()
+                .map(|(name, reason)| match reason {
+                    Some(reason) => format!("Forbidden by {name}: {reason}"),
+                    None => format!("Forbidden by {name}"),
+                })
+                .unwrap_or_else(|| "Access forbidden".into());
+            AccessEvaluation::Denied {
+                reason,
+                trace: EvalTrace::with_root(tree),
+            }
+        }
+        Decision::Indeterminate => {
+            let reason = tree
+                .indeterminate_leaf()
+                .map(|(name, reason)| format!("Could not evaluate {name}: {reason}"))
+                .unwrap_or_else(|| "Authorization could not be evaluated".into());
+            AccessEvaluation::Indeterminate {
+                reason,
+                trace: EvalTrace::with_root(tree),
+            }
+        }
+        _ => AccessEvaluation::Denied {
+            reason: if matches!(&tree, PolicyEvalResult::Combined { children, .. } if children.is_empty())
+            {
+                "No policies configured".into()
+            } else {
+                "All policies denied access".into()
+            },
+            trace: EvalTrace::with_root(tree),
+        },
+    }
+}
+fn winning_grant(tree: &PolicyEvalResult) -> Option<(Cow<'static, str>, Option<String>)> {
+    match tree {
+        PolicyEvalResult::Combined { children, .. } => children
+            .iter()
+            .find(|child| child.is_granted())
+            .map(|child| {
+                let policy_type = match child {
+                    PolicyEvalResult::Granted { policy_type, .. }
+                    | PolicyEvalResult::NotApplicable { policy_type, .. }
+                    | PolicyEvalResult::Forbidden { policy_type, .. }
+                    | PolicyEvalResult::Indeterminate { policy_type, .. }
+                    | PolicyEvalResult::Combined { policy_type, .. } => policy_type.clone(),
+                };
+                (policy_type, child.reason())
+            }),
+        _ => None,
+    }
+}
+#[cfg(feature = "tracing")]
+fn emit_policy_event<D: PolicyDomain>(
+    policy: &dyn PhasePolicy<D>,
+    result: &PolicyEvalResult,
+    phase: Phase,
+) {
+    let metadata = policy.security_rule();
+    let policy_type = policy.policy_type();
+    let reason = result.reason();
+    let event_outcome = match result.decision() {
+        Decision::Grant => "success",
+        Decision::Indeterminate => "unknown",
+        _ => "failure",
+    };
+    let effect = phase_effect(phase);
+    tracing::trace!(target: "gatehouse::security", {
+        security_rule.name = metadata.name().unwrap_or(policy_type.as_ref()),
+        security_rule.category = metadata.category().unwrap_or(DEFAULT_SECURITY_RULE_CATEGORY),
+        security_rule.description = metadata.description(), security_rule.reference = metadata.reference(),
+        security_rule.ruleset.name = metadata.ruleset_name().unwrap_or(PERMISSION_CHECKER_POLICY_TYPE),
+        security_rule.uuid = metadata.uuid(), security_rule.version = metadata.version(), security_rule.license = metadata.license(),
+        event.outcome = event_outcome, policy.type = policy_type.as_ref(), policy.effect = effect, policy.result.reason = reason.as_deref(),
+        }, "Security rule evaluated");
+}
+
+#[cfg(feature = "tracing")]
+fn phase_effect(phase: Phase) -> &'static str {
+    match phase {
+        Phase::Grant => "allow",
+        Phase::Veto => "deny",
     }
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -735,9 +735,10 @@ impl<'a, D: PolicyDomain> BoundEvaluator<'a, D> {
     ///
     /// Indeterminate resources are excluded exactly like denials, so this
     /// method can return `Ok` with a shorter or empty page during an
-    /// authorization-data outage. Drive the lookup and hydration steps
-    /// directly, then use [`Self::evaluate`] if the caller must surface that
-    /// distinction.
+    /// authorization-data outage. Use [`Self::try_lookup_page`] if the caller
+    /// must surface that distinction. Although the return type is shared with
+    /// the strict API, this method never returns
+    /// [`LookupAuthorizedError::Evaluation`].
     pub async fn lookup_page<L, H>(
         &self,
         lookup: &L,

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -1,624 +1,231 @@
+use crate::capability::combined;
 use crate::{
-    BatchEvalCtx, CombineOp, Decision, Effect, EvalCtx, FactOutcome, Policy, PolicyBatchItem,
-    PolicyDomain, PolicyEvalResult,
+    BatchEvalCtx, CombineOp, Decision, EvalCtx, GrantResult, Policy, PolicyBatchItem, PolicyDomain,
+    VetoPolicy, VetoResult,
 };
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
-fn arc_policy<D, P>(policy: P) -> Arc<dyn Policy<D>>
-where
-    D: PolicyDomain,
-    P: Policy<D> + 'static,
-{
-    Arc::new(policy)
-}
-
-fn ordered_policies<D>(policies: Vec<Arc<dyn Policy<D>>>) -> (Vec<Arc<dyn Policy<D>>>, usize)
-where
-    D: PolicyDomain,
-{
-    let mut veto_capable = Vec::new();
-    let mut allow_only = Vec::new();
-    for policy in policies {
-        if policy.effect().can_forbid() {
-            veto_capable.push(policy);
-        } else {
-            allow_only.push(policy);
-        }
-    }
-    let veto_capable_count = veto_capable.len();
-    let mut ordered = Vec::with_capacity(veto_capable_count + allow_only.len());
-    ordered.extend(veto_capable);
-    ordered.extend(allow_only);
-    (ordered, veto_capable_count)
-}
-
-fn any_child_can_forbid<D>(policies: &[Arc<dyn Policy<D>>]) -> bool
-where
-    D: PolicyDomain,
-{
-    policies.iter().any(|policy| policy.effect().can_forbid())
-}
-
-/// Fluent combinator helpers for policies.
-pub trait PolicyExt<D>: Policy<D> + Sized + 'static
-where
-    D: PolicyDomain,
-{
-    /// Requires this policy and `other` to grant.
-    fn and<P>(self, other: P) -> AndPolicy<D>
-    where
-        P: Policy<D> + 'static,
-    {
-        AndPolicy::from_policies(vec![arc_policy::<D, _>(self), arc_policy::<D, _>(other)])
-    }
-
-    /// Grants when this policy or `other` grants.
-    fn or<P>(self, other: P) -> OrPolicy<D>
-    where
-        P: Policy<D> + 'static,
-    {
-        OrPolicy::from_policies(vec![arc_policy::<D, _>(self), arc_policy::<D, _>(other)])
-    }
-
-    /// Inverts this policy.
-    fn not(self) -> NotPolicy<D> {
-        NotPolicy {
-            policy: arc_policy::<D, _>(self),
-        }
-    }
-
-    /// Boxes this policy as a trait object.
-    fn boxed(self) -> Box<dyn Policy<D>> {
-        Box::new(self)
-    }
-}
-
-impl<D, P> PolicyExt<D> for P
-where
-    D: PolicyDomain,
-    P: Policy<D> + Sized + 'static,
-{
-}
-
-/// Combines multiple policies with logical AND semantics.
-pub struct AndPolicy<D: PolicyDomain> {
-    policies: Vec<Arc<dyn Policy<D>>>,
-    veto_capable_count: usize,
-}
-
-/// Error returned when no policies are provided to a combinator policy.
+/// Error returned when no policies are provided to a combinator.
 #[derive(Debug, Copy, Clone)]
 pub struct EmptyPoliciesError(pub &'static str);
-
 impl std::fmt::Display for EmptyPoliciesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.0)
     }
 }
-
 impl std::error::Error for EmptyPoliciesError {}
 
-impl<D: PolicyDomain> AndPolicy<D> {
-    fn from_policies(policies: Vec<Arc<dyn Policy<D>>>) -> Self {
-        let (policies, veto_capable_count) = ordered_policies(policies);
-        Self {
-            policies,
-            veto_capable_count,
+/// Boolean composition for grant policies only.
+///
+/// ```compile_fail
+/// use gatehouse::{PolicyDomain,PolicyBuilder,PolicyExt};
+/// struct D;
+/// impl PolicyDomain for D { type Subject=(); type Action=(); type Resource=(); type Context=(); }
+/// let grant = PolicyBuilder::<D>::new("grant").build();
+/// let veto = PolicyBuilder::<D>::new("veto").build_veto();
+/// let invalid = grant.and(veto);
+/// ```
+pub trait PolicyExt<D: PolicyDomain>: Policy<D> + Sized + 'static {
+    /// Requires both policies to grant.
+    fn and<P: Policy<D> + 'static>(self, other: P) -> AndPolicy<D> {
+        AndPolicy {
+            policies: vec![Arc::new(self), Arc::new(other)],
         }
     }
-
-    /// Creates a new `AndPolicy` from a non-empty list of policies.
-    pub fn try_new(policies: Vec<Arc<dyn Policy<D>>>) -> Result<Self, EmptyPoliciesError> {
-        if policies.is_empty() {
-            Err(EmptyPoliciesError(
-                "AndPolicy must have at least one policy",
-            ))
-        } else {
-            Ok(Self::from_policies(policies))
+    /// Grants if either policy grants.
+    fn or<P: Policy<D> + 'static>(self, other: P) -> OrPolicy<D> {
+        OrPolicy {
+            policies: vec![Arc::new(self), Arc::new(other)],
         }
     }
-}
-
-#[async_trait]
-impl<D: PolicyDomain> Policy<D> for AndPolicy<D> {
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("AndPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        let can_grant = self
-            .policies
-            .iter()
-            .all(|policy| policy.effect().can_grant());
-        Effect::from_capabilities(can_grant, any_child_can_forbid(&self.policies))
-    }
-
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
-        let mut children_results = Vec::with_capacity(self.policies.len());
-        let mut veto_prefix_failed = false;
-        let mut veto_prefix_indeterminate = false;
-        let mut allow_indeterminate = false;
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            let inner_ctx = EvalCtx::new(
-                ctx.session(),
-                ctx.subject,
-                ctx.action,
-                ctx.resource,
-                ctx.context,
-                policy.policy_type(),
-            );
-            let result = policy.evaluate(&inner_ctx).await;
-            let result = inner_ctx.finish(result);
-            let is_granted = result.is_granted();
-            let is_forbidden = result.is_forbidden();
-            let is_indeterminate = result.decision() == Decision::Indeterminate;
-            children_results.push(result);
-
-            if is_forbidden {
-                return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
-                    operation: CombineOp::And,
-                    children: children_results,
-                    decision: Decision::Forbid,
-                };
-            }
-
-            if policy_index < self.veto_capable_count {
-                // An indeterminate veto-capable child might have forbidden;
-                // that possibility outranks a definite non-grant because at
-                // the checker level Forbid and NotApplicable behave
-                // differently for sibling grants.
-                veto_prefix_indeterminate |= is_indeterminate;
-                veto_prefix_failed |= !is_granted && !is_indeterminate;
-                if policy_index + 1 == self.veto_capable_count {
-                    if veto_prefix_indeterminate {
-                        return PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::And,
-                            children: children_results,
-                            decision: Decision::Indeterminate,
-                        };
-                    }
-                    if veto_prefix_failed {
-                        return PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::And,
-                            children: children_results,
-                            decision: Decision::NotApplicable,
-                        };
-                    }
-                }
-            } else if is_indeterminate {
-                // The conjunction cannot be granted, but a later definite
-                // non-grant can still resolve it to NotApplicable, so keep
-                // evaluating.
-                allow_indeterminate = true;
-            } else if !is_granted {
-                return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
-                    operation: CombineOp::And,
-                    children: children_results,
-                    decision: Decision::NotApplicable,
-                };
-            }
-        }
-
-        PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
-            operation: CombineOp::And,
-            children: children_results,
-            decision: if allow_indeterminate {
-                Decision::Indeterminate
-            } else {
-                Decision::Grant
-            },
+    /// Inverts a definite grant or abstention; uncertainty remains uncertain.
+    fn not(self) -> NotPolicy<D> {
+        NotPolicy {
+            policy: Arc::new(self),
         }
     }
-
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
-        let mut children_by_item = vec![Vec::new(); ctx.items.len()];
-        let mut results = vec![None; ctx.items.len()];
-        let mut pending = (0..ctx.items.len()).collect::<Vec<_>>();
-        let mut veto_prefix_failed = vec![false; ctx.items.len()];
-        let mut veto_prefix_indeterminate = vec![false; ctx.items.len()];
-        let mut allow_indeterminate = vec![false; ctx.items.len()];
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            if pending.is_empty() {
-                break;
-            }
-
-            let batch_items = pending
-                .iter()
-                .map(|&index| PolicyBatchItem {
-                    resource: ctx.items[index].resource,
-                })
-                .collect::<Vec<_>>();
-            let batch_ctx = BatchEvalCtx::new(
-                ctx.session(),
-                ctx.subject,
-                ctx.action,
-                ctx.context,
-                &batch_items,
-                policy.policy_type(),
-            );
-            let child_results = policy.evaluate_batch(&batch_ctx).await;
-            let child_results = batch_ctx.finish(child_results);
-
-            // A wrong-length child batch means this child evaluated none of
-            // the pending items. Treat each as an indeterminate child result
-            // and keep the items pending, so the remaining children still
-            // apply the normal combination rules (a later definite forbid in
-            // the prefix wins; a definite answer from an allow-only child can
-            // still settle the aggregate).
-            let child_results = if child_results.len() == pending.len() {
-                child_results
-            } else {
-                pending
-                    .iter()
-                    .map(|_| {
-                        PolicyEvalResult::indeterminate(
-                            policy.policy_type(),
-                            "Policy batch result count did not match input count",
-                        )
-                    })
-                    .collect()
-            };
-
-            let mut still_pending = Vec::new();
-            for (index, child_result) in pending.into_iter().zip(child_results) {
-                let is_granted = child_result.is_granted();
-                let is_forbidden = child_result.is_forbidden();
-                let is_indeterminate = child_result.decision() == Decision::Indeterminate;
-                children_by_item[index].push(child_result);
-
-                if is_forbidden {
-                    results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
-                        operation: CombineOp::And,
-                        children: std::mem::take(&mut children_by_item[index]),
-                        decision: Decision::Forbid,
-                    });
-                } else if policy_index < self.veto_capable_count {
-                    veto_prefix_indeterminate[index] |= is_indeterminate;
-                    veto_prefix_failed[index] |= !is_granted && !is_indeterminate;
-                    if policy_index + 1 == self.veto_capable_count
-                        && (veto_prefix_indeterminate[index] || veto_prefix_failed[index])
-                    {
-                        results[index] = Some(PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::And,
-                            children: std::mem::take(&mut children_by_item[index]),
-                            decision: if veto_prefix_indeterminate[index] {
-                                Decision::Indeterminate
-                            } else {
-                                Decision::NotApplicable
-                            },
-                        });
-                    } else {
-                        still_pending.push(index);
-                    }
-                } else if is_indeterminate {
-                    allow_indeterminate[index] = true;
-                    still_pending.push(index);
-                } else if is_granted {
-                    still_pending.push(index);
-                } else {
-                    results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
-                        operation: CombineOp::And,
-                        children: std::mem::take(&mut children_by_item[index]),
-                        decision: Decision::NotApplicable,
-                    });
-                }
-            }
-            pending = still_pending;
-        }
-
-        for index in pending {
-            results[index] = Some(PolicyEvalResult::Combined {
-                policy_type: self.policy_type(),
-                operation: CombineOp::And,
-                children: std::mem::take(&mut children_by_item[index]),
-                decision: if allow_indeterminate[index] {
-                    Decision::Indeterminate
-                } else {
-                    Decision::Grant
-                },
-            });
-        }
-
-        results
-            .into_iter()
-            .map(|result| {
-                result.unwrap_or_else(|| {
-                    PolicyEvalResult::not_applicable(
-                        self.policy_type(),
-                        "Batch item was not evaluated",
-                    )
-                })
-            })
-            .collect()
+    /// Boxes the policy.
+    fn boxed(self) -> Box<dyn Policy<D>> {
+        Box::new(self)
     }
 }
+impl<D: PolicyDomain, P: Policy<D> + Sized + 'static> PolicyExt<D> for P {}
 
-/// Combines multiple policies with logical OR semantics.
+/// Requires every child policy to grant.
+pub struct AndPolicy<D: PolicyDomain> {
+    policies: Vec<Arc<dyn Policy<D>>>,
+}
+/// Grants when any child policy grants.
 pub struct OrPolicy<D: PolicyDomain> {
     policies: Vec<Arc<dyn Policy<D>>>,
-    veto_capable_count: usize,
 }
-
-impl<D: PolicyDomain> OrPolicy<D> {
-    fn from_policies(policies: Vec<Arc<dyn Policy<D>>>) -> Self {
-        let (policies, veto_capable_count) = ordered_policies(policies);
-        Self {
-            policies,
-            veto_capable_count,
-        }
-    }
-
-    /// Creates a new `OrPolicy` from a non-empty list of policies.
-    pub fn try_new(policies: Vec<Arc<dyn Policy<D>>>) -> Result<Self, EmptyPoliciesError> {
-        if policies.is_empty() {
-            Err(EmptyPoliciesError("OrPolicy must have at least one policy"))
-        } else {
-            Ok(Self::from_policies(policies))
-        }
-    }
-}
-
-#[async_trait]
-impl<D: PolicyDomain> Policy<D> for OrPolicy<D> {
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("OrPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        let can_grant = self
-            .policies
-            .iter()
-            .any(|policy| policy.effect().can_grant());
-        Effect::from_capabilities(can_grant, any_child_can_forbid(&self.policies))
-    }
-
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
-        let mut children_results = Vec::with_capacity(self.policies.len());
-        let mut veto_prefix_granted = false;
-        let mut veto_prefix_indeterminate = false;
-        let mut allow_indeterminate = false;
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            let inner_ctx = EvalCtx::new(
-                ctx.session(),
-                ctx.subject,
-                ctx.action,
-                ctx.resource,
-                ctx.context,
-                policy.policy_type(),
-            );
-            let result = policy.evaluate(&inner_ctx).await;
-            let result = inner_ctx.finish(result);
-            let is_granted = result.is_granted();
-            let is_forbidden = result.is_forbidden();
-            let is_indeterminate = result.decision() == Decision::Indeterminate;
-            children_results.push(result);
-
-            if is_forbidden {
-                return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
-                    operation: CombineOp::Or,
-                    children: children_results,
-                    decision: Decision::Forbid,
-                };
-            }
-
-            if policy_index < self.veto_capable_count {
-                // An indeterminate veto-capable child might have forbidden,
-                // which would override every grant — so it blocks a sibling
-                // grant inside this OR, exactly like the checker's veto
-                // prefix. A definite forbid from a later prefix child still
-                // wins over the indeterminate.
-                veto_prefix_indeterminate |= is_indeterminate;
-                veto_prefix_granted |= is_granted;
-                if policy_index + 1 == self.veto_capable_count {
-                    if veto_prefix_indeterminate {
-                        return PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::Or,
-                            children: children_results,
-                            decision: Decision::Indeterminate,
-                        };
-                    }
-                    if veto_prefix_granted {
-                        return PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::Or,
-                            children: children_results,
-                            decision: Decision::Grant,
-                        };
-                    }
-                }
-            } else if is_granted {
-                // An allow-only indeterminate sibling cannot forbid, so a
-                // definite grant resolves the OR regardless of it.
-                return PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
-                    operation: CombineOp::Or,
-                    children: children_results,
-                    decision: Decision::Grant,
-                };
-            } else if is_indeterminate {
-                allow_indeterminate = true;
-            }
-        }
-
-        PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
-            operation: CombineOp::Or,
-            children: children_results,
-            decision: if allow_indeterminate {
-                Decision::Indeterminate
-            } else {
-                Decision::NotApplicable
-            },
-        }
-    }
-
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
-        let mut children_by_item = vec![Vec::new(); ctx.items.len()];
-        let mut results = vec![None; ctx.items.len()];
-        let mut pending = (0..ctx.items.len()).collect::<Vec<_>>();
-        let mut veto_prefix_granted = vec![false; ctx.items.len()];
-        let mut veto_prefix_indeterminate = vec![false; ctx.items.len()];
-        let mut allow_indeterminate = vec![false; ctx.items.len()];
-
-        for (policy_index, policy) in self.policies.iter().enumerate() {
-            if pending.is_empty() {
-                break;
-            }
-
-            let batch_items = pending
-                .iter()
-                .map(|&index| PolicyBatchItem {
-                    resource: ctx.items[index].resource,
-                })
-                .collect::<Vec<_>>();
-            let batch_ctx = BatchEvalCtx::new(
-                ctx.session(),
-                ctx.subject,
-                ctx.action,
-                ctx.context,
-                &batch_items,
-                policy.policy_type(),
-            );
-            let child_results = policy.evaluate_batch(&batch_ctx).await;
-            let child_results = batch_ctx.finish(child_results);
-
-            // A wrong-length child batch means this child evaluated none of
-            // the pending items. Treat each as an indeterminate child result
-            // and keep the items pending, so the remaining children still
-            // apply the normal combination rules (a later definite forbid in
-            // the prefix wins; a definite answer from an allow-only child can
-            // still settle the aggregate).
-            let child_results = if child_results.len() == pending.len() {
-                child_results
-            } else {
-                pending
-                    .iter()
-                    .map(|_| {
-                        PolicyEvalResult::indeterminate(
-                            policy.policy_type(),
-                            "Policy batch result count did not match input count",
-                        )
-                    })
-                    .collect()
-            };
-
-            let mut still_pending = Vec::new();
-            for (index, child_result) in pending.into_iter().zip(child_results) {
-                let is_granted = child_result.is_granted();
-                let is_forbidden = child_result.is_forbidden();
-                let is_indeterminate = child_result.decision() == Decision::Indeterminate;
-                children_by_item[index].push(child_result);
-
-                if is_forbidden {
-                    results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
-                        operation: CombineOp::Or,
-                        children: std::mem::take(&mut children_by_item[index]),
-                        decision: Decision::Forbid,
-                    });
-                } else if policy_index < self.veto_capable_count {
-                    veto_prefix_indeterminate[index] |= is_indeterminate;
-                    veto_prefix_granted[index] |= is_granted;
-                    if policy_index + 1 == self.veto_capable_count
-                        && (veto_prefix_indeterminate[index] || veto_prefix_granted[index])
-                    {
-                        results[index] = Some(PolicyEvalResult::Combined {
-                            policy_type: self.policy_type(),
-                            operation: CombineOp::Or,
-                            children: std::mem::take(&mut children_by_item[index]),
-                            decision: if veto_prefix_indeterminate[index] {
-                                Decision::Indeterminate
-                            } else {
-                                Decision::Grant
-                            },
-                        });
-                    } else {
-                        still_pending.push(index);
-                    }
-                } else if is_granted {
-                    results[index] = Some(PolicyEvalResult::Combined {
-                        policy_type: self.policy_type(),
-                        operation: CombineOp::Or,
-                        children: std::mem::take(&mut children_by_item[index]),
-                        decision: Decision::Grant,
-                    });
-                } else {
-                    if is_indeterminate {
-                        allow_indeterminate[index] = true;
-                    }
-                    still_pending.push(index);
-                }
-            }
-            pending = still_pending;
-        }
-
-        for index in pending {
-            results[index] = Some(PolicyEvalResult::Combined {
-                policy_type: self.policy_type(),
-                operation: CombineOp::Or,
-                children: std::mem::take(&mut children_by_item[index]),
-                decision: if allow_indeterminate[index] {
-                    Decision::Indeterminate
-                } else {
-                    Decision::NotApplicable
-                },
-            });
-        }
-
-        results
-            .into_iter()
-            .map(|result| {
-                result.unwrap_or_else(|| {
-                    PolicyEvalResult::not_applicable(
-                        self.policy_type(),
-                        "Batch item was not evaluated",
-                    )
-                })
-            })
-            .collect()
-    }
-}
-
-/// Inverts the decision of an inner policy.
+/// Inverts a grant policy, preserving uncertainty.
 pub struct NotPolicy<D: PolicyDomain> {
     policy: Arc<dyn Policy<D>>,
 }
 
 impl<D: PolicyDomain> NotPolicy<D> {
-    /// Creates a new `NotPolicy` that inverts the given policy's decision.
-    pub fn new(policy: impl Policy<D> + 'static) -> Self {
+    /// Inverts the given grant policy, preserving indeterminate results.
+    pub fn new<P: Policy<D> + 'static>(policy: P) -> Self {
         Self {
             policy: Arc::new(policy),
         }
     }
 }
 
+macro_rules! constructor {
+    ($name:ident,$policy:ident) => {
+        impl<D: PolicyDomain> $name<D> {
+            /// Builds a combinator from a nonempty list.
+            pub fn try_new(policies: Vec<Arc<dyn $policy<D>>>) -> Result<Self, EmptyPoliciesError> {
+                if policies.is_empty() {
+                    Err(EmptyPoliciesError(concat!(
+                        stringify!($name),
+                        " requires at least one policy"
+                    )))
+                } else {
+                    Ok(Self { policies })
+                }
+            }
+        }
+    };
+}
+constructor!(AndPolicy, Policy);
+constructor!(OrPolicy, Policy);
+
+async fn grant_children<D: PolicyDomain>(
+    policies: &[Arc<dyn Policy<D>>],
+    ctx: &BatchEvalCtx<'_, D>,
+    conjunction: bool,
+    single: bool,
+) -> Vec<GrantResult> {
+    let mut children = vec![Vec::new(); ctx.items.len()];
+    let mut pending: Vec<usize> = (0..ctx.items.len()).collect();
+    for policy in policies {
+        let items: Vec<_> = pending
+            .iter()
+            .map(|&index| PolicyBatchItem {
+                resource: ctx.items[index].resource,
+            })
+            .collect();
+        let results = if single {
+            let inner = EvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                items[0].resource,
+                ctx.context,
+                policy.policy_type(),
+            );
+            let result = policy.evaluate(&inner).await;
+            vec![inner.finish(result)]
+        } else {
+            let inner = BatchEvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                ctx.context,
+                &items,
+                policy.policy_type(),
+            );
+            let results = policy.evaluate_batch(&inner).await;
+            inner.finish(results)
+        };
+        let results = if results.len() == pending.len() {
+            results
+        } else {
+            pending
+                .iter()
+                .map(|_| {
+                    GrantResult::indeterminate(
+                        policy.policy_type(),
+                        "Policy batch result count did not match input count",
+                    )
+                })
+                .collect()
+        };
+        for (&index, result) in pending.iter().zip(results) {
+            children[index].push(result);
+        }
+        pending.retain(|&index| {
+            let decision = children[index].last().expect("evaluated child").decision();
+            if conjunction {
+                decision != Decision::NotApplicable
+            } else {
+                decision != Decision::Grant
+            }
+        });
+        if pending.is_empty() {
+            break;
+        }
+    }
+    children
+        .into_iter()
+        .map(|children| {
+            if conjunction {
+                GrantResult::all("AndPolicy", children)
+            } else {
+                GrantResult::any("OrPolicy", children)
+            }
+        })
+        .collect()
+}
+macro_rules! grant_combinator {
+    ($name:ident,$conjunction:expr) => {
+        #[async_trait]
+        impl<D: PolicyDomain> Policy<D> for $name<D> {
+            async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
+                let items = [PolicyBatchItem {
+                    resource: ctx.resource,
+                }];
+                let inner = BatchEvalCtx::new(
+                    ctx.session(),
+                    ctx.subject,
+                    ctx.action,
+                    ctx.context,
+                    &items,
+                    self.policy_type(),
+                );
+                grant_children(&self.policies, &inner, $conjunction, true)
+                    .await
+                    .remove(0)
+            }
+            async fn evaluate_batch<'item>(
+                &self,
+                ctx: &BatchEvalCtx<'item, D>,
+            ) -> Vec<GrantResult> {
+                if ctx.items.is_empty() {
+                    return Vec::new();
+                }
+                grant_children(&self.policies, ctx, $conjunction, false).await
+            }
+            fn policy_type(&self) -> Cow<'static, str> {
+                Cow::Borrowed(stringify!($name))
+            }
+        }
+    };
+}
+grant_combinator!(AndPolicy, true);
+grant_combinator!(OrPolicy, false);
+
+fn invert(result: GrantResult) -> GrantResult {
+    let decision = match result.decision() {
+        Decision::Grant => Decision::NotApplicable,
+        Decision::NotApplicable if !has_fact_errors(result.trace()) => Decision::Grant,
+        _ => Decision::Indeterminate,
+    };
+    GrantResult(combined(
+        "NotPolicy",
+        CombineOp::Not,
+        vec![result.0],
+        decision,
+    ))
+}
 #[async_trait]
 impl<D: PolicyDomain> Policy<D> for NotPolicy<D> {
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("NotPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::from_capabilities(true, self.policy.effect().can_forbid())
-    }
-
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
-        let inner_ctx = EvalCtx::new(
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
+        let inner = EvalCtx::new(
             ctx.session(),
             ctx.subject,
             ctx.action,
@@ -626,20 +233,11 @@ impl<D: PolicyDomain> Policy<D> for NotPolicy<D> {
             ctx.context,
             self.policy.policy_type(),
         );
-        let inner_result = self.policy.evaluate(&inner_ctx).await;
-        let inner_result = inner_ctx.finish(inner_result);
-        let decision = not_decision(&inner_result);
-
-        PolicyEvalResult::Combined {
-            policy_type: Policy::<D>::policy_type(self),
-            operation: CombineOp::Not,
-            children: vec![inner_result],
-            decision,
-        }
+        let result = self.policy.evaluate(&inner).await;
+        invert(inner.finish(result))
     }
-
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
-        let inner_ctx = BatchEvalCtx::new(
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
+        let inner = BatchEvalCtx::new(
             ctx.session(),
             ctx.subject,
             ctx.action,
@@ -647,66 +245,206 @@ impl<D: PolicyDomain> Policy<D> for NotPolicy<D> {
             ctx.items,
             self.policy.policy_type(),
         );
-        let inner_results = self.policy.evaluate_batch(&inner_ctx).await;
-        let inner_results = inner_ctx.finish(inner_results);
-
-        if inner_results.len() != ctx.items.len() {
+        let results = self.policy.evaluate_batch(&inner).await;
+        let results = inner.finish(results);
+        if results.len() != ctx.items.len() {
             return ctx
                 .items
                 .iter()
                 .map(|_| {
-                    PolicyEvalResult::indeterminate(
+                    GrantResult::indeterminate(
                         self.policy_type(),
                         "Policy batch result count did not match input count",
                     )
                 })
                 .collect();
         }
-
-        inner_results
-            .into_iter()
-            .map(|inner_result| {
-                let decision = not_decision(&inner_result);
-                PolicyEvalResult::Combined {
-                    policy_type: self.policy_type(),
-                    operation: CombineOp::Not,
-                    children: vec![inner_result],
-                    decision,
-                }
-            })
-            .collect()
+        results.into_iter().map(invert).collect()
+    }
+    fn policy_type(&self) -> Cow<'static, str> {
+        Cow::Borrowed("NotPolicy")
     }
 }
 
-/// Decision mapping for [`NotPolicy`].
-///
-/// `NOT` inverts grant/non-grant only; it never neutralizes a veto and never
-/// manufactures certainty out of an indeterminate child:
-///
-/// * `Forbid` stays `Forbid` (the veto propagates; `is_forbidden` also
-///   covers a forbidden leaf hidden inside a mislabeled child tree).
-/// * `Grant` becomes `NotApplicable`.
-/// * `NotApplicable` becomes `Grant`, unless its leaf provenance reports a
-///   failed fact load; that inconsistent escape-hatch shape is treated as
-///   `Indeterminate` rather than manufacturing a grant.
-/// * `Indeterminate` stays `Indeterminate` — the inner policy might have
-///   granted or not, so the inversion is equally unknown.
-fn not_decision(inner_result: &PolicyEvalResult) -> Decision {
-    if inner_result.is_forbidden() {
-        return Decision::Forbid;
-    }
-    match inner_result.decision() {
-        Decision::Forbid => Decision::Forbid,
-        Decision::Grant => Decision::NotApplicable,
-        Decision::NotApplicable
-            if inner_result
-                .provenance()
-                .iter()
-                .any(|fact| fact.outcome == FactOutcome::Error) =>
-        {
-            Decision::Indeterminate
+/// Composition of veto predicates. Passing never grants permission.
+pub trait VetoPolicyExt<D: PolicyDomain>: VetoPolicy<D> + Sized + 'static {
+    /// Forbids only if both children forbid. A definite pass defeats uncertainty.
+    fn all_of<P: VetoPolicy<D> + 'static>(self, other: P) -> AllOfVeto<D> {
+        AllOfVeto {
+            policies: vec![Arc::new(self), Arc::new(other)],
         }
-        Decision::NotApplicable => Decision::Grant,
-        Decision::Indeterminate => Decision::Indeterminate,
     }
+    /// Forbids if either child forbids. A definite veto defeats uncertainty.
+    fn any_of<P: VetoPolicy<D> + 'static>(self, other: P) -> AnyOfVeto<D> {
+        AnyOfVeto {
+            policies: vec![Arc::new(self), Arc::new(other)],
+        }
+    }
+    /// Boxes the veto policy.
+    fn boxed(self) -> Box<dyn VetoPolicy<D>> {
+        Box::new(self)
+    }
+}
+impl<D: PolicyDomain, P: VetoPolicy<D> + Sized + 'static> VetoPolicyExt<D> for P {}
+/// Forbids when all veto children forbid.
+pub struct AllOfVeto<D: PolicyDomain> {
+    policies: Vec<Arc<dyn VetoPolicy<D>>>,
+}
+/// Forbids when any veto child forbids.
+pub struct AnyOfVeto<D: PolicyDomain> {
+    policies: Vec<Arc<dyn VetoPolicy<D>>>,
+}
+constructor!(AllOfVeto, VetoPolicy);
+constructor!(AnyOfVeto, VetoPolicy);
+
+async fn veto_children<D: PolicyDomain>(
+    policies: &[Arc<dyn VetoPolicy<D>>],
+    ctx: &BatchEvalCtx<'_, D>,
+    conjunction: bool,
+    single: bool,
+) -> Vec<VetoResult> {
+    let mut children = vec![Vec::new(); ctx.items.len()];
+    let mut pending: Vec<usize> = (0..ctx.items.len()).collect();
+    for policy in policies {
+        let items: Vec<_> = pending
+            .iter()
+            .map(|&index| PolicyBatchItem {
+                resource: ctx.items[index].resource,
+            })
+            .collect();
+        let results = if single {
+            let inner = EvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                items[0].resource,
+                ctx.context,
+                policy.policy_type(),
+            );
+            let result = policy.evaluate(&inner).await;
+            vec![inner.finish(result)]
+        } else {
+            let inner = BatchEvalCtx::new(
+                ctx.session(),
+                ctx.subject,
+                ctx.action,
+                ctx.context,
+                &items,
+                policy.policy_type(),
+            );
+            let results = policy.evaluate_batch(&inner).await;
+            inner.finish(results)
+        };
+        let results = if results.len() == pending.len() {
+            results
+        } else {
+            pending
+                .iter()
+                .map(|_| {
+                    VetoResult::indeterminate(
+                        policy.policy_type(),
+                        "Policy batch result count did not match input count",
+                    )
+                })
+                .collect()
+        };
+        for (&index, result) in pending.iter().zip(results) {
+            children[index].push(result);
+        }
+        pending.retain(|&index| {
+            let decision = children[index].last().expect("evaluated child").decision();
+            if conjunction {
+                decision != Decision::NotApplicable
+            } else {
+                decision != Decision::Forbid
+            }
+        });
+        if pending.is_empty() {
+            break;
+        }
+    }
+    children
+        .into_iter()
+        .map(|children| {
+            let any_forbid = children.iter().any(VetoResult::is_forbidden);
+            let any_pass = children
+                .iter()
+                .any(|child| child.decision() == Decision::NotApplicable);
+            let any_unknown = children
+                .iter()
+                .any(|child| child.decision() == Decision::Indeterminate);
+            let decision = if conjunction && any_pass {
+                Decision::NotApplicable
+            } else if !conjunction && any_forbid {
+                Decision::Forbid
+            } else if any_unknown {
+                Decision::Indeterminate
+            } else if conjunction && !children.is_empty() {
+                Decision::Forbid
+            } else {
+                Decision::NotApplicable
+            };
+            VetoResult(combined(
+                if conjunction {
+                    "AllOfVeto"
+                } else {
+                    "AnyOfVeto"
+                },
+                if conjunction {
+                    CombineOp::And
+                } else {
+                    CombineOp::Or
+                },
+                children.into_iter().map(|child| child.0).collect(),
+                decision,
+            ))
+        })
+        .collect()
+}
+macro_rules! veto_combinator {
+    ($name:ident,$conjunction:expr) => {
+        #[async_trait]
+        impl<D: PolicyDomain> VetoPolicy<D> for $name<D> {
+            async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> VetoResult {
+                let items = [PolicyBatchItem {
+                    resource: ctx.resource,
+                }];
+                let inner = BatchEvalCtx::new(
+                    ctx.session(),
+                    ctx.subject,
+                    ctx.action,
+                    ctx.context,
+                    &items,
+                    self.policy_type(),
+                );
+                veto_children(&self.policies, &inner, $conjunction, true)
+                    .await
+                    .remove(0)
+            }
+            async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<VetoResult> {
+                if ctx.items.is_empty() {
+                    return Vec::new();
+                }
+                veto_children(&self.policies, ctx, $conjunction, false).await
+            }
+            fn policy_type(&self) -> Cow<'static, str> {
+                Cow::Borrowed(stringify!($name))
+            }
+        }
+    };
+}
+veto_combinator!(AllOfVeto, true);
+veto_combinator!(AnyOfVeto, false);
+
+fn has_fact_errors(result: &crate::PolicyEvalResult) -> bool {
+    result
+        .provenance()
+        .iter()
+        .any(|fact| fact.outcome == crate::FactOutcome::Error)
+        || match result {
+            crate::PolicyEvalResult::Combined { children, .. } => {
+                children.iter().any(has_fact_errors)
+            }
+            _ => false,
+        }
 }

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -212,7 +212,7 @@ grant_combinator!(OrPolicy, false);
 fn invert(result: GrantResult) -> GrantResult {
     let decision = match result.decision() {
         Decision::Grant => Decision::NotApplicable,
-        Decision::NotApplicable if !has_fact_errors(result.trace()) => Decision::Grant,
+        Decision::NotApplicable => Decision::Grant,
         _ => Decision::Indeterminate,
     };
     GrantResult(combined(
@@ -253,7 +253,7 @@ impl<D: PolicyDomain> Policy<D> for NotPolicy<D> {
                 .iter()
                 .map(|_| {
                     GrantResult::indeterminate(
-                        self.policy_type(),
+                        self.policy.policy_type(),
                         "Policy batch result count did not match input count",
                     )
                 })
@@ -435,16 +435,3 @@ macro_rules! veto_combinator {
 }
 veto_combinator!(AllOfVeto, true);
 veto_combinator!(AnyOfVeto, false);
-
-fn has_fact_errors(result: &crate::PolicyEvalResult) -> bool {
-    result
-        .provenance()
-        .iter()
-        .any(|fact| fact.outcome == crate::FactOutcome::Error)
-        || match result {
-            crate::PolicyEvalResult::Combined { children, .. } => {
-                children.iter().any(has_fact_errors)
-            }
-            _ => false,
-        }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,9 @@
 //!
 //! let decision = bound.check(&resource).await;
 //! let decisions = bound.evaluate(resources.clone()).await;
-//! let authorized = bound.filter(resources).await;
-//! let authorized_rows = bound.filter_by(rows, |row| &row.authz_resource).await;
-//! let page = bound.lookup_page(&lookup, &hydrator, cursor.as_deref(), limit).await?;
+//! let authorized = bound.try_filter(resources).await?;
+//! let authorized_rows = bound.try_filter_by(rows, |row| &row.authz_resource).await?;
+//! let page = bound.try_lookup_page(&lookup, &hydrator, cursor.as_deref(), limit).await?;
 //! ```
 //!
 //! Use [`EvaluationSession::empty`] for fact-free decisions. Use a session from
@@ -99,59 +99,63 @@
 //! (which also records provenance) or the raw session — such as [`RebacPolicy`]
 //! or a custom fact-backed policy.
 //!
-//! [`BoundEvaluator::evaluate`] preserves input order and returns one
-//! [`AccessEvaluation`] per input resource. [`BoundEvaluator::filter`] keeps
-//! only granted resources. [`BoundEvaluator::evaluate_by`] and
-//! [`BoundEvaluator::filter_by`] are for wide caller-owned rows where
-//! authorization uses a projected resource. [`BoundEvaluator::lookup_page`] is
-//! for list endpoints where the application cannot load every possible
-//! candidate first; the [`LookupSource`] enumerates candidate IDs, a
-//! [`Hydrator`] resolves them, and the full policy stack authorizes the
-//! hydrated resources.
+//! [`BoundEvaluator::evaluate`] preserves input order and retains every item
+//! and decision. [`BoundEvaluator::try_filter`] excludes definite denials but
+//! fails on indeterminate decisions; [`BoundEvaluator::try_filter_by`] applies
+//! the same rule to projected caller-owned rows. Errors retain all input items
+//! and evaluations. The original `filter` helpers deliberately omit outages.
+//!
+//! [`BoundEvaluator::try_lookup_page`] enumerates candidate IDs, hydrates them,
+//! and strictly authorizes one page. [`LookupSource`] must cover every grant
+//! path, including admin overrides. On evaluation failure, no next cursor is
+//! returned: retry the same cursor with a fresh session after recovery.
 //!
 //! # Decision Semantics
 //!
-//! Gatehouse deliberately keeps combining semantics fixed:
+//! [`Policy`] returns [`GrantResult`]: grant, abstention, or indeterminate.
+//! [`VetoPolicy`] returns [`VetoResult`]: veto, pass, or indeterminate. Register
+//! them with [`PermissionChecker::add_policy`] and [`PermissionChecker::add_veto`].
+//! These types prevent grant policies from returning veto authority.
 //!
-//! - [`PermissionChecker`] applies deny-overrides. Any evaluated result
-//!   containing [`PolicyEvalResult::Forbidden`] denies the request and
-//!   overrides grants.
-//! - Policies declaring [`Effect::Forbid`] or [`Effect::AllowOrForbid`] are
-//!   evaluated before allow-only policies so a veto cannot be skipped by grant
-//!   short-circuiting.
-//! - If no policy forbids, the first grant wins.
-//! - If nothing grants, the checker denies with `"All policies denied access"`.
-//! - An empty checker denies with `"No policies configured"`.
-//! - [`PolicyEvalResult::NotApplicable`] means the policy did not grant.
-//!   [`PolicyEvalResult::Forbidden`] means the policy actively vetoed.
-//! - [`PolicyEvalResult::Indeterminate`] means the policy could not be
-//!   evaluated (typically a failed fact load). It never grants. An
-//!   indeterminate **veto-capable** policy blocks sibling grants — its
-//!   unresolved potential veto must not be short-circuited — and surfaces as
-//!   [`AccessEvaluation::Indeterminate`]; an observed `Forbidden` still
-//!   overrides it. An indeterminate **allow-only** policy never blocks a
-//!   sibling grant, but if nothing grants the evaluation is
-//!   [`AccessEvaluation::Indeterminate`] rather than an ordinary denial, so
-//!   callers can map authorization-data outages to a 5xx instead of a 403.
-//! - [`PolicyBuilder`] combines configured predicates with AND logic.
-//!   [`PolicyBuilder::forbid`] makes a matching built policy forbid; a
-//!   non-match remains not applicable and does not block.
-//! - [`AndPolicy`] and [`OrPolicy`] evaluate veto-capable children before
-//!   allow-only children, then short-circuit normally. [`NotPolicy`] inverts
-//!   grants and non-grants, but never turns `Forbidden` into a grant.
-//! - `Forbidden` propagates through [`AndPolicy`], [`OrPolicy`], [`NotPolicy`],
-//!   and [`DelegatingPolicy`].
-//! - [`NotPolicy`] does not neutralize a veto. `admin.or(blocked.not())` still
-//!   denies when `blocked` returns `Forbidden`. For "grant unless blocked", use
-//!   an allow-only `blocked` predicate under `not()`, or register an explicit
-//!   forbid policy when the block should be global.
-//! - `grant.and(forbid_only)` can never grant: a forbid-only child does not
-//!   satisfy AND's "all children grant" rule. Use
-//!   `grant.and(blocked_allow_predicate.not())` for a local exclusion.
+//! A definite veto denies access. An unresolved veto blocks grants. After
+//! vetoes pass, any grant authorizes, including a grant after another grant
+//! policy failed. With no grant, uncertainty yields [`AccessEvaluation::Indeterminate`];
+//! otherwise access is denied. An empty checker denies access.
 //!
-//! Denials from [`AccessEvaluation`] are summary-level. Use
-//! [`AccessEvaluation::display_trace`] or the attached [`EvalTrace`] to inspect
-//! individual policy reasons and fact provenance.
+//! [`AndPolicy`], [`OrPolicy`], and [`NotPolicy`] compose grants only. A definite
+//! abstention settles AND; a definite grant settles OR; NOT retains uncertainty.
+//! Use `grant.and(blocked.not())` for a local exclusion. Vetoes use
+//! [`AllOfVeto`] or [`AnyOfVeto`]; a pass settles all-of and a veto settles any-of,
+//! otherwise uncertainty remains. Veto negation is not supported.
+//!
+//! [`PolicyBuilder::build`] produces a grant policy;
+//! [`PolicyBuilder::build_veto`] produces a veto when its predicate matches.
+//! Register [`DelegatingPolicy`] once with [`PermissionChecker::add_delegate`]
+//! to preserve both child capabilities and their distinct failure semantics.
+//!
+//! [`PolicyEvalResult`] is the inspectable audit tree, not a policy return type.
+//! Typed result constructors compute aggregate decisions; arbitrary raw trees
+//! cannot be promoted into typed authority. [`GrantResult::all`] and
+//! [`GrantResult::any`] support custom grant aggregates.
+//!
+//! Use [`AccessEvaluation::into_result`] to distinguish [`AccessError::Denied`]
+//! from [`AccessError::Indeterminate`] without parsing reasons. Both errors retain
+//! the full trace and classified fact errors. The original `to_result` combines
+//! both outcomes into one reason-only callback.
+//!
+//! Recorded successful, missing, and failed facts are retained on every node,
+//! including aggregates. Recorded errors upgrade abstention/pass to indeterminate;
+//! decisive grants and vetoes remain decisive. Attaching evidence has the same
+//! behavior for leaves and aggregate nodes. Call `ctx.finish(result)` when
+//! evaluating a policy directly; the checker and built-in combinators do this
+//! automatically.
+//!
+//! # Cargo Features
+//!
+//! `tracing` is enabled by default. Disable default features to remove its
+//! instrumentation and dependency; decisions, returned [`EvalTrace`], and fact
+//! provenance remain available. No telemetry events or contract warnings are
+//! emitted without tracing. `serde` independently enables audit serialization.
 //!
 //! # Fact-Loaded Authorization
 //!
@@ -176,8 +180,8 @@
 //! for the stream lifetime.
 //!
 //! If your product contract authorizes once at stream open, create a fresh
-//! session, compute the visible ID set with [`BoundEvaluator::filter`] or
-//! [`BoundEvaluator::filter_by`], drop the session, and only emit frames for
+//! session, compute the visible ID set with [`BoundEvaluator::try_filter`] or
+//! [`BoundEvaluator::try_filter_by`], drop the session, and only emit frames for
 //! that set. If the stream must observe mid-stream permission revocation, run
 //! periodic reauthorization with a fresh [`FactRegistry::session`] and re-bind
 //! the checker for that pass.
@@ -197,7 +201,8 @@
 //! # Custom Policies
 //!
 //! Implement [`Policy`] directly when a rule needs async work, custom batching,
-//! custom telemetry metadata, or hand-written forbid behavior:
+//! or custom telemetry metadata. Implement [`VetoPolicy`] for custom vetoes.
+//! A grant policy looks like this:
 //!
 //! ```rust
 //! # use async_trait::async_trait;
@@ -217,7 +222,7 @@
 //!
 //! #[async_trait]
 //! impl Policy<Documents> for OwnerPolicy {
-//!     async fn evaluate(&self, ctx: &EvalCtx<'_, Documents>) -> PolicyEvalResult {
+//!     async fn evaluate(&self, ctx: &EvalCtx<'_, Documents>) -> GrantResult {
 //!         if ctx.subject.id == ctx.resource.owner_id {
 //!             ctx.grant("subject owns the document")
 //!         } else {
@@ -242,6 +247,7 @@
 #![allow(clippy::type_complexity)]
 
 mod builder;
+mod capability;
 mod checker;
 mod combinators;
 mod facts;
@@ -253,18 +259,25 @@ mod results;
 mod session;
 
 pub use builder::PolicyBuilder;
+pub use capability::{GrantResult, PolicyResult, VetoPolicy, VetoResult};
 pub use checker::{BoundEvaluator, PermissionChecker};
-pub use combinators::{AndPolicy, EmptyPoliciesError, NotPolicy, OrPolicy, PolicyExt};
+pub use combinators::{
+    AllOfVeto, AndPolicy, AnyOfVeto, EmptyPoliciesError, NotPolicy, OrPolicy, PolicyExt,
+    VetoPolicyExt,
+};
 pub use facts::{
     FactKey, FactLoadError, FactLoadErrorKind, FactLoadResult, FactSource, RelationshipQuery,
 };
 pub use lookup::{Hydrator, LookupAuthorizedError, LookupAuthorizedPage, LookupPage, LookupSource};
 pub use metadata::SecurityRuleMetadata;
-pub(crate) use metadata::{DEFAULT_SECURITY_RULE_CATEGORY, PERMISSION_CHECKER_POLICY_TYPE};
+#[cfg(feature = "tracing")]
+pub(crate) use metadata::DEFAULT_SECURITY_RULE_CATEGORY;
+pub(crate) use metadata::PERMISSION_CHECKER_POLICY_TYPE;
 pub use policies::{DelegatingPolicy, RbacPolicy, RebacPolicy};
-pub use policy::{BatchEvalCtx, Effect, EvalCtx, Policy, PolicyBatchItem, PolicyDomain};
+pub use policy::{BatchEvalCtx, EvalCtx, Policy, PolicyBatchItem, PolicyDomain};
 pub use results::{
-    AccessEvaluation, CombineOp, Decision, EvalTrace, FactOutcome, FactProvenance, PolicyEvalResult,
+    AccessError, AccessEvaluation, CombineOp, Decision, EvalTrace, FactOutcome, FactProvenance,
+    FilterError, PolicyEvalResult,
 };
 pub use session::{EvaluationSession, FactRegistry, FactRegistryBuilder};
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,6 +1,6 @@
 //! Lookup-style enumeration for "what can this subject see?" authorization.
 //!
-//! [`crate::BoundEvaluator::check`] and [`crate::BoundEvaluator::filter`] both
+//! [`crate::BoundEvaluator::check`] and [`crate::BoundEvaluator::try_filter`] both
 //! require the caller to already hold every candidate resource. That breaks
 //! down for list and scope endpoints where the candidate population may be
 //! millions of rows and the visible subset is tiny.
@@ -40,7 +40,7 @@ use std::num::NonZeroUsize;
 /// grants (deny-overrides over OR). If you compose policies whose grant
 /// axes are independent (for example, "I own it" OR "it is public" OR
 /// "the admin override applies"), the `LookupSource` must enumerate the
-/// union of every grant axis. Forbid-effect policies only *remove* results,
+/// union of every grant axis. Veto policies only *remove* results,
 /// so they never widen what the source must enumerate. Lookup is the
 /// scaling story for the narrow case where one axis dominates; it is
 /// **not** a way to express policy logic inside the data layer.
@@ -151,13 +151,20 @@ where
     }
 }
 
-/// Failure modes for [`crate::BoundEvaluator::lookup_page`].
+/// Failure modes for lookup, hydration, and authorization of one candidate page.
+///
+/// [`crate::BoundEvaluator::try_lookup_page`] uses the resource type in its
+/// third parameter and may return [`Self::Evaluation`]. The original
+/// [`crate::BoundEvaluator::lookup_page`] omits indeterminate resources instead.
 ///
 /// The generic parameters carry the source's and hydrator's own error
 /// types, so callers retain full backend context on the wrapped variants.
-#[derive(Debug)]
 #[non_exhaustive]
-pub enum LookupAuthorizedError<LookupErr, HydrateErr> {
+pub enum LookupAuthorizedError<LookupErr, HydrateErr, Resource = ()> {
+    /// At least one resource could not be authorized; no partial page is returned.
+    /// Inspect the contained evaluations for audit evidence. This variant has no
+    /// [`std::error::Error::source`], allowing it to retain borrowed resources.
+    Evaluation(crate::FilterError<Resource>),
     /// The [`LookupSource`] returned an error for the current page.
     Lookup(LookupErr),
     /// The [`Hydrator`] returned an error for the current page.
@@ -176,13 +183,30 @@ pub enum LookupAuthorizedError<LookupErr, HydrateErr> {
     LookupCursorStuck,
 }
 
-impl<L, H> fmt::Display for LookupAuthorizedError<L, H>
+impl<L: fmt::Debug, H: fmt::Debug, R> fmt::Debug for LookupAuthorizedError<L, H, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Evaluation(error) => f.debug_tuple("Evaluation").field(error).finish(),
+            Self::Lookup(error) => f.debug_tuple("Lookup").field(error).finish(),
+            Self::Hydrate(error) => f.debug_tuple("Hydrate").field(error).finish(),
+            Self::HydratorContractViolation { expected, actual } => f
+                .debug_struct("HydratorContractViolation")
+                .field("expected", expected)
+                .field("actual", actual)
+                .finish(),
+            Self::LookupCursorStuck => f.write_str("LookupCursorStuck"),
+        }
+    }
+}
+
+impl<L, H, R> fmt::Display for LookupAuthorizedError<L, H, R>
 where
     L: fmt::Display,
     H: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Evaluation(err) => fmt::Display::fmt(err, f),
             Self::Lookup(err) => write!(f, "lookup source error: {err}"),
             Self::Hydrate(err) => write!(f, "hydrator error: {err}"),
             Self::HydratorContractViolation { expected, actual } => write!(
@@ -198,13 +222,14 @@ where
     }
 }
 
-impl<L, H> std::error::Error for LookupAuthorizedError<L, H>
+impl<L, H, R> std::error::Error for LookupAuthorizedError<L, H, R>
 where
     L: std::error::Error + 'static,
     H: std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::Evaluation(_) => None,
             Self::Lookup(err) => Some(err),
             Self::Hydrate(err) => Some(err),
             Self::HydratorContractViolation { .. } | Self::LookupCursorStuck => None,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "tracing")]
 pub(crate) const DEFAULT_SECURITY_RULE_CATEGORY: &str = "Access Control";
 pub(crate) const PERMISSION_CHECKER_POLICY_TYPE: &str = "PermissionChecker";
 

--- a/src/policies/delegating.rs
+++ b/src/policies/delegating.rs
@@ -1,66 +1,14 @@
+use crate::capability::combined;
+use crate::checker::{Phase, PhasePolicy, PhaseScope};
 use crate::{
-    AccessEvaluation, BatchEvalCtx, CombineOp, Decision, Effect, EvalCtx, PermissionChecker,
-    Policy, PolicyDomain, PolicyEvalResult, SecurityRuleMetadata, PERMISSION_CHECKER_POLICY_TYPE,
+    BatchEvalCtx, CombineOp, EvalCtx, PermissionChecker, PolicyBatchItem, PolicyDomain,
+    PolicyEvalResult, SecurityRuleMetadata,
 };
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 
-fn delegated_evaluation_to_result(
-    policy_type: std::borrow::Cow<'static, str>,
-    evaluation: AccessEvaluation,
-) -> PolicyEvalResult {
-    let (decision, child) = match evaluation {
-        AccessEvaluation::Granted {
-            policy_type: child_policy_type,
-            reason,
-            trace,
-        } => (
-            Decision::Grant,
-            trace
-                .root()
-                .cloned()
-                .unwrap_or(PolicyEvalResult::granted(child_policy_type, reason)),
-        ),
-        AccessEvaluation::Denied { reason, trace } => {
-            let child = trace
-                .root()
-                .cloned()
-                .unwrap_or(PolicyEvalResult::not_applicable(
-                    PERMISSION_CHECKER_POLICY_TYPE,
-                    reason,
-                ));
-            // A child-checker denial is either a veto (which must propagate
-            // so the parent checker honors it over sibling grants) or an
-            // ordinary "nothing granted".
-            let decision = if child.is_forbidden() {
-                Decision::Forbid
-            } else {
-                Decision::NotApplicable
-            };
-            (decision, child)
-        }
-        AccessEvaluation::Indeterminate { reason, trace } => (
-            Decision::Indeterminate,
-            trace
-                .root()
-                .cloned()
-                .unwrap_or(PolicyEvalResult::indeterminate(
-                    PERMISSION_CHECKER_POLICY_TYPE,
-                    reason,
-                )),
-        ),
-    };
-
-    PolicyEvalResult::Combined {
-        policy_type,
-        operation: CombineOp::Delegate,
-        children: vec![child],
-        decision,
-    }
-}
-
-/// A policy that maps the current domain into a child domain and delegates to
-/// another [`PermissionChecker`].
+/// Maps inputs into a child checker. Install with [`PermissionChecker::add_delegate`].
 pub struct DelegatingPolicy<ParentD: PolicyDomain, ChildD: PolicyDomain> {
     policy_type: std::borrow::Cow<'static, str>,
     security_rule: SecurityRuleMetadata,
@@ -127,65 +75,153 @@ impl<ParentD: PolicyDomain, ChildD: PolicyDomain> DelegatingPolicy<ParentD, Chil
         self.security_rule = security_rule;
         self
     }
+    pub(crate) fn into_phases(
+        self,
+        registration: usize,
+    ) -> (Arc<dyn PhasePolicy<ParentD>>, Arc<dyn PhasePolicy<ParentD>>) {
+        let delegate = Arc::new(self);
+        (
+            Arc::new(DelegatePhase {
+                delegate: delegate.clone(),
+                phase: Phase::Veto,
+                registration,
+            }),
+            Arc::new(DelegatePhase {
+                delegate,
+                phase: Phase::Grant,
+                registration,
+            }),
+        )
+    }
 }
 
-#[async_trait]
-impl<ParentD, ChildD> Policy<ParentD> for DelegatingPolicy<ParentD, ChildD>
-where
-    ParentD: PolicyDomain,
-    ChildD: PolicyDomain,
-{
-    async fn evaluate(&self, ctx: &EvalCtx<'_, ParentD>) -> PolicyEvalResult {
-        let child_subject = (self.subject)(ctx.subject);
-        let child_action = (self.action)(ctx.action);
-        let child_resource = (self.resource)(ctx.subject, ctx.action, ctx.resource, ctx.context);
-        let child_context = (self.context)(ctx.subject, ctx.action, ctx.context);
-        let evaluation = self
-            .checker
-            .bind(ctx.session(), &child_subject, &child_action, &child_context)
-            .check(&child_resource)
-            .await;
-
-        delegated_evaluation_to_result(self.policy_type.clone(), evaluation)
+struct DelegatePhase<ParentD: PolicyDomain, ChildD: PolicyDomain> {
+    delegate: Arc<DelegatingPolicy<ParentD, ChildD>>,
+    phase: Phase,
+    registration: usize,
+}
+struct PreparedInputs<D: PolicyDomain> {
+    subject: D::Subject,
+    action: D::Action,
+    context: D::Context,
+    resources: HashMap<usize, D::Resource>,
+}
+impl<ParentD: PolicyDomain, ChildD: PolicyDomain> DelegatePhase<ParentD, ChildD> {
+    async fn run(
+        &self,
+        ctx: &BatchEvalCtx<'_, ParentD>,
+        single: bool,
+        scope: &mut PhaseScope<'_>,
+    ) -> Vec<PolicyEvalResult> {
+        let delegate = &self.delegate;
+        let mut path = scope.path.to_vec();
+        path.push(self.registration);
+        let mut prepared = match scope.state.delegates.remove(&path) {
+            Some(prepared) => prepared
+                .downcast::<PreparedInputs<ChildD>>()
+                .expect("delegate registration has one child domain"),
+            None => Box::new(PreparedInputs::<ChildD> {
+                subject: (delegate.subject)(ctx.subject),
+                action: (delegate.action)(ctx.action),
+                context: (delegate.context)(ctx.subject, ctx.action, ctx.context),
+                resources: HashMap::new(),
+            }),
+        };
+        for (&index, item) in scope.item_indices.iter().zip(ctx.items) {
+            prepared.resources.entry(index).or_insert_with(|| {
+                (delegate.resource)(ctx.subject, ctx.action, item.resource, ctx.context)
+            });
+        }
+        let items: Vec<_> = scope
+            .item_indices
+            .iter()
+            .map(|index| PolicyBatchItem {
+                resource: &prepared.resources[index],
+            })
+            .collect();
+        let inner = BatchEvalCtx::new(
+            ctx.session(),
+            &prepared.subject,
+            &prepared.action,
+            &prepared.context,
+            &items,
+            delegate.policy_type.clone(),
+        );
+        let mut child_scope = PhaseScope {
+            state: scope.state,
+            item_indices: scope.item_indices,
+            path: &path,
+        };
+        let children = if single {
+            let inner = EvalCtx::new(
+                ctx.session(),
+                &prepared.subject,
+                &prepared.action,
+                items[0].resource,
+                &prepared.context,
+                delegate.policy_type.clone(),
+            );
+            vec![
+                delegate
+                    .checker
+                    .evaluate_phase_one(self.phase, &inner, &mut child_scope)
+                    .await,
+            ]
+        } else {
+            delegate
+                .checker
+                .evaluate_phase(self.phase, &inner, &mut child_scope)
+                .await
+        };
+        let results = children
+            .into_iter()
+            .map(|child| {
+                let decision = child.decision();
+                combined(
+                    delegate.policy_type.clone(),
+                    CombineOp::Delegate,
+                    vec![child],
+                    decision,
+                )
+            })
+            .collect();
+        scope.state.delegates.insert(path, prepared);
+        results
     }
-
+}
+#[async_trait]
+impl<ParentD: PolicyDomain, ChildD: PolicyDomain> PhasePolicy<ParentD>
+    for DelegatePhase<ParentD, ChildD>
+{
+    async fn evaluate(
+        &self,
+        ctx: &EvalCtx<'_, ParentD>,
+        scope: &mut PhaseScope<'_>,
+    ) -> PolicyEvalResult {
+        let items = [PolicyBatchItem {
+            resource: ctx.resource,
+        }];
+        let batch = BatchEvalCtx::new(
+            ctx.session(),
+            ctx.subject,
+            ctx.action,
+            ctx.context,
+            &items,
+            ctx.policy_type.clone(),
+        );
+        self.run(&batch, true, scope).await.remove(0)
+    }
     async fn evaluate_batch<'item>(
         &self,
         ctx: &BatchEvalCtx<'item, ParentD>,
+        scope: &mut PhaseScope<'_>,
     ) -> Vec<PolicyEvalResult> {
-        if ctx.items.is_empty() {
-            return Vec::new();
-        }
-
-        let child_subject = (self.subject)(ctx.subject);
-        let child_action = (self.action)(ctx.action);
-        let child_context = (self.context)(ctx.subject, ctx.action, ctx.context);
-        let child_resources = ctx
-            .items
-            .iter()
-            .map(|item| (self.resource)(ctx.subject, ctx.action, item.resource, ctx.context))
-            .collect::<Vec<_>>();
-
-        self.checker
-            .bind(ctx.session(), &child_subject, &child_action, &child_context)
-            .evaluate(child_resources)
-            .await
-            .into_iter()
-            .map(|(_resource, evaluation)| {
-                delegated_evaluation_to_result(self.policy_type.clone(), evaluation)
-            })
-            .collect()
+        self.run(ctx, false, scope).await
     }
-
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        self.policy_type.clone()
+        self.delegate.policy_type.clone()
     }
-
-    fn effect(&self) -> Effect {
-        self.checker.aggregate_effect()
-    }
-
     fn security_rule(&self) -> SecurityRuleMetadata {
-        self.security_rule.clone()
+        self.delegate.security_rule.clone()
     }
 }

--- a/src/policies/rbac.rs
+++ b/src/policies/rbac.rs
@@ -1,4 +1,4 @@
-use crate::{EvalCtx, Policy, PolicyDomain, PolicyEvalResult};
+use crate::{EvalCtx, GrantResult, Policy, PolicyDomain};
 use async_trait::async_trait;
 use std::marker::PhantomData;
 
@@ -32,7 +32,7 @@ where
     F1: Fn(&D::Action, &D::Resource) -> Vec<RoleId> + Sync + Send,
     F2: Fn(&D::Subject) -> Vec<RoleId> + Sync + Send,
 {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
         let required_roles = (self.required_roles_resolver)(ctx.action, ctx.resource);
         let subject_roles = (self.subject_roles_resolver)(ctx.subject);
         let has_role = required_roles

--- a/src/policies/rebac.rs
+++ b/src/policies/rebac.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BatchEvalCtx, EvalCtx, FactLoadError, FactLoadErrorKind, FactLoadResult, Policy, PolicyDomain,
-    PolicyEvalResult, RelationshipQuery,
+    BatchEvalCtx, EvalCtx, FactLoadError, FactLoadErrorKind, FactLoadResult, GrantResult, Policy,
+    PolicyDomain, RelationshipQuery,
 };
 use async_trait::async_trait;
 use std::fmt;
@@ -47,7 +47,7 @@ where
     ResourceId: Eq + Hash + Clone + Send + Sync + fmt::Debug + 'static,
     Relation: Eq + Hash + Clone + Send + Sync + fmt::Display + fmt::Debug + 'static,
 {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
         let key = RelationshipQuery {
             subject_id: (self.subject_id)(ctx.subject),
             resource_id: (self.resource_id)(ctx.resource),
@@ -62,7 +62,7 @@ where
         }
     }
 
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
         let subject_id = (self.subject_id)(ctx.subject);
         // `facts_by` performs one deduplicated `get_many` and records
         // provenance against each originating item; the caller's
@@ -79,7 +79,7 @@ where
                 .items
                 .iter()
                 .map(|_| {
-                    PolicyEvalResult::indeterminate(
+                    GrantResult::indeterminate(
                         self.policy_type(),
                         "Relationship fact source returned the wrong number of results",
                     )
@@ -132,16 +132,16 @@ where
         &self,
         policy_type: std::borrow::Cow<'static, str>,
         fact: FactLoadResult<bool>,
-    ) -> PolicyEvalResult {
+    ) -> GrantResult {
         match fact {
             FactLoadResult::Found(true) => {
-                PolicyEvalResult::granted(policy_type, Some(self.granted_reason()))
+                GrantResult::granted(policy_type, Some(self.granted_reason()))
             }
             FactLoadResult::Found(false) => {
-                PolicyEvalResult::not_applicable(policy_type, self.no_relationship_reason())
+                GrantResult::not_applicable(policy_type, self.no_relationship_reason())
             }
             FactLoadResult::Missing => {
-                PolicyEvalResult::not_applicable(policy_type, self.missing_reason())
+                GrantResult::not_applicable(policy_type, self.missing_reason())
             }
             // Fail closed, but structurally: the relationship could not be
             // loaded, so the policy could not decide. This surfaces as
@@ -149,7 +149,7 @@ where
             // denial, letting callers map an authorization-data outage to a
             // 5xx instead of a 403.
             FactLoadResult::Error(error) => {
-                PolicyEvalResult::indeterminate(policy_type, self.error_reason(&error))
+                GrantResult::indeterminate(policy_type, self.error_reason(&error))
             }
         }
     }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,6 +1,6 @@
 use crate::{
     EvaluationSession, FactKey, FactLoadError, FactLoadResult, FactOutcome, FactProvenance,
-    PolicyEvalResult, SecurityRuleMetadata,
+    GrantResult, PolicyEvalResult, PolicyResult, SecurityRuleMetadata, VetoResult,
 };
 use async_trait::async_trait;
 use std::borrow::Cow;
@@ -23,53 +23,6 @@ pub trait PolicyDomain: Send + Sync + 'static {
     type Context: Send + Sync;
 }
 
-/// The declared effect of a policy: whether it can grant, forbid, or both.
-///
-/// `Allow` (the default everywhere) means the policy grants access when it
-/// matches. `Forbid` means the policy **forbids** access when it matches: a
-/// matched forbid produces [`PolicyEvalResult::Forbidden`], which
-/// [`crate::PermissionChecker`] honors over any grant from sibling policies.
-/// `AllowOrForbid` is for composed or custom policies that can produce either
-/// result depending on their inputs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Effect {
-    /// The policy may grant access, but must not actively forbid.
-    Allow,
-    /// The policy may actively forbid access, but must not grant.
-    Forbid,
-    /// The policy may either grant or actively forbid access.
-    AllowOrForbid,
-}
-
-impl Effect {
-    /// Whether this effect can produce a grant.
-    pub fn can_grant(self) -> bool {
-        matches!(self, Self::Allow | Self::AllowOrForbid)
-    }
-
-    /// Whether this effect can produce an active forbid.
-    pub fn can_forbid(self) -> bool {
-        matches!(self, Self::Forbid | Self::AllowOrForbid)
-    }
-
-    pub(crate) fn from_capabilities(can_grant: bool, can_forbid: bool) -> Self {
-        match (can_grant, can_forbid) {
-            (true, true) => Self::AllowOrForbid,
-            (false, true) => Self::Forbid,
-            _ => Self::Allow,
-        }
-    }
-
-    pub(crate) fn telemetry_label(self) -> &'static str {
-        match self {
-            Self::Allow => "allow",
-            Self::Forbid => "deny",
-            Self::AllowOrForbid => "allow_or_forbid",
-        }
-    }
-}
-
 /// A borrowed resource passed to batch policy evaluators.
 ///
 /// Values are borrowed from caller-owned batch items, so policy implementations
@@ -79,7 +32,7 @@ pub struct PolicyBatchItem<'a, D: PolicyDomain> {
     pub resource: &'a D::Resource,
 }
 
-/// Merges context-recorded fact provenance into a leaf result.
+/// Merges context-recorded fact provenance into a result node.
 ///
 /// Recorded entries precede any explicitly attached provenance (they were
 /// loaded before the result was constructed). When the recorded entries
@@ -88,11 +41,8 @@ pub struct PolicyBatchItem<'a, D: PolicyDomain> {
 /// was unavailable, so "did not grant" cannot be distinguished from "could
 /// not decide" — the context witnessed the failure and reports it
 /// structurally. Grants and forbids are decisive and are never rewritten.
-/// `Combined` nodes have no provenance field. When a recorded load failed,
-/// the entry is preserved on a synthetic `Indeterminate` child and every
-/// non-forbid aggregate decision is downgraded to `Indeterminate`. Benign
-/// recorded entries are dropped with a debug event.
-fn attach_recorded(
+/// Aggregate nodes follow the same rule and retain their own recorded facts.
+pub(crate) fn attach_recorded(
     result: PolicyEvalResult,
     mut recorded: Vec<FactProvenance>,
 ) -> PolicyEvalResult {
@@ -162,50 +112,21 @@ fn attach_recorded(
         PolicyEvalResult::Combined {
             policy_type,
             operation,
-            mut children,
+            children,
             decision,
+            provenance,
         } => {
-            if recorded_error {
-                let recorded_count = recorded.len();
-                let error_count = recorded
-                    .iter()
-                    .filter(|fact| fact.outcome == FactOutcome::Error)
-                    .count();
-                tracing::warn!(
-                    policy.type = %policy_type,
-                    recorded_count,
-                    error_count,
-                    "a policy returned a Combined result after recorded fact loads failed; \
-                     preserving the failures on an Indeterminate child and failing closed"
-                );
-                children.push(PolicyEvalResult::indeterminate_with_facts(
-                    policy_type.clone(),
-                    "Fact load recorded by combined policy failed",
-                    recorded,
-                ));
-                PolicyEvalResult::Combined {
-                    policy_type,
-                    operation,
-                    children,
-                    decision: if decision == crate::Decision::Forbid {
-                        crate::Decision::Forbid
-                    } else {
-                        crate::Decision::Indeterminate
-                    },
-                }
-            } else {
-                tracing::debug!(
-                    policy.type = %policy_type,
-                    recorded_count = recorded.len(),
-                    "facts recorded on an evaluation context were dropped: the policy \
-                     returned a Combined result, which has no provenance to merge into"
-                );
-                PolicyEvalResult::Combined {
-                    policy_type,
-                    operation,
-                    children,
-                    decision,
-                }
+            recorded.extend(provenance);
+            PolicyEvalResult::Combined {
+                policy_type,
+                operation,
+                children,
+                decision: if recorded_error && decision == crate::Decision::NotApplicable {
+                    crate::Decision::Indeterminate
+                } else {
+                    decision
+                },
+                provenance: recorded,
             }
         }
     }
@@ -368,30 +289,28 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
     ///
     /// [`crate::PermissionChecker`] and the built-in combinators call this
     /// after every [`Policy::evaluate`], so a policy that loads facts through
-    /// [`Self::fact`] and then builds a [`PolicyEvalResult`] by hand still
+    /// [`Self::fact`] and then builds a [`GrantResult`] or [`VetoResult`] directly still
     /// produces full provenance — and a hand-built `NotApplicable` after a
     /// recorded load failure is upgraded to `Indeterminate` (see
     /// [`Self::not_applicable`]). Call it yourself when driving
-    /// [`Policy::evaluate`] directly. A `Combined` result has no provenance
-    /// field: recorded failures are preserved on a synthetic `Indeterminate`
-    /// child and make every non-forbid aggregate indeterminate; benign entries
-    /// are dropped with a debug event.
+    /// [`Policy::evaluate`] directly. Aggregate nodes retain their own facts
+    /// and follow the same decision rules as leaves.
     #[inline]
-    pub fn finish(self, result: PolicyEvalResult) -> PolicyEvalResult {
+    pub fn finish<R: PolicyResult>(self, result: R) -> R {
         let recorded = self.recorded.into_inner().expect("recorded facts poisoned");
         if recorded.is_empty() {
             return result;
         }
-        attach_recorded(result, recorded)
+        result.attach_recorded(recorded)
     }
 
     /// Builds a granted result tagged with `ctx.policy_type`, attaching all
     /// facts recorded on this context.
-    pub fn grant(&self, reason: impl Into<String>) -> PolicyEvalResult {
-        attach_recorded(
+    pub fn grant(&self, reason: impl Into<String>) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::granted(self.policy_type.clone(), Some(reason.into())),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// Builds a not-applicable result tagged with `ctx.policy_type`,
@@ -405,26 +324,22 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
     /// load looked identical to a genuine non-match. Use
     /// [`Self::session`] to load without recording when this behavior is
     /// truly not wanted.
-    pub fn not_applicable(&self, reason: impl Into<String>) -> PolicyEvalResult {
-        attach_recorded(
+    pub fn not_applicable(&self, reason: impl Into<String>) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::not_applicable(self.policy_type.clone(), reason),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// Builds a forbidden result tagged with `ctx.policy_type`, attaching
     /// all facts recorded on this context.
     ///
-    /// Use this for an active veto. A hand-written policy that can only veto
-    /// should override [`Policy::effect`] to return [`Effect::Forbid`]. A policy
-    /// that can grant or veto should return [`Effect::AllowOrForbid`]. Both
-    /// make [`crate::PermissionChecker`] evaluate the policy before allow-only
-    /// policies so grant short-circuiting cannot skip the veto.
-    pub fn forbid(&self, reason: impl Into<String>) -> PolicyEvalResult {
-        attach_recorded(
+    /// Returns a veto result, which cannot be returned by a grant policy.
+    pub fn forbid(&self, reason: impl Into<String>) -> VetoResult {
+        VetoResult(attach_recorded(
             PolicyEvalResult::forbidden(self.policy_type.clone(), reason),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// Builds an indeterminate result tagged with `ctx.policy_type`,
@@ -434,11 +349,27 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
     /// unavailable — typically after [`Self::fact`] returned
     /// [`FactLoadResult::Error`]. Fail-closed: never treated as a grant, and
     /// surfaced as [`crate::AccessEvaluation::Indeterminate`] when decisive.
-    pub fn indeterminate(&self, reason: impl Into<String>) -> PolicyEvalResult {
-        attach_recorded(
+    pub fn indeterminate(&self, reason: impl Into<String>) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::indeterminate(self.policy_type.clone(), reason),
             self.take_recorded(),
-        )
+        ))
+    }
+
+    /// Builds a passing veto result and attaches recorded facts.
+    pub fn pass(&self, reason: impl Into<String>) -> VetoResult {
+        VetoResult(attach_recorded(
+            PolicyEvalResult::not_applicable(self.policy_type.clone(), reason),
+            self.take_recorded(),
+        ))
+    }
+
+    /// Builds an unresolved veto result and attaches recorded facts.
+    pub fn veto_indeterminate(&self, reason: impl Into<String>) -> VetoResult {
+        VetoResult(attach_recorded(
+            PolicyEvalResult::indeterminate(self.policy_type.clone(), reason),
+            self.take_recorded(),
+        ))
     }
 
     /// [`Self::grant`] with extra explicit provenance appended after the
@@ -447,15 +378,15 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
         &self,
         reason: impl Into<String>,
         provenance: Vec<FactProvenance>,
-    ) -> PolicyEvalResult {
-        attach_recorded(
+    ) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::granted_with_facts(
                 self.policy_type.clone(),
                 Some(reason.into()),
                 provenance,
             ),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// [`Self::not_applicable`] with extra explicit provenance appended
@@ -472,15 +403,15 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
         &self,
         reason: impl Into<String>,
         provenance: Vec<FactProvenance>,
-    ) -> PolicyEvalResult {
-        attach_recorded(
+    ) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::not_applicable_with_facts(
                 self.policy_type.clone(),
                 reason,
                 provenance,
             ),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// [`Self::forbid`] with extra explicit provenance appended after the
@@ -489,11 +420,11 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
         &self,
         reason: impl Into<String>,
         provenance: Vec<FactProvenance>,
-    ) -> PolicyEvalResult {
-        attach_recorded(
+    ) -> VetoResult {
+        VetoResult(attach_recorded(
             PolicyEvalResult::forbidden_with_facts(self.policy_type.clone(), reason, provenance),
             self.take_recorded(),
-        )
+        ))
     }
 
     /// [`Self::indeterminate`] with extra explicit provenance appended after
@@ -502,15 +433,15 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
         &self,
         reason: impl Into<String>,
         provenance: Vec<FactProvenance>,
-    ) -> PolicyEvalResult {
-        attach_recorded(
+    ) -> GrantResult {
+        GrantResult(attach_recorded(
             PolicyEvalResult::indeterminate_with_facts(
                 self.policy_type.clone(),
                 reason,
                 provenance,
             ),
             self.take_recorded(),
-        )
+        ))
     }
 }
 
@@ -635,7 +566,7 @@ impl<'a, D: PolicyDomain> BatchEvalCtx<'a, D> {
     /// A `results` vector whose length does not match [`Self::items`] is
     /// returned unchanged (the caller's wrong-length handling applies).
     #[inline]
-    pub fn finish(self, results: Vec<PolicyEvalResult>) -> Vec<PolicyEvalResult> {
+    pub fn finish<R: PolicyResult>(self, results: Vec<R>) -> Vec<R> {
         let recorded = self.recorded.into_inner().expect("recorded facts poisoned");
         if recorded.is_empty() || results.len() != recorded.len() {
             return results;
@@ -643,17 +574,21 @@ impl<'a, D: PolicyDomain> BatchEvalCtx<'a, D> {
         results
             .into_iter()
             .zip(recorded)
-            .map(|(result, recorded)| attach_recorded(result, recorded))
+            .map(|(result, recorded)| result.attach_recorded(recorded))
             .collect()
     }
 }
 
-/// A generic async trait representing a single authorization policy for one
-/// [`PolicyDomain`].
+/// A grant policy for one [`PolicyDomain`].
+///
+/// Returns [`GrantResult`], which can grant, abstain, or be indeterminate.
+/// Implement [`crate::VetoPolicy`] for rules that can veto; grant policies
+/// cannot return veto authority. Register grants with
+/// [`crate::PermissionChecker::add_policy`].
 #[async_trait]
 pub trait Policy<D: PolicyDomain>: Send + Sync {
     /// Evaluates whether access should be granted.
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult;
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult;
 
     /// Evaluates access for a batch of resources.
     ///
@@ -661,7 +596,7 @@ pub trait Policy<D: PolicyDomain>: Send + Sync {
     /// each item sequentially. Policies with set-oriented backends can override
     /// this method to reduce round trips while returning one result per input
     /// item in the same order.
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
         let mut results = Vec::with_capacity(ctx.items.len());
         for item in ctx.items {
             let item_ctx = EvalCtx::new(
@@ -681,23 +616,6 @@ pub trait Policy<D: PolicyDomain>: Send + Sync {
     /// Policy name for debugging, trace trees, and telemetry fallbacks.
     fn policy_type(&self) -> Cow<'static, str>;
 
-    /// The declared effect of this policy. Defaults to [`Effect::Allow`].
-    ///
-    /// [`crate::PermissionChecker`] reads this declaration when the policy is
-    /// added. Policies declaring [`Effect::Forbid`] or
-    /// [`Effect::AllowOrForbid`] run before allow-only policies, so a matched
-    /// forbid is observed before a grant can short-circuit.
-    ///
-    /// A policy that returns [`PolicyEvalResult::Forbidden`] while leaving this
-    /// at the default [`Effect::Allow`] still vetoes wherever it is observed,
-    /// but the checker emits a contract-violation `WARN`: the veto is not
-    /// scheduled ahead of grants and an earlier grant can short-circuit before
-    /// it is reached. Declare [`Effect::Forbid`] or [`Effect::AllowOrForbid`]
-    /// for an order-independent veto.
-    fn effect(&self) -> Effect {
-        Effect::Allow
-    }
-
     /// Metadata describing the security rule that backs this policy.
     fn security_rule(&self) -> SecurityRuleMetadata {
         SecurityRuleMetadata::default()
@@ -709,20 +627,16 @@ impl<D> Policy<D> for Box<dyn Policy<D>>
 where
     D: PolicyDomain,
 {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
         (**self).evaluate(ctx).await
     }
 
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
         (**self).evaluate_batch(ctx).await
     }
 
     fn policy_type(&self) -> Cow<'static, str> {
         (**self).policy_type()
-    }
-
-    fn effect(&self) -> Effect {
-        (**self).effect()
     }
 
     fn security_rule(&self) -> SecurityRuleMetadata {
@@ -735,20 +649,16 @@ impl<D> Policy<D> for Arc<dyn Policy<D>>
 where
     D: PolicyDomain,
 {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, D>) -> GrantResult {
         (**self).evaluate(ctx).await
     }
 
-    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, D>) -> Vec<GrantResult> {
         (**self).evaluate_batch(ctx).await
     }
 
     fn policy_type(&self) -> Cow<'static, str> {
         (**self).policy_type()
-    }
-
-    fn effect(&self) -> Effect {
-        (**self).effect()
     }
 
     fn security_rule(&self) -> SecurityRuleMetadata {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -392,13 +392,8 @@ impl<'a, D: PolicyDomain> EvalCtx<'a, D> {
     /// [`Self::not_applicable`] with extra explicit provenance appended
     /// after the recorded entries.
     ///
-    /// The upgrade to `Indeterminate` considers only **recorded** load
-    /// failures (witnessed by the context); explicit provenance passed here
-    /// is attached verbatim without changing the result variant, so policies
-    /// that deliberately report a failed load as not-applicable can still do
-    /// so by constructing provenance themselves. [`crate::NotPolicy`] still
-    /// treats an error-bearing not-applicable leaf as indeterminate instead of
-    /// inverting it to a grant.
+    /// Either recorded or explicit failed facts upgrade the abstention to
+    /// `Indeterminate`, preserving its reason and evidence.
     pub fn not_applicable_with_facts(
         &self,
         reason: impl Into<String>,

--- a/src/results.rs
+++ b/src/results.rs
@@ -207,10 +207,12 @@ impl fmt::Display for FactProvenance {
     }
 }
 
-/// The result of evaluating a single policy (or a combination).
+/// The inspectable audit representation of a policy decision or aggregate.
 ///
-/// This enum is used both by individual policies and by combinators to represent the
-/// outcome of access evaluation.
+/// Policies return [`crate::GrantResult`] or [`crate::VetoResult`], whose
+/// constructors preserve capability boundaries. This public enum supports
+/// inspection, formatting, and serialization; constructing a raw tree does not
+/// grant authority and it cannot be converted into a typed policy result.
 ///
 /// - [`PolicyEvalResult::Granted`]: Indicates that access is granted, with an optional reason.
 /// - [`PolicyEvalResult::NotApplicable`]: Indicates the policy did not grant access — either its
@@ -218,9 +220,8 @@ impl fmt::Display for FactProvenance {
 ///   has nothing positive to say. `NotApplicable` from one policy never overrides a sibling's grant.
 /// - [`PolicyEvalResult::Forbidden`]: Indicates the policy **actively forbids** this request.
 ///   Inside a [`crate::PermissionChecker`] a forbid overrides every grant (deny-overrides
-///   semantics). Produced by [`crate::PolicyBuilder`] policies with
-///   [`crate::Effect::Forbid`] whose predicate matches, or by custom policies via
-///   [`crate::EvalCtx::forbid`].
+///   semantics). Produced by [`crate::PolicyBuilder::build_veto`] policies
+///   whose predicates match, or custom [`crate::VetoPolicy`] implementations.
 /// - [`PolicyEvalResult::Combined`]: Represents the aggregate result of combining multiple policies.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -298,6 +299,8 @@ pub enum PolicyEvalResult {
         children: Vec<PolicyEvalResult>,
         /// The aggregate decision after applying the combining operation.
         decision: Decision,
+        /// Facts consulted directly by this aggregate policy.
+        provenance: Vec<FactProvenance>,
     },
 }
 
@@ -405,6 +408,98 @@ pub enum AccessEvaluation {
     },
 }
 
+/// A non-grant decision with its full audit evidence.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub enum AccessError {
+    /// Authorization completed and denied access.
+    Denied {
+        /// Summary reason for the denial.
+        reason: String,
+        /// Complete evaluation evidence.
+        trace: EvalTrace,
+    },
+    /// Authorization could not be decided.
+    Indeterminate {
+        /// Summary reason for the unresolved decision.
+        reason: String,
+        /// Complete evaluation evidence, including fact errors.
+        trace: EvalTrace,
+    },
+}
+
+impl AccessError {
+    /// Returns the complete audit trace.
+    pub fn trace(&self) -> &EvalTrace {
+        match self {
+            Self::Denied { trace, .. } | Self::Indeterminate { trace, .. } => trace,
+        }
+    }
+
+    /// Returns all recorded fact failures, including failures in child policies.
+    pub fn fact_load_errors(&self) -> Vec<&FactProvenance> {
+        let mut errors = Vec::new();
+        if let Some(root) = self.trace().root() {
+            collect_fact_load_errors(root, &mut errors);
+        }
+        errors
+    }
+}
+
+impl fmt::Display for AccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Denied { reason, .. } => write!(f, "access denied: {reason}"),
+            Self::Indeterminate { reason, .. } => {
+                write!(f, "authorization indeterminate: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AccessError {}
+
+/// An authorization batch containing at least one indeterminate decision.
+///
+/// No partial authorized list is returned. The original items and every
+/// decision remain available in input order for inspection or recovery.
+pub struct FilterError<T> {
+    /// All input items paired with their completed evaluations.
+    pub evaluations: Vec<(T, AccessEvaluation)>,
+}
+
+impl<T> fmt::Debug for FilterError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(
+                self.evaluations
+                    .iter()
+                    .enumerate()
+                    .map(|(index, (_, evaluation))| (index, evaluation)),
+            )
+            .finish()
+    }
+}
+
+impl<T> FilterError<T> {
+    /// Iterates over the original items whose authorization could not be decided.
+    pub fn indeterminate(&self) -> impl Iterator<Item = (&T, &AccessEvaluation)> {
+        self.evaluations
+            .iter()
+            .filter(|(_, evaluation)| evaluation.is_indeterminate())
+            .map(|(item, evaluation)| (item, evaluation))
+    }
+}
+
+impl<T> fmt::Display for FilterError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("could not determine authorization for every item")
+    }
+}
+
+impl<T> std::error::Error for FilterError<T> {}
+
 /// Walks a [`PolicyEvalResult`] tree looking for a `NotApplicable`
 /// leaf whose `policy_type` equals `expected`. Used by
 /// [`AccessEvaluation::assert_not_applicable_by`].
@@ -423,40 +518,23 @@ fn leaf_not_applicable_matches(node: &PolicyEvalResult, expected: &str) -> bool 
 /// Collects every [`FactProvenance`] with [`FactOutcome::Error`] from a
 /// result tree (leaves and combinator children).
 fn collect_fact_load_errors<'a>(node: &'a PolicyEvalResult, out: &mut Vec<&'a FactProvenance>) {
-    match node {
-        PolicyEvalResult::Granted { provenance, .. }
-        | PolicyEvalResult::NotApplicable { provenance, .. }
-        | PolicyEvalResult::Forbidden { provenance, .. }
-        | PolicyEvalResult::Indeterminate { provenance, .. } => {
-            for fact in provenance {
-                if fact.outcome == FactOutcome::Error {
-                    out.push(fact);
-                }
-            }
-        }
-        PolicyEvalResult::Combined { children, .. } => {
-            for child in children {
-                collect_fact_load_errors(child, out);
-            }
+    out.extend(
+        node.provenance()
+            .iter()
+            .filter(|fact| fact.outcome == FactOutcome::Error),
+    );
+    if let PolicyEvalResult::Combined { children, .. } = node {
+        for child in children {
+            collect_fact_load_errors(child, out);
         }
     }
 }
 
-/// Returns `true` on the first [`FactOutcome::Error`] in the tree — no
-/// allocation, early exit. Used by
-/// [`AccessEvaluation::denied_due_to_fact_load_error`].
 fn trace_has_fact_load_error(node: &PolicyEvalResult) -> bool {
-    match node {
-        PolicyEvalResult::Granted { provenance, .. }
-        | PolicyEvalResult::NotApplicable { provenance, .. }
-        | PolicyEvalResult::Forbidden { provenance, .. }
-        | PolicyEvalResult::Indeterminate { provenance, .. } => provenance
-            .iter()
-            .any(|fact| fact.outcome == FactOutcome::Error),
-        PolicyEvalResult::Combined { children, .. } => {
-            children.iter().any(trace_has_fact_load_error)
-        }
-    }
+    node.provenance()
+        .iter()
+        .any(|fact| fact.outcome == FactOutcome::Error)
+        || matches!(node, PolicyEvalResult::Combined { children, .. } if children.iter().any(trace_has_fact_load_error))
 }
 
 impl AccessEvaluation {
@@ -828,10 +906,9 @@ impl AccessEvaluation {
     /// # }
     /// # let mut checker = PermissionChecker::<Domain>::new();
     /// # checker.add_policy(PolicyBuilder::<Domain>::new("AllowAll").build());
-    /// # checker.add_policy(
+    /// # checker.add_veto(
     /// #     PolicyBuilder::<Domain>::new("GlobalFreeze")
-    /// #         .forbid()
-    /// #         .build(),
+    /// #         .build_veto(),
     /// # );
     /// # let session = EvaluationSession::empty();
     /// # let evaluation = checker.bind(&session, &(), &(), &()).check(&()).await;
@@ -885,7 +962,9 @@ impl AccessEvaluation {
         );
     }
 
-    /// Converts the evaluation into a `Result`, mapping a denial into an error.
+    /// Converts the evaluation into a `Result`, mapping denial and indeterminate
+    /// into the same reason-only error callback. Prefer [`Self::into_result`]
+    /// when callers need to distinguish those outcomes.
     ///
     /// `error_fn` receives the denial reason string and should return your
     /// application's error type.
@@ -929,6 +1008,36 @@ impl AccessEvaluation {
             // as a 5xx) should branch on `is_indeterminate()` first.
             Self::Denied { reason, .. } | Self::Indeterminate { reason, .. } => {
                 Err(error_fn(reason))
+            }
+        }
+    }
+
+    /// Converts a decision to a typed error, retaining the reason and complete audit trace.
+    ///
+    /// Unlike [`Self::to_result`], this distinguishes a definite denial from an
+    /// inability to evaluate authorization. Map [`AccessError::Denied`] to a
+    /// forbidden response and [`AccessError::Indeterminate`] to an appropriate
+    /// service error in application code.
+    ///
+    /// ```
+    /// use gatehouse::{AccessError, AccessEvaluation, EvalTrace};
+    /// let evaluation = AccessEvaluation::Indeterminate {
+    ///     reason: "relationship backend unavailable".into(),
+    ///     trace: EvalTrace::new(),
+    /// };
+    /// let status = match evaluation.into_result() {
+    ///     Ok(()) => 200,
+    ///     Err(AccessError::Denied { .. }) => 403,
+    ///     Err(_) => 503,
+    /// };
+    /// assert_eq!(status, 503);
+    /// ```
+    pub fn into_result(self) -> Result<(), AccessError> {
+        match self {
+            Self::Granted { .. } => Ok(()),
+            Self::Denied { reason, trace } => Err(AccessError::Denied { reason, trace }),
+            Self::Indeterminate { reason, trace } => {
+                Err(AccessError::Indeterminate { reason, trace })
             }
         }
     }
@@ -1073,15 +1182,11 @@ impl PolicyEvalResult {
         }
     }
 
-    /// Builds a forbidden leaf result with no fact provenance.
+    /// Builds a forbidden audit leaf with no fact provenance.
     ///
-    /// A forbid is an **active veto**: inside a [`crate::PermissionChecker`]
-    /// it overrides grants from sibling policies. Custom policies returning
-    /// this from [`crate::Policy::evaluate`] should also override
-    /// [`crate::Policy::effect`] to return [`crate::Effect::Forbid`] if they
-    /// can only veto, or [`crate::Effect::AllowOrForbid`] if they can grant or
-    /// veto, so the checker schedules them ahead of allow-only policies. Prefer
-    /// [`crate::EvalCtx::forbid`] inside policy bodies.
+    /// This is an audit representation, not a veto result accepted by the
+    /// checker. Custom veto policies return [`crate::VetoResult`] through
+    /// [`crate::EvalCtx::forbid`] or [`crate::VetoResult::forbid`].
     pub fn forbidden(policy_type: impl Into<Cow<'static, str>>, reason: impl Into<String>) -> Self {
         Self::Forbidden {
             policy_type: policy_type.into(),
@@ -1165,6 +1270,17 @@ impl PolicyEvalResult {
     /// Returns the decision carried by this node.
     ///
     /// Leaves map 1:1 onto their variant; [`PolicyEvalResult::Combined`]
+    /// Returns the name of this audit-tree node.
+    pub fn policy_type(&self) -> &str {
+        match self {
+            Self::Granted { policy_type, .. }
+            | Self::NotApplicable { policy_type, .. }
+            | Self::Forbidden { policy_type, .. }
+            | Self::Indeterminate { policy_type, .. }
+            | Self::Combined { policy_type, .. } => policy_type,
+        }
+    }
+
     /// returns its stored aggregate decision without walking children.
     pub fn decision(&self) -> Decision {
         match self {
@@ -1181,47 +1297,13 @@ impl PolicyEvalResult {
         self.decision() == Decision::Grant
     }
 
-    /// Returns whether this result contains an active forbid.
+    /// Whether this node's aggregate decision is a veto.
     ///
-    /// True when this node's [`Self::decision`] is [`Decision::Forbid`]
-    /// **or** a [`PolicyEvalResult::Forbidden`] leaf survives anywhere in
-    /// the tree. The whole-tree scan is a fail-closed backstop: the crate's
-    /// combinators always keep a `Combined` node's decision consistent with
-    /// its children, but a custom combinator that (incorrectly) reports a
-    /// non-forbid decision while keeping a `Forbidden` leaf in its children
-    /// is still treated as forbidding — and a `WARN` names the inconsistent
-    /// node so the broken combinator is visible in logs rather than being
-    /// silently corrected forever. The warning fires on every call that
-    /// takes the backstop path (the checker and combinators consult
-    /// `is_forbidden` several times per evaluation), so one inconsistent
-    /// node can log more than once per request; that is accepted noise for
-    /// a condition that indicates a broken combinator. The scan
-    /// short-circuits as soon as a forbid is found.
+    /// Audit descendants can contain inactive vetoes (for example one child
+    /// of an all-of veto whose other child passed). Only the node's decision
+    /// carries authority.
     pub fn is_forbidden(&self) -> bool {
-        if self.decision() == Decision::Forbid {
-            return true;
-        }
-        match self.forbidden_leaf() {
-            Some((leaf_policy_type, _)) => {
-                if let Self::Combined {
-                    policy_type,
-                    decision,
-                    ..
-                } = self
-                {
-                    tracing::warn!(
-                        node.policy_type = policy_type.as_ref(),
-                        node.decision = %decision,
-                        forbidden_leaf.policy_type = leaf_policy_type,
-                        "Combined node reports a non-forbid decision but keeps a Forbidden \
-                         leaf in its children; treating it as forbidding (fail closed). \
-                         Fix the combinator that built this node."
-                    );
-                }
-                true
-            }
-            None => false,
-        }
+        self.decision() == Decision::Forbid
     }
 
     pub(crate) fn forbidden_leaf(&self) -> Option<(&str, Option<&str>)> {
@@ -1231,18 +1313,24 @@ impl PolicyEvalResult {
                 reason,
                 ..
             } => Some((policy_type.as_ref(), Some(reason.as_str()))),
-            Self::Combined { children, .. } => children.iter().find_map(Self::forbidden_leaf),
+            Self::Combined {
+                children,
+                decision: Decision::Forbid,
+                ..
+            } => children.iter().find_map(Self::forbidden_leaf),
+            Self::Combined { .. } => None,
             Self::Granted { .. } | Self::NotApplicable { .. } | Self::Indeterminate { .. } => None,
         }
     }
 
-    /// Returns the first indeterminate leaf along the indeterminate spine of
-    /// the tree, as `(policy_type, reason)`. Used to attribute an
-    /// [`AccessEvaluation::Indeterminate`] summary to the policy whose input
-    /// was unavailable. Combined nodes are only entered when they are
-    /// themselves indeterminate, so an incidental indeterminate leaf inside
-    /// a resolved subtree is not misattributed as the cause.
+    /// Attributes uncertainty along the active indeterminate spine.
+    ///
+    /// Resolved subtrees are skipped. An aggregate's own recorded failures
+    /// are attributed to that aggregate. Indeterminate NOT also admits
+    /// explicit error evidence on an abstaining child, since that evidence
+    /// prevents inversion even when the child has no indeterminate leaf.
     pub(crate) fn indeterminate_leaf(&self) -> Option<(&str, &str)> {
+        const FACT_FAILURE_REASON: &str = "A consulted fact could not be loaded";
         match self {
             Self::Indeterminate {
                 policy_type,
@@ -1250,14 +1338,47 @@ impl PolicyEvalResult {
                 ..
             } => Some((policy_type.as_ref(), reason.as_str())),
             Self::Combined {
+                policy_type,
                 children,
+                operation,
+                provenance,
                 decision: Decision::Indeterminate,
-                ..
-            } => children.iter().find_map(Self::indeterminate_leaf),
+            } => children
+                .iter()
+                .find_map(Self::indeterminate_leaf)
+                .or_else(|| {
+                    if provenance
+                        .iter()
+                        .any(|fact| fact.outcome == FactOutcome::Error)
+                    {
+                        Some((policy_type.as_ref(), FACT_FAILURE_REASON))
+                    } else if *operation == CombineOp::Not {
+                        children
+                            .iter()
+                            .find_map(Self::fact_error_policy)
+                            .map(|policy_type| (policy_type, FACT_FAILURE_REASON))
+                    } else {
+                        None
+                    }
+                }),
             Self::Combined { .. }
             | Self::Granted { .. }
             | Self::NotApplicable { .. }
             | Self::Forbidden { .. } => None,
+        }
+    }
+
+    fn fact_error_policy(&self) -> Option<&str> {
+        if self
+            .provenance()
+            .iter()
+            .any(|fact| fact.outcome == FactOutcome::Error)
+        {
+            return Some(self.policy_type());
+        }
+        match self {
+            Self::Combined { children, .. } => children.iter().find_map(Self::fact_error_policy),
+            _ => None,
         }
     }
 
@@ -1282,14 +1403,14 @@ impl PolicyEvalResult {
 
     /// Returns the facts the policy consulted to reach this decision.
     ///
-    /// Empty for combinators and for policies that are not fact-backed.
+    /// Aggregate nodes contain their own facts; child facts remain on their children.
     pub fn provenance(&self) -> &[FactProvenance] {
         match self {
             Self::Granted { provenance, .. }
             | Self::NotApplicable { provenance, .. }
             | Self::Forbidden { provenance, .. }
-            | Self::Indeterminate { provenance, .. } => provenance,
-            Self::Combined { .. } => &[],
+            | Self::Indeterminate { provenance, .. }
+            | Self::Combined { provenance, .. } => provenance,
         }
     }
 
@@ -1339,6 +1460,7 @@ impl PolicyEvalResult {
                 operation,
                 children,
                 decision,
+                provenance,
             } => {
                 let decision_char = match decision {
                     Decision::Grant => "✔",
@@ -1351,6 +1473,7 @@ impl PolicyEvalResult {
                     indent_str, decision_char, policy_type, operation
                 );
 
+                result = Self::append_provenance(result, &indent_str, provenance);
                 for child in children {
                     result.push_str(&format!("\n{}", child.format(indent + 2)));
                 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -676,10 +676,8 @@ impl AccessEvaluation {
     /// This helper remains an **any-error-in-trace** scan, not a causal
     /// check: it does not prove the load failure was the reason for the
     /// denial (a policy may record a load error yet deny for ordinary
-    /// reasons). Its only remaining use is catching errors attached as
-    /// explicit `NotApplicable` provenance by policies that bypass the
-    /// recording context; with [`crate::EvalCtx::fact`] such failures are
-    /// upgraded to [`PolicyEvalResult::Indeterminate`] automatically. Use
+    /// reasons). A settled aggregate may retain failed facts from an
+    /// inconclusive child without itself being indeterminate. Use
     /// [`Self::fact_load_errors`] when you need the failed loads
     /// themselves.
     #[deprecated(
@@ -1208,17 +1206,14 @@ impl PolicyEvalResult {
         }
     }
 
-    /// Builds a not-applicable leaf result carrying the facts that informed it.
+    /// Builds an abstention with explicit facts, or an indeterminate result if
+    /// any of those facts failed to load. The reason and facts are preserved.
     pub fn not_applicable_with_facts(
         policy_type: impl Into<Cow<'static, str>>,
         reason: impl Into<String>,
         provenance: Vec<FactProvenance>,
     ) -> Self {
-        Self::NotApplicable {
-            policy_type: policy_type.into(),
-            reason: reason.into(),
-            provenance,
-        }
+        crate::policy::attach_recorded(Self::not_applicable(policy_type, reason), provenance)
     }
 
     /// Builds a forbidden leaf result carrying the facts that informed it.

--- a/src/results.rs
+++ b/src/results.rs
@@ -44,8 +44,8 @@ impl fmt::Display for CombineOp {
 /// `Indeterminate` is the fail-closed "could not evaluate" decision: the node
 /// consulted an input (typically a fact load) that was unavailable. It never
 /// grants, and inside [`crate::PermissionChecker`] an `Indeterminate` from a
-/// veto-capable policy also blocks sibling grants, because the failed policy
-/// might have forbidden the request.
+/// veto policy also blocks grants, because the failed policy might have
+/// forbidden the request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -274,7 +274,7 @@ pub enum PolicyEvalResult {
     /// [`PolicyEvalResult::NotApplicable`] ("this policy does not grant"),
     /// `Indeterminate` means "this policy might have granted or forbidden,
     /// but its inputs were unavailable". [`crate::PermissionChecker`] blocks
-    /// grants when a veto-capable policy is indeterminate, and surfaces the
+    /// grants when a veto policy is indeterminate, and surfaces the
     /// failure as [`AccessEvaluation::Indeterminate`] so callers can map an
     /// authorization-data outage to a 5xx instead of a 403.
     Indeterminate {
@@ -391,10 +391,9 @@ pub enum AccessEvaluation {
     /// [`AccessEvaluation::Denied`] so callers can map "authorization inputs
     /// were unavailable" (usually a 5xx and a retry) differently from "the
     /// policies decided against this request" (a 403). Produced when a
-    /// veto-capable policy was indeterminate (its potential veto is
-    /// unresolved, so a grant cannot be released), or when no policy granted
-    /// and at least one allow-only policy was indeterminate (it might have
-    /// granted).
+    /// veto policy was indeterminate (its potential veto is unresolved, so a
+    /// grant cannot be released), or when no policy granted and at least one
+    /// grant policy was indeterminate (it might have granted).
     ///
     /// The classified fact-load failures are in the trace; use
     /// [`Self::fact_load_errors`] to collect them and
@@ -1321,9 +1320,10 @@ impl PolicyEvalResult {
     /// Attributes uncertainty along the active indeterminate spine.
     ///
     /// Resolved subtrees are skipped. An aggregate's own recorded failures
-    /// are attributed to that aggregate. Indeterminate NOT also admits
-    /// explicit error evidence on an abstaining child, since that evidence
-    /// prevents inversion even when the child has no indeterminate leaf.
+    /// are attributed to that aggregate. Every indeterminate aggregate the
+    /// crate produces either contains an indeterminate leaf or carries a
+    /// failed fact in its own provenance, so this search always names a
+    /// policy for a crate-built tree.
     pub(crate) fn indeterminate_leaf(&self) -> Option<(&str, &str)> {
         const FACT_FAILURE_REASON: &str = "A consulted fact could not be loaded";
         match self {
@@ -1335,45 +1335,22 @@ impl PolicyEvalResult {
             Self::Combined {
                 policy_type,
                 children,
-                operation,
                 provenance,
                 decision: Decision::Indeterminate,
+                ..
             } => children
                 .iter()
                 .find_map(Self::indeterminate_leaf)
                 .or_else(|| {
-                    if provenance
+                    provenance
                         .iter()
                         .any(|fact| fact.outcome == FactOutcome::Error)
-                    {
-                        Some((policy_type.as_ref(), FACT_FAILURE_REASON))
-                    } else if *operation == CombineOp::Not {
-                        children
-                            .iter()
-                            .find_map(Self::fact_error_policy)
-                            .map(|policy_type| (policy_type, FACT_FAILURE_REASON))
-                    } else {
-                        None
-                    }
+                        .then(|| (policy_type.as_ref(), FACT_FAILURE_REASON))
                 }),
             Self::Combined { .. }
             | Self::Granted { .. }
             | Self::NotApplicable { .. }
             | Self::Forbidden { .. } => None,
-        }
-    }
-
-    fn fact_error_policy(&self) -> Option<&str> {
-        if self
-            .provenance()
-            .iter()
-            .any(|fact| fact.outcome == FactOutcome::Error)
-        {
-            return Some(self.policy_type());
-        }
-        match self {
-            Self::Combined { children, .. } => children.iter().find_map(Self::fact_error_policy),
-            _ => None,
         }
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -9,8 +9,10 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::Hasher;
 use std::num::NonZeroUsize;
+#[cfg(feature = "tracing")]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+#[cfg(feature = "tracing")]
 use tracing::Instrument;
 
 const FACT_STATE_STRIPES: usize = 64;
@@ -27,6 +29,7 @@ type StripeCore<K> = FactStripeCore<K, StripeWaiter>;
 #[derive(Default)]
 struct EvaluationSessionInner {
     states: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    #[cfg(feature = "tracing")]
     next_load_id: AtomicU64,
     shared_empty: bool,
 }
@@ -478,7 +481,9 @@ impl EvaluationSession {
                     .max(1);
 
                 for chunk in load_plan.keys.chunks(chunk_size) {
+                    #[cfg(feature = "tracing")]
                     let load_id = self.inner.next_load_id.fetch_add(1, Ordering::Relaxed);
+                    #[cfg(feature = "tracing")]
                     let load_span = tracing::debug_span!(
                         "gatehouse.fact_load",
                         fact.name = K::NAME,
@@ -486,7 +491,10 @@ impl EvaluationSession {
                         fact.key_count = chunk.len(),
                         fact.unique_key_count = chunk.len(),
                     );
-                    let loaded = source.load_many(chunk).instrument(load_span).await;
+                    let loaded = source.load_many(chunk);
+                    #[cfg(feature = "tracing")]
+                    let loaded = loaded.instrument(load_span);
+                    let loaded = loaded.await;
                     let results = if loaded.len() == chunk.len() {
                         loaded
                     } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3610,6 +3610,68 @@ mod policy_builder_tests {
         ));
     }
 
+    #[tokio::test]
+    async fn veto_builder_preserves_borrowed_names_in_scalar_and_batch_results() {
+        let session = EvaluationSession::empty();
+        let subject = TestSubject {
+            name: "Alice".into(),
+        };
+        let items = [
+            PolicyBatchItem {
+                resource: &TestResource,
+            },
+            PolicyBatchItem {
+                resource: &TestResource,
+            },
+        ];
+        for matches_predicate in [false, true] {
+            for per_resource in [false, true] {
+                let builder = PolicyBuilder::<TestDomain>::new("StaticVeto");
+                let policy = if per_resource {
+                    builder.resources(move |_| matches_predicate)
+                } else {
+                    builder.subjects(move |_| matches_predicate)
+                }
+                .build_veto();
+                let scalar = EvalCtx::new(
+                    &session,
+                    &subject,
+                    &TestAction,
+                    &TestResource,
+                    &TestContext,
+                    policy.policy_type(),
+                );
+                let batch = BatchEvalCtx::new(
+                    &session,
+                    &subject,
+                    &TestAction,
+                    &TestContext,
+                    &items,
+                    policy.policy_type(),
+                );
+                let mut results = policy.evaluate_batch(&batch).await;
+                assert_eq!(results.len(), items.len());
+                results.push(policy.evaluate(&scalar).await);
+                for result in results {
+                    assert_eq!(result.is_forbidden(), matches_predicate);
+                    assert!(
+                        matches!(
+                            result.trace(),
+                            PolicyEvalResult::Forbidden {
+                                policy_type: std::borrow::Cow::Borrowed("StaticVeto"),
+                                ..
+                            } | PolicyEvalResult::NotApplicable {
+                                policy_type: std::borrow::Cow::Borrowed("StaticVeto"),
+                                ..
+                            }
+                        ),
+                        "static veto name should remain borrowed: {result:?}"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn new_with_owned_string_stores_owned_policy_type() {
         let dynamic = format!("Dynamic{}", 42);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,15 +6,24 @@ use std::sync::Arc;
 
 mod core_tests {
     use super::*;
-    use std::collections::{BTreeMap, HashSet};
+    #[cfg(feature = "tracing")]
+    use std::collections::BTreeMap;
+    use std::collections::HashSet;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc as StdArc, Mutex};
+    #[cfg(feature = "tracing")]
+    use std::sync::Arc as StdArc;
+    use std::sync::Mutex;
+    #[cfg(feature = "tracing")]
     use tracing::field::{Field, Visit};
+    #[cfg(feature = "tracing")]
     use tracing::{Event, Subscriber};
+    #[cfg(feature = "tracing")]
     use tracing_subscriber::layer::{Context, Layer};
+    #[cfg(feature = "tracing")]
     use tracing_subscriber::prelude::*;
+    #[cfg(feature = "tracing")]
     use tracing_subscriber::Registry;
 
     trait TestPolicyExt<D>: Policy<D>
@@ -55,7 +64,7 @@ mod core_tests {
                 let policy_type = self.policy_type();
                 let ctx = EvalCtx::new(&session, subject, action, resource, context, policy_type);
                 let result = self.evaluate(&ctx).await;
-                ctx.finish(result)
+                ctx.finish(result).into_trace()
             })
         }
 
@@ -72,6 +81,9 @@ mod core_tests {
                 let ctx = BatchEvalCtx::new(&session, subject, action, context, items, policy_type);
                 let results = self.evaluate_batch(&ctx).await;
                 ctx.finish(results)
+                    .into_iter()
+                    .map(PolicyResult::into_trace)
+                    .collect()
             })
         }
     }
@@ -216,17 +228,20 @@ mod core_tests {
         type Context = TestContext;
     }
 
+    #[cfg(feature = "tracing")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RecordedEvent {
         target: String,
         fields: BTreeMap<String, String>,
     }
 
+    #[cfg(feature = "tracing")]
     #[derive(Default)]
     struct FieldRecorder {
         fields: BTreeMap<String, String>,
     }
 
+    #[cfg(feature = "tracing")]
     impl Visit for FieldRecorder {
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
             self.fields
@@ -254,11 +269,13 @@ mod core_tests {
         }
     }
 
+    #[cfg(feature = "tracing")]
     #[derive(Clone, Default)]
     struct EventRecorder {
         events: StdArc<Mutex<Vec<RecordedEvent>>>,
     }
 
+    #[cfg(feature = "tracing")]
     impl<S> Layer<S> for EventRecorder
     where
         S: Subscriber,
@@ -284,7 +301,9 @@ mod core_tests {
     /// cache with `Interest::never`, and later threads using
     /// `with_default(...)` see zero events. This is the standard flake in
     /// tracing tests under parallel execution.
+    #[cfg(feature = "tracing")]
     struct PermissiveNoop;
+    #[cfg(feature = "tracing")]
     impl Subscriber for PermissiveNoop {
         fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
             true
@@ -299,6 +318,7 @@ mod core_tests {
         fn exit(&self, _: &tracing::span::Id) {}
     }
 
+    #[cfg(feature = "tracing")]
     fn install_permissive_global() {
         use std::sync::Once;
         static ONCE: Once = Once::new();
@@ -310,6 +330,7 @@ mod core_tests {
         });
     }
 
+    #[cfg(feature = "tracing")]
     fn with_recorded_events<T>(f: impl FnOnce() -> T) -> (T, Vec<RecordedEvent>) {
         install_permissive_global();
         let recorder = EventRecorder::default();
@@ -320,6 +341,7 @@ mod core_tests {
         (result, events)
     }
 
+    #[cfg(feature = "tracing")]
     fn security_events(events: &[RecordedEvent]) -> Vec<&RecordedEvent> {
         events
             .iter()
@@ -354,8 +376,8 @@ mod core_tests {
 
     #[async_trait]
     impl Policy<TestDomain> for AlwaysAllowPolicy {
-        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
-            PolicyEvalResult::granted(
+        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
+            GrantResult::granted(
                 self.policy_type().to_string(),
                 Some("Always allow policy".to_string()),
             )
@@ -371,8 +393,8 @@ mod core_tests {
 
     #[async_trait]
     impl Policy<TestDomain> for AlwaysDenyPolicy {
-        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
-            PolicyEvalResult::not_applicable(self.policy_type().to_string(), self.0)
+        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
+            GrantResult::not_applicable(self.policy_type().to_string(), self.0)
         }
 
         fn policy_type(&self) -> std::borrow::Cow<'static, str> {
@@ -387,22 +409,22 @@ mod core_tests {
 
     #[async_trait]
     impl Policy<TestDomain> for EvenResourceBatchPolicy {
-        async fn evaluate(&self, ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
+        async fn evaluate(&self, ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
             self.single_calls.fetch_add(1, Ordering::SeqCst);
             if ctx.resource.id.as_u128() % 2 == 0 {
-                PolicyEvalResult::granted(
+                GrantResult::granted(
                     self.policy_type().to_string(),
                     Some("even resource".to_string()),
                 )
             } else {
-                PolicyEvalResult::not_applicable(self.policy_type().to_string(), "odd resource")
+                GrantResult::not_applicable(self.policy_type().to_string(), "odd resource")
             }
         }
 
         async fn evaluate_batch<'item>(
             &self,
             ctx: &BatchEvalCtx<'item, TestDomain>,
-        ) -> Vec<PolicyEvalResult> {
+        ) -> Vec<GrantResult> {
             self.batch_calls.fetch_add(1, Ordering::SeqCst);
             let mut results = Vec::with_capacity(ctx.items.len());
             for item in ctx.items {
@@ -429,8 +451,8 @@ mod core_tests {
 
     #[async_trait]
     impl Policy<TestDomain> for MismatchedBatchPolicy {
-        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
-            PolicyEvalResult::granted(
+        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
+            GrantResult::granted(
                 self.policy_type().to_string(),
                 Some("single item fallback".to_string()),
             )
@@ -439,12 +461,12 @@ mod core_tests {
         async fn evaluate_batch<'item>(
             &self,
             ctx: &BatchEvalCtx<'item, TestDomain>,
-        ) -> Vec<PolicyEvalResult> {
+        ) -> Vec<GrantResult> {
             ctx.items
                 .iter()
                 .skip(1)
                 .map(|_| {
-                    PolicyEvalResult::granted(
+                    GrantResult::granted(
                         self.policy_type().to_string(),
                         Some("wrong batch length".to_string()),
                     )
@@ -457,15 +479,14 @@ mod core_tests {
         }
     }
 
+    #[cfg(feature = "tracing")]
     struct CustomMetadataDenyPolicy;
 
+    #[cfg(feature = "tracing")]
     #[async_trait]
     impl Policy<TestDomain> for CustomMetadataDenyPolicy {
-        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
-            PolicyEvalResult::not_applicable(
-                self.policy_type().to_string(),
-                "Blocked by custom rule",
-            )
+        async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
+            GrantResult::not_applicable(self.policy_type().to_string(), "Blocked by custom rule")
         }
 
         fn policy_type(&self) -> std::borrow::Cow<'static, str> {
@@ -1003,7 +1024,7 @@ mod core_tests {
         struct OddResourcePolicy;
         #[async_trait]
         impl Policy<TestDomain> for OddResourcePolicy {
-            async fn evaluate(&self, ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
+            async fn evaluate(&self, ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
                 if ctx.resource.id.as_u128() % 2 == 1 {
                     ctx.grant("odd id")
                 } else {
@@ -1260,6 +1281,7 @@ mod core_tests {
         );
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn test_tracing_uses_default_security_rule_fallbacks() {
         let mut checker = PermissionChecker::new();
@@ -1325,6 +1347,7 @@ mod core_tests {
         );
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn test_tracing_uses_custom_security_rule_metadata() {
         let mut checker = PermissionChecker::new();
@@ -1541,7 +1564,10 @@ mod core_tests {
             provenance[0].key
         );
         // The rendered trace surfaces the fact inline.
-        assert!(result.format(0).contains("↳ fact relationship [found]"));
+        assert!(result
+            .trace()
+            .format(0)
+            .contains("↳ fact relationship [found]"));
     }
 
     #[tokio::test]
@@ -1678,7 +1704,7 @@ mod core_tests {
         assert_eq!(
             results
                 .iter()
-                .map(PolicyEvalResult::is_granted)
+                .map(GrantResult::is_granted)
                 .collect::<Vec<_>>(),
             vec![true, false, true, true, false]
         );
@@ -1922,6 +1948,7 @@ mod core_tests {
                 operation,
                 children,
                 decision,
+                ..
             } => {
                 assert_eq!(operation, CombineOp::And);
                 assert_eq!(decision, Decision::NotApplicable);
@@ -1975,6 +2002,7 @@ mod core_tests {
                 operation,
                 children,
                 decision,
+                ..
             } => {
                 assert_eq!(operation, CombineOp::Or);
                 assert_eq!(decision, Decision::NotApplicable);
@@ -2021,6 +2049,7 @@ mod core_tests {
                 operation,
                 children,
                 decision,
+                ..
             } => {
                 assert_eq!(operation, CombineOp::Not);
                 assert_eq!(decision, Decision::NotApplicable);
@@ -2100,17 +2129,14 @@ mod core_tests {
 
     #[async_trait]
     impl Policy<FeatureFlagDomain> for FeatureFlagPolicy {
-        async fn evaluate(&self, ctx: &EvalCtx<'_, FeatureFlagDomain>) -> PolicyEvalResult {
+        async fn evaluate(&self, ctx: &EvalCtx<'_, FeatureFlagDomain>) -> GrantResult {
             if ctx.context.feature_enabled {
-                PolicyEvalResult::granted(
+                GrantResult::granted(
                     self.policy_type().to_string(),
                     Some("Feature flag enabled".to_string()),
                 )
             } else {
-                PolicyEvalResult::not_applicable(
-                    self.policy_type().to_string(),
-                    "Feature flag disabled",
-                )
+                GrantResult::not_applicable(self.policy_type().to_string(), "Feature flag disabled")
             }
         }
 
@@ -2561,16 +2587,16 @@ mod core_tests {
 
         #[async_trait]
         impl Policy<TestDomain> for CountingPolicy {
-            async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> PolicyEvalResult {
+            async fn evaluate(&self, _ctx: &EvalCtx<'_, TestDomain>) -> GrantResult {
                 self.counter.fetch_add(1, Ordering::SeqCst);
 
                 if self.result {
-                    PolicyEvalResult::granted(
+                    GrantResult::granted(
                         self.policy_type().to_string(),
                         Some("Counting policy granted".to_string()),
                     )
                 } else {
-                    PolicyEvalResult::not_applicable(
+                    GrantResult::not_applicable(
                         self.policy_type().to_string(),
                         "Counting policy denied",
                     )
@@ -2874,6 +2900,7 @@ mod core_tests {
     #[test]
     fn test_policy_eval_result_reason_combined() {
         let result = PolicyEvalResult::Combined {
+            provenance: Vec::new(),
             policy_type: std::borrow::Cow::Borrowed("CombinedPolicy"),
             operation: CombineOp::And,
             children: vec![],
@@ -3118,6 +3145,7 @@ mod core_tests {
         assert_eq!(denied.reason_str(), Some("nope"));
 
         let combined = PolicyEvalResult::Combined {
+            provenance: Vec::new(),
             policy_type: "C".into(),
             operation: CombineOp::Or,
             children: vec![],
@@ -3276,10 +3304,9 @@ mod core_tests {
         // tree-walker checks policy_type, not reason — what we're pinning
         // is that it finds *any* matching leaf.)
         let custom = PolicyBuilder::<TestDomain>::new("SupplierBlock")
-            .forbid()
             .subjects(|_subject| false)
-            .build();
-        checker.add_policy(custom);
+            .build_veto();
+        checker.add_veto(custom);
         checker
     }
 
@@ -3323,11 +3350,7 @@ mod core_tests {
         }
 
         let mut checker = PermissionChecker::<UnitDomain>::new();
-        checker.add_policy(
-            PolicyBuilder::<UnitDomain>::new("GlobalFreeze")
-                .forbid()
-                .build(),
-        );
+        checker.add_veto(PolicyBuilder::<UnitDomain>::new("GlobalFreeze").build_veto());
         let session = EvaluationSession::empty();
         let evaluation = checker.bind(&session, &(), &(), &()).check(&()).await;
         evaluation.assert_not_applicable_by("GlobalFreeze");
@@ -3520,7 +3543,28 @@ mod policy_builder_tests {
                 let policy_type = self.policy_type();
                 let ctx = EvalCtx::new(&session, subject, action, resource, context, policy_type);
                 let result = self.evaluate(&ctx).await;
-                ctx.finish(result)
+                ctx.finish(result).into_trace()
+            })
+        }
+    }
+
+    impl<D> PolicyBoxExt<D> for Box<dyn VetoPolicy<D>>
+    where
+        D: PolicyDomain,
+    {
+        fn evaluate_access<'a>(
+            &'a self,
+            subject: &'a D::Subject,
+            action: &'a D::Action,
+            resource: &'a D::Resource,
+            context: &'a D::Context,
+        ) -> Pin<Box<dyn Future<Output = PolicyEvalResult> + Send + 'a>> {
+            Box::pin(async move {
+                let session = EvaluationSession::new();
+                let policy_type = self.policy_type();
+                let ctx = EvalCtx::new(&session, subject, action, resource, context, policy_type);
+                let result = self.evaluate(&ctx).await;
+                ctx.finish(result).into_trace()
             })
         }
     }
@@ -3679,12 +3723,10 @@ mod policy_builder_tests {
         );
     }
 
-    // Test that `.forbid()` turns an otherwise matching predicate into an active veto.
+    // A matching veto builder forbids without granting authority.
     #[tokio::test]
     async fn test_policy_builder_forbid() {
-        let policy = PolicyBuilder::<TestDomain>::new("ForbidPolicy")
-            .forbid()
-            .build();
+        let policy = PolicyBuilder::<TestDomain>::new("ForbidPolicy").build_veto();
 
         // Even though no predicate fails (so predicate returns true),
         // the forbid effect should result in a Denied outcome.
@@ -3710,9 +3752,8 @@ mod policy_builder_tests {
     async fn test_policy_builder_forbid_overrides_other_grants() {
         for block_registered_first in [true, false] {
             let block_policy = PolicyBuilder::<TestDomain>::new("BlockAlicePolicy")
-                .forbid()
                 .subjects(|subject| subject.name == "Alice")
-                .build();
+                .build_veto();
 
             let allow_policy = PolicyBuilder::<TestDomain>::new("AllowAlicePolicy")
                 .subjects(|subject| subject.name == "Alice")
@@ -3720,11 +3761,11 @@ mod policy_builder_tests {
 
             let mut checker = PermissionChecker::new();
             if block_registered_first {
-                checker.add_policy(block_policy);
+                checker.add_veto(block_policy);
                 checker.add_policy(allow_policy);
             } else {
                 checker.add_policy(allow_policy);
-                checker.add_policy(block_policy);
+                checker.add_veto(block_policy);
             }
 
             let session = EvaluationSession::empty();
@@ -3767,17 +3808,23 @@ mod policy_builder_tests {
     }
 
     #[tokio::test]
-    async fn forbid_veto_composes_through_fluent_or_policy() {
+    async fn veto_any_of_overrides_sibling_grant() {
         let allow_policy = PolicyBuilder::<TestDomain>::new("AllowAlicePolicy")
             .subjects(|subject| subject.name == "Alice")
             .build();
         let block_policy = PolicyBuilder::<TestDomain>::new("BlockAlicePolicy")
-            .forbid()
             .subjects(|subject| subject.name == "Alice")
-            .build();
+            .build_veto();
 
         let mut checker = PermissionChecker::new();
-        checker.add_policy(allow_policy.or(block_policy));
+        checker.add_policy(allow_policy);
+        checker.add_veto(
+            block_policy.any_of(
+                PolicyBuilder::<TestDomain>::new("NoMatch")
+                    .subjects(|_| false)
+                    .build_veto(),
+            ),
+        );
 
         let session = EvaluationSession::empty();
         let result = checker
@@ -3793,21 +3840,23 @@ mod policy_builder_tests {
             .await;
 
         result.assert_forbidden_by("BlockAlicePolicy");
-        result.assert_trace_contains("OrPolicy");
+        result.assert_trace_contains("AnyOfVeto");
     }
 
     #[tokio::test]
-    async fn forbid_veto_composes_through_fluent_and_policy_batch() {
+    async fn veto_all_of_overrides_sibling_grant_batch() {
         let allow_policy = PolicyBuilder::<TestDomain>::new("AllowAlicePolicy")
             .subjects(|subject| subject.name == "Alice")
             .build();
         let block_policy = PolicyBuilder::<TestDomain>::new("BlockAlicePolicy")
-            .forbid()
             .subjects(|subject| subject.name == "Alice")
-            .build();
+            .build_veto();
 
         let mut checker = PermissionChecker::new();
-        checker.add_policy(allow_policy.and(block_policy));
+        checker.add_policy(allow_policy);
+        checker.add_veto(
+            block_policy.all_of(PolicyBuilder::<TestDomain>::new("SecondBlock").build_veto()),
+        );
 
         let session = EvaluationSession::empty();
         let results = checker
@@ -3825,7 +3874,7 @@ mod policy_builder_tests {
         assert_eq!(results.len(), 2);
         for (_resource, evaluation) in results {
             evaluation.assert_forbidden_by("BlockAlicePolicy");
-            evaluation.assert_trace_contains("AndPolicy");
+            evaluation.assert_trace_contains("AllOfVeto");
         }
     }
 
@@ -3834,9 +3883,8 @@ mod policy_builder_tests {
     #[tokio::test]
     async fn test_non_matching_deny_policy_does_not_block_grants() {
         let deny_policy = PolicyBuilder::<TestDomain>::new("BlockNobodyPolicy")
-            .forbid()
             .subjects(|_subject| false)
-            .build();
+            .build_veto();
 
         let allow_policy = PolicyBuilder::<TestDomain>::new("AllowAlicePolicy")
             .subjects(|subject| subject.name == "Alice")
@@ -3844,7 +3892,7 @@ mod policy_builder_tests {
 
         let mut checker = PermissionChecker::new();
         checker.add_policy(allow_policy);
-        checker.add_policy(deny_policy);
+        checker.add_veto(deny_policy);
 
         let session = EvaluationSession::empty();
         let result = checker
@@ -4375,7 +4423,7 @@ mod policy_builder_tests {
         let bctx = batch_ctx(&session, &subject, &action, &ctx, &items);
         let results = policy.evaluate_batch(&bctx).await;
 
-        assert!(results.iter().all(PolicyEvalResult::is_granted));
+        assert!(results.iter().all(GrantResult::is_granted));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
@@ -4557,7 +4605,7 @@ mod recording_ctx_tests {
         assert_eq!(provenance[0].outcome, FactOutcome::Error);
         assert_eq!(provenance[0].error_kind, Some(FactLoadErrorKind::Backend));
         // The policy's own reason is preserved through the upgrade.
-        assert_eq!(result.reason_str(), Some("not odd"));
+        assert_eq!(result.trace().reason_str(), Some("not odd"));
     }
 
     #[tokio::test]
@@ -4600,23 +4648,24 @@ mod recording_ctx_tests {
         assert!(result.is_granted());
         assert_eq!(result.provenance().len(), 1);
 
-        // A recorded failure cannot merge directly into a Combined node, so
-        // finish preserves it on a synthetic child and fails closed.
+        // An independently decisive aggregate grant matches a leaf grant.
         let c = ctx(&session, &subject, &resource);
         c.fact(Flag(2)).await;
         let combined = c.finish(PolicyEvalResult::Combined {
+            provenance: Vec::new(),
             policy_type: std::borrow::Cow::Borrowed("C"),
             operation: CombineOp::And,
             children: vec![],
             decision: Decision::Grant,
         });
-        assert_eq!(combined.decision(), Decision::Indeterminate);
+        assert_eq!(combined.decision(), Decision::Grant);
         assert!(combined.format(0).contains("fact flag [error]"));
 
         // A definite forbid still wins over the failed load.
         let c = ctx(&session, &subject, &resource);
         c.fact(Flag(2)).await;
         let combined = c.finish(PolicyEvalResult::Combined {
+            provenance: Vec::new(),
             policy_type: std::borrow::Cow::Borrowed("C"),
             operation: CombineOp::And,
             children: vec![],

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -789,7 +789,7 @@ mod core_tests {
 
         // The malformed policy's own (wrong-length) grants are discarded:
         // each item gets a synthesized indeterminate for it, and evaluation
-        // continues, so a healthy allow-only sibling still grants on its own
+        // continues, so a healthy grant sibling still grants on its own
         // merits and the trace keeps the contract violation visible.
         let mut checker = PermissionChecker::new();
         checker.add_policy(MismatchedBatchPolicy);
@@ -3298,7 +3298,7 @@ mod core_tests {
         let mut checker = PermissionChecker::new();
         checker.add_policy(AlwaysDenyPolicy("first denial reason"));
         // A second policy with a different name and reason. Its
-        // forbid-effect predicate never matches, so it lands in the trace as
+        // predicate never matches, so it lands in the trace as
         // a not-applicable leaf rather than vetoing the whole
         // evaluation before the first policy is consulted. (The
         // tree-walker checks policy_type, not reason — what we're pinning
@@ -3808,7 +3808,7 @@ mod policy_builder_tests {
         );
     }
 
-    /// The headline deny-overrides behavior: a matched `Effect::Forbid` policy
+    /// The headline deny-overrides behavior: a matched veto policy
     /// vetoes a sibling grant, regardless of registration order.
     #[tokio::test]
     async fn test_policy_builder_forbid_overrides_other_grants() {
@@ -3940,7 +3940,7 @@ mod policy_builder_tests {
         }
     }
 
-    /// A non-matching `Effect::Forbid` policy contributes nothing: the allow
+    /// A non-matching veto policy contributes nothing: the allow
     /// set still decides, and the trace root reflects deny-overrides.
     #[tokio::test]
     async fn test_non_matching_deny_policy_does_not_block_grants() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4671,14 +4671,12 @@ mod recording_ctx_tests {
     }
 
     #[tokio::test]
-    async fn explicit_provenance_alone_does_not_upgrade() {
+    async fn explicit_failed_provenance_upgrades_abstention() {
         let session = flag_session([]);
         let subject = Subject(0);
         let resource = Resource(0);
         let c = ctx(&session, &subject, &resource);
 
-        // Error provenance constructed by hand (not witnessed by the
-        // context) leaves the author's variant choice untouched.
         let explicit = FactProvenance::from_load_result::<bool>(
             "flag",
             "Flag(0)",
@@ -4686,7 +4684,7 @@ mod recording_ctx_tests {
         );
         let result = c.not_applicable_with_facts("treated as ordinary", vec![explicit]);
 
-        assert_eq!(result.decision(), Decision::NotApplicable);
+        assert_eq!(result.decision(), Decision::Indeterminate);
         assert_eq!(result.provenance().len(), 1);
     }
 

--- a/tests/actix_example.rs
+++ b/tests/actix_example.rs
@@ -210,3 +210,45 @@ async fn list_posts_filters_by_relationship() {
     );
     assert!(body.contains("published announcement"));
 }
+
+struct UnavailableRelationships;
+
+#[async_trait::async_trait]
+impl<K: gatehouse::FactKey<Value = bool>> gatehouse::FactSource<K> for UnavailableRelationships {
+    async fn load_many(&self, keys: &[K]) -> Vec<gatehouse::FactLoadResult<bool>> {
+        keys.iter()
+            .map(|_| {
+                gatehouse::FactLoadResult::Error(gatehouse::FactLoadError::backend_message(
+                    "injected outage",
+                ))
+            })
+            .collect()
+    }
+}
+
+#[actix_web::test]
+async fn authorization_outage_returns_503_for_single_and_list_but_admin_still_grants() {
+    let state = actix_example::AppState::demo().with_relationship_source(UnavailableRelationships);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .route("/posts", web::get().to(actix_example::list_posts))
+            .route("/posts/{id}", web::get().to(actix_example::view_post)),
+    )
+    .await;
+    for uri in ["/posts", "/posts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"] {
+        let request = test::TestRequest::get().uri(uri).to_request();
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = test::read_body(response).await;
+        assert!(!String::from_utf8_lossy(&body).contains("injected outage"));
+        let request = test::TestRequest::get()
+            .uri(uri)
+            .insert_header(("x-roles", "admin"))
+            .to_request();
+        assert_eq!(
+            test::call_service(&app, request).await.status(),
+            StatusCode::OK
+        );
+    }
+}

--- a/tests/axum_example.rs
+++ b/tests/axum_example.rs
@@ -177,3 +177,49 @@ async fn edit_invoice_denies_stale_invoice() {
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+struct UnavailableRelationships;
+
+#[async_trait::async_trait]
+impl<K: gatehouse::FactKey<Value = bool>> gatehouse::FactSource<K> for UnavailableRelationships {
+    async fn load_many(&self, keys: &[K]) -> Vec<gatehouse::FactLoadResult<bool>> {
+        keys.iter()
+            .map(|_| {
+                gatehouse::FactLoadResult::Error(gatehouse::FactLoadError::backend_message(
+                    "injected outage",
+                ))
+            })
+            .collect()
+    }
+}
+
+#[tokio::test]
+async fn authorization_outage_returns_503_for_single_and_list_but_admin_still_grants() {
+    let state = axum_example::AppState::demo().with_relationship_source(UnavailableRelationships);
+    let app = Router::new()
+        .route("/invoices", get(axum_example::list_invoices_handler))
+        .route(
+            "/invoices/{invoice_id}",
+            get(axum_example::view_invoice_handler),
+        )
+        .with_state(state);
+    for uri in [
+        "/invoices",
+        "/invoices/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    ] {
+        let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert!(!String::from_utf8_lossy(&body).contains("injected outage"));
+        let request = Request::builder()
+            .uri(uri)
+            .header("x-roles", "admin")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+}

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use gatehouse::{
-    AccessEvaluation, AndPolicy, BatchEvalCtx, Decision, DelegatingPolicy, Effect, EvalCtx,
-    EvaluationSession, FactLoadResult, FactOutcome, FactProvenance, FactSource, Hydrator,
-    LookupAuthorizedError, LookupPage, LookupSource, NotPolicy, OrPolicy, PermissionChecker,
-    Policy, PolicyBatchItem, PolicyBuilder, PolicyDomain, PolicyEvalResult, RebacPolicy,
-    RelationshipQuery,
+    AccessEvaluation, AndPolicy, BatchEvalCtx, Decision, DelegatingPolicy, EvalCtx,
+    EvaluationSession, FactLoadResult, FactOutcome, FactProvenance, FactSource, GrantResult,
+    Hydrator, LookupAuthorizedError, LookupPage, LookupSource, OrPolicy, PermissionChecker, Policy,
+    PolicyBatchItem, PolicyBuilder, PolicyDomain, PolicyExt, RebacPolicy, RelationshipQuery,
+    VetoPolicy, VetoPolicyExt, VetoResult,
 };
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -72,18 +72,6 @@ where
     bind(checker, session).evaluate(resources).await
 }
 
-async fn filter_resources<I>(
-    checker: &PermissionChecker<Domain>,
-    session: &EvaluationSession,
-    resources: I,
-) -> Vec<I::Item>
-where
-    I: IntoIterator,
-    I::Item: std::borrow::Borrow<Resource>,
-{
-    bind(checker, session).filter(resources).await
-}
-
 struct BatchGrantPolicy {
     name: &'static str,
     batch_calls: Arc<AtomicUsize>,
@@ -94,15 +82,12 @@ struct BatchGrantPolicy {
 
 #[async_trait]
 impl Policy<Domain> for BatchGrantPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         self.single_calls.fetch_add(1, Ordering::SeqCst);
         self.result_for(ctx.resource.id)
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
         self.batch_calls.fetch_add(1, Ordering::SeqCst);
         self.seen_batches.lock().unwrap().push(
             ctx.items
@@ -122,319 +107,13 @@ impl Policy<Domain> for BatchGrantPolicy {
 }
 
 impl BatchGrantPolicy {
-    fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
+    fn result_for(&self, resource_id: u8) -> GrantResult {
         if (self.grant)(resource_id) {
-            PolicyEvalResult::granted(self.name, Some(format!("{resource_id} granted")))
+            GrantResult::granted(self.name, Some(format!("{resource_id} granted")))
         } else {
-            PolicyEvalResult::not_applicable(self.name, format!("{resource_id} denied"))
+            GrantResult::not_applicable(self.name, format!("{resource_id} denied"))
         }
     }
-}
-
-struct RandomStackPolicy {
-    name: String,
-    spec: RandomPolicySpec,
-}
-
-#[async_trait]
-impl Policy<Domain> for RandomStackPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        self.result_for(ctx.resource.id)
-    }
-
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
-        ctx.items
-            .iter()
-            .map(|item| self.result_for(item.resource.id))
-            .collect()
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Owned(self.name.clone())
-    }
-
-    fn effect(&self) -> Effect {
-        self.spec.effect
-    }
-}
-
-impl RandomStackPolicy {
-    fn result_for(&self, resource_id: u8) -> PolicyEvalResult {
-        match self.spec.leaf_outcome(resource_id) {
-            LeafOutcome::Grant => {
-                PolicyEvalResult::granted(self.name.clone(), Some(format!("{resource_id} granted")))
-            }
-            LeafOutcome::Forbid => {
-                PolicyEvalResult::forbidden(self.name.clone(), format!("{resource_id} forbidden"))
-            }
-            LeafOutcome::Indeterminate => PolicyEvalResult::indeterminate(
-                self.name.clone(),
-                format!("{resource_id} indeterminate"),
-            ),
-            LeafOutcome::NotApplicable => {
-                PolicyEvalResult::not_applicable(self.name.clone(), format!("{resource_id} denied"))
-            }
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct RandomPolicySpec {
-    grant_percent: u8,
-    forbid_percent: u8,
-    indeterminate_percent: u8,
-    salt: u16,
-    effect: Effect,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum LeafOutcome {
-    Grant,
-    Forbid,
-    Indeterminate,
-    NotApplicable,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ExpectedDecision {
-    Granted,
-    Forbidden,
-    Indeterminate,
-    Denied,
-}
-
-impl RandomPolicySpec {
-    fn leaf_outcome(self, resource_id: u8) -> LeafOutcome {
-        let grant_score = ((resource_id as u16 * 37) ^ self.salt).wrapping_add(self.salt / 3) % 100;
-        let forbid_score =
-            ((resource_id as u16 * 53) ^ self.salt).wrapping_add(self.salt / 5) % 100;
-        let indeterminate_score =
-            ((resource_id as u16 * 71) ^ self.salt).wrapping_add(self.salt / 7) % 100;
-        let grant_matched = grant_score < self.grant_percent as u16;
-        let forbid_matched = forbid_score < self.forbid_percent as u16;
-        let indeterminate_matched = indeterminate_score < self.indeterminate_percent as u16;
-
-        if self.effect.can_forbid() && forbid_matched {
-            LeafOutcome::Forbid
-        } else if indeterminate_matched {
-            // Any policy can fail to load an input, regardless of effect.
-            LeafOutcome::Indeterminate
-        } else if self.effect.can_grant() && grant_matched {
-            LeafOutcome::Grant
-        } else {
-            LeafOutcome::NotApplicable
-        }
-    }
-
-    fn into_policy(self, index: usize) -> RandomStackPolicy {
-        RandomStackPolicy {
-            name: format!("random_{index}"),
-            spec: self,
-        }
-    }
-}
-
-/// Deny-overrides oracle with four-valued leaves:
-///
-/// 1. Any observed `Forbid` denies — a definite veto beats everything,
-///    including indeterminate results.
-/// 2. Otherwise an `Indeterminate` from a veto-capable policy makes the
-///    evaluation indeterminate: its unresolved potential veto blocks every
-///    grant.
-/// 3. Otherwise the first grant wins. An `Indeterminate` from an allow-only
-///    policy never blocks a sibling grant (it could only have granted).
-/// 4. Otherwise, if anything was indeterminate the evaluation is
-///    indeterminate (the failed policy might have granted); else denied.
-fn oracle_decision(specs: &[RandomPolicySpec], resource_id: u8) -> ExpectedDecision {
-    let mut saw_grant = false;
-    let mut saw_veto_indeterminate = false;
-    let mut saw_indeterminate = false;
-    for spec in specs {
-        match spec.leaf_outcome(resource_id) {
-            LeafOutcome::Forbid => return ExpectedDecision::Forbidden,
-            LeafOutcome::Grant => saw_grant = true,
-            LeafOutcome::Indeterminate => {
-                saw_indeterminate = true;
-                if spec.effect.can_forbid() {
-                    saw_veto_indeterminate = true;
-                }
-            }
-            LeafOutcome::NotApplicable => {}
-        }
-    }
-
-    if saw_veto_indeterminate {
-        ExpectedDecision::Indeterminate
-    } else if saw_grant {
-        ExpectedDecision::Granted
-    } else if saw_indeterminate {
-        ExpectedDecision::Indeterminate
-    } else {
-        ExpectedDecision::Denied
-    }
-}
-
-fn access_decision(evaluation: &AccessEvaluation) -> ExpectedDecision {
-    if evaluation.is_granted() {
-        ExpectedDecision::Granted
-    } else if evaluation.forbidden_by().is_some() {
-        ExpectedDecision::Forbidden
-    } else if evaluation.is_indeterminate() {
-        ExpectedDecision::Indeterminate
-    } else {
-        ExpectedDecision::Denied
-    }
-}
-
-fn policy_decision(result: &PolicyEvalResult) -> ExpectedDecision {
-    if result.is_forbidden() {
-        ExpectedDecision::Forbidden
-    } else if result.is_granted() {
-        ExpectedDecision::Granted
-    } else if result.decision() == Decision::Indeterminate {
-        ExpectedDecision::Indeterminate
-    } else {
-        ExpectedDecision::Denied
-    }
-}
-
-fn checker_from_specs(
-    specs: &[RandomPolicySpec],
-    max_batch_size: Option<usize>,
-) -> PermissionChecker<Domain> {
-    let mut checker = if let Some(max_batch_size) = max_batch_size {
-        PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(max_batch_size).unwrap())
-    } else {
-        PermissionChecker::new()
-    };
-    for (index, spec) in specs.iter().copied().enumerate() {
-        checker.add_policy(spec.into_policy(index));
-    }
-    checker
-}
-
-fn arc_policies_from_specs(specs: &[RandomPolicySpec]) -> Vec<Arc<dyn Policy<Domain>>> {
-    specs
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(index, spec)| Arc::new(spec.into_policy(index)) as Arc<dyn Policy<Domain>>)
-        .collect()
-}
-
-fn policy_spec_strategy() -> impl Strategy<Value = RandomPolicySpec> {
-    prop_oneof![
-        2 => (0u8..=100, 0u8..=100, any::<u16>()).prop_map(
-            |(grant_percent, indeterminate_percent, salt)| RandomPolicySpec {
-                grant_percent,
-                forbid_percent: 0,
-                indeterminate_percent,
-                salt,
-                effect: Effect::Allow,
-            }
-        ),
-        3 => (0u8..=100, 0u8..=100, any::<u16>()).prop_map(
-            |(forbid_percent, indeterminate_percent, salt)| RandomPolicySpec {
-                grant_percent: 0,
-                forbid_percent,
-                indeterminate_percent,
-                salt,
-                effect: Effect::Forbid,
-            }
-        ),
-        5 => (0u8..=100, 0u8..=100, 0u8..=100, any::<u16>()).prop_map(
-            |(grant_percent, forbid_percent, indeterminate_percent, salt)| RandomPolicySpec {
-                grant_percent,
-                forbid_percent,
-                indeterminate_percent,
-                salt,
-                effect: Effect::AllowOrForbid,
-            }
-        ),
-    ]
-}
-
-fn adversarial_policy_stack_strategy() -> impl Strategy<Value = Vec<RandomPolicySpec>> {
-    let exact_deferred_grant = prop::collection::vec(
-        prop_oneof![
-            Just(RandomPolicySpec {
-                grant_percent: 0,
-                forbid_percent: 0,
-                indeterminate_percent: 0,
-                salt: 0,
-                effect: Effect::Allow,
-            }),
-            Just(RandomPolicySpec {
-                grant_percent: 0,
-                forbid_percent: 0,
-                indeterminate_percent: 0,
-                salt: 0,
-                effect: Effect::AllowOrForbid,
-            }),
-        ],
-        0..=3,
-    )
-    .prop_map(|mut tail| {
-        let mut specs = vec![
-            RandomPolicySpec {
-                grant_percent: 100,
-                forbid_percent: 0,
-                indeterminate_percent: 0,
-                salt: 0,
-                effect: Effect::AllowOrForbid,
-            },
-            RandomPolicySpec {
-                grant_percent: 0,
-                forbid_percent: 0,
-                indeterminate_percent: 0,
-                salt: 0,
-                effect: Effect::AllowOrForbid,
-            },
-        ];
-        specs.append(&mut tail);
-        specs
-    });
-
-    // A veto-capable policy that is always indeterminate, ahead of an
-    // allow-only policy that always grants: the unresolved potential veto
-    // must block the grant on every path. Distinguishes mutants that skip
-    // the veto-prefix indeterminate check or misplace the prefix boundary.
-    let veto_indeterminate_blocks_grant = Just(vec![
-        RandomPolicySpec {
-            grant_percent: 0,
-            forbid_percent: 0,
-            indeterminate_percent: 100,
-            salt: 0,
-            effect: Effect::AllowOrForbid,
-        },
-        RandomPolicySpec {
-            grant_percent: 100,
-            forbid_percent: 0,
-            indeterminate_percent: 0,
-            salt: 0,
-            effect: Effect::Allow,
-        },
-    ]);
-
-    let veto_heavy = prop::collection::vec(policy_spec_strategy(), 2..=5).prop_filter(
-        "at least two veto-capable policies, one mixed-capability policy",
-        |specs| {
-            specs.iter().filter(|spec| spec.effect.can_forbid()).count() >= 2
-                && specs
-                    .iter()
-                    .any(|spec| spec.effect == Effect::AllowOrForbid)
-        },
-    );
-
-    prop_oneof![
-        4 => exact_deferred_grant,
-        2 => veto_indeterminate_blocks_grant,
-        7 => veto_heavy,
-        2 => prop::collection::vec(policy_spec_strategy(), 1..=5),
-    ]
 }
 
 struct NeverConsultedPolicy {
@@ -443,15 +122,12 @@ struct NeverConsultedPolicy {
 
 #[async_trait]
 impl Policy<Domain> for NeverConsultedPolicy {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        PolicyEvalResult::not_applicable(self.policy_type().to_string(), "single called")
+        GrantResult::not_applicable(self.policy_type().to_string(), "single called")
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        _ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, _ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         Vec::new()
     }
@@ -567,7 +243,7 @@ async fn delegating_policy_preserves_child_batch_evaluation() {
     );
 
     let mut checker = PermissionChecker::new();
-    checker.add_policy(delegating_policy);
+    checker.add_delegate(delegating_policy);
 
     let session = EvaluationSession::empty();
     let results = evaluate_resources(
@@ -738,166 +414,6 @@ async fn batch_decisions_match_naive_loop_for_empty_and_mixed_items() {
     assert_granted(&batch[0].1, true);
     assert_granted(&batch[1].1, false);
 }
-
-proptest! {
-    #![proptest_config(ProptestConfig {
-        cases: 1_000,
-        ..ProptestConfig::default()
-    })]
-
-    #[test]
-    fn checker_paths_match_deny_overrides_oracle(
-        policy_specs in adversarial_policy_stack_strategy(),
-        resource_ids in prop::collection::vec(0u8..64, 0..50),
-        max_batch_size in prop::option::of(1usize..8),
-    ) {
-        let items = resource_ids
-            .iter()
-            .copied()
-            .map(|id| Resource { id })
-            .collect::<Vec<_>>();
-        let expected = resource_ids
-            .iter()
-            .map(|id| oracle_decision(&policy_specs, *id))
-            .collect::<Vec<_>>();
-
-        let unchunked = checker_from_specs(&policy_specs, None);
-        let unchunked_session = EvaluationSession::empty();
-        let unchunked_batch = tokio_test::block_on(evaluate_resources(
-            &unchunked,
-            &unchunked_session,
-            items.clone(),
-        ))
-        .into_iter()
-        .map(|(_item, evaluation)| access_decision(&evaluation))
-        .collect::<Vec<_>>();
-        prop_assert_eq!(&unchunked_batch, &expected);
-
-        let chunk_one = checker_from_specs(&policy_specs, Some(1));
-        let chunk_one_session = EvaluationSession::empty();
-        let chunk_one_batch = tokio_test::block_on(evaluate_resources(
-            &chunk_one,
-            &chunk_one_session,
-            items.clone(),
-        ))
-        .into_iter()
-        .map(|(_item, evaluation)| access_decision(&evaluation))
-        .collect::<Vec<_>>();
-        prop_assert_eq!(&chunk_one_batch, &expected);
-
-        if let Some(max_batch_size) = max_batch_size {
-            let chunked = checker_from_specs(&policy_specs, Some(max_batch_size));
-            let chunked_session = EvaluationSession::empty();
-            let chunked_batch = tokio_test::block_on(evaluate_resources(
-                &chunked,
-                &chunked_session,
-                items.clone(),
-            ))
-            .into_iter()
-            .map(|(_item, evaluation)| access_decision(&evaluation))
-            .collect::<Vec<_>>();
-            prop_assert_eq!(&chunked_batch, &expected);
-        }
-
-        let mut repeated_single = Vec::new();
-        for resource in &items {
-            let session = EvaluationSession::empty();
-            let evaluation = tokio_test::block_on(check_resource(&unchunked, &session, resource));
-            repeated_single.push(access_decision(&evaluation));
-        }
-        prop_assert_eq!(repeated_single, expected);
-    }
-
-    #[test]
-    fn singleton_filter_matches_single_resource_check_for_random_policy_stacks(
-        policy_specs in adversarial_policy_stack_strategy(),
-        resource_id in 0u8..64,
-        max_batch_size in prop::option::of(1usize..8),
-    ) {
-        let checker = checker_from_specs(&policy_specs, max_batch_size);
-
-        let resource = Resource { id: resource_id };
-        let single_session = EvaluationSession::empty();
-        let single = tokio_test::block_on(check_resource(&checker, &single_session, &resource));
-        let expected = oracle_decision(&policy_specs, resource_id);
-        prop_assert_eq!(access_decision(&single), expected);
-
-        let filter_session = EvaluationSession::empty();
-        let filtered = tokio_test::block_on(filter_resources(&checker, &filter_session, vec![resource]));
-
-        prop_assert_eq!(single.is_granted(), expected == ExpectedDecision::Granted);
-        prop_assert_eq!(!filtered.is_empty(), expected == ExpectedDecision::Granted);
-    }
-
-    #[test]
-    fn checker_decision_is_registration_order_invariant(
-        policy_specs in adversarial_policy_stack_strategy(),
-        resource_id in 0u8..64,
-        rotation in 0usize..8,
-        reverse in any::<bool>(),
-    ) {
-        let mut permuted = policy_specs.clone();
-        let len = permuted.len();
-        permuted.rotate_left(rotation % len);
-        if reverse {
-            permuted.reverse();
-        }
-
-        let checker = checker_from_specs(&policy_specs, None);
-        let permuted_checker = checker_from_specs(&permuted, None);
-        let resource = Resource { id: resource_id };
-
-        let session = EvaluationSession::empty();
-        let decision = tokio_test::block_on(check_resource(&checker, &session, &resource));
-        let permuted_session = EvaluationSession::empty();
-        let permuted_decision =
-            tokio_test::block_on(check_resource(&permuted_checker, &permuted_session, &resource));
-
-        let expected = oracle_decision(&policy_specs, resource_id);
-        prop_assert_eq!(oracle_decision(&permuted, resource_id), expected);
-        prop_assert_eq!(access_decision(&decision), expected);
-        prop_assert_eq!(access_decision(&permuted_decision), expected);
-    }
-
-    #[test]
-    fn combinator_single_and_batch_paths_agree(
-        policy_specs in adversarial_policy_stack_strategy(),
-        resource_id in 0u8..64,
-        combinator in 0u8..3,
-    ) {
-        let policy: Box<dyn Policy<Domain>> = match combinator {
-            0 => Box::new(AndPolicy::try_new(arc_policies_from_specs(&policy_specs)).unwrap()),
-            1 => Box::new(OrPolicy::try_new(arc_policies_from_specs(&policy_specs)).unwrap()),
-            _ => Box::new(NotPolicy::new(policy_specs[0].into_policy(0))),
-        };
-
-        let session = EvaluationSession::empty();
-        let resource = Resource { id: resource_id };
-        let single = tokio_test::block_on(policy.evaluate(&EvalCtx::new(
-            &session,
-            &Subject,
-            &Action,
-            &resource,
-            &Ctx,
-            policy.policy_type(),
-        )));
-
-        let items = [PolicyBatchItem { resource: &resource }];
-        let batch = tokio_test::block_on(policy.evaluate_batch(&BatchEvalCtx::new(
-            &session,
-            &Subject,
-            &Action,
-            &Ctx,
-            &items,
-            policy.policy_type(),
-        )));
-
-        prop_assert_eq!(batch.len(), 1);
-        prop_assert_eq!(policy_decision(&single), policy_decision(&batch[0]));
-    }
-}
-
-#[derive(Clone)]
 struct MixedSubject {
     id: u8,
 }
@@ -1011,32 +527,16 @@ fn allow_everything(name: &str) -> Box<dyn Policy<Domain>> {
     PolicyBuilder::<Domain>::new(name.to_string()).build()
 }
 
-fn forbid_odd_resources(name: &str) -> Box<dyn Policy<Domain>> {
+fn forbid_odd_resources(name: &str) -> Box<dyn VetoPolicy<Domain>> {
     PolicyBuilder::<Domain>::new(name.to_string())
         .resources(|resource: &Resource| resource.id % 2 == 1)
-        .forbid()
-        .build()
+        .build_veto()
 }
 
 fn grant_even_resources(name: &str) -> impl Policy<Domain> {
     PolicyBuilder::<Domain>::new(name.to_string())
         .resources(|resource: &Resource| resource.id % 2 == 0)
         .build()
-}
-
-struct NamedNoopPolicy {
-    name: &'static str,
-}
-
-#[async_trait]
-impl Policy<Domain> for NamedNoopPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.not_applicable("not applicable")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(self.name)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1111,38 +611,6 @@ async fn checker_clone_preserves_name_batching_and_policies() {
 }
 
 #[tokio::test]
-async fn add_forbid_policy_declares_and_stably_orders_veto_capable_policies() {
-    let session = EvaluationSession::empty();
-
-    let mut veto_checker = PermissionChecker::new();
-    veto_checker.add_policy(allow_everything("AllowAll"));
-    veto_checker.add_forbid_policy(UndeclaredForbidPolicy);
-
-    let blocked = check_resource(&veto_checker, &session, &Resource { id: 0 }).await;
-    blocked.assert_forbidden_by("UndeclaredForbidPolicy");
-
-    let mut order_checker = PermissionChecker::new();
-    order_checker.add_forbid_policy(NamedNoopPolicy {
-        name: "FirstVetoSlot",
-    });
-    order_checker.add_forbid_policy(NamedNoopPolicy {
-        name: "SecondVetoSlot",
-    });
-    order_checker.add_policy(allow_everything("AllowAll"));
-
-    let granted = check_resource(&order_checker, &session, &Resource { id: 0 }).await;
-    granted.assert_granted_by("AllowAll");
-    let trace = granted.trace().format();
-    let first = trace.find("FirstVetoSlot").unwrap();
-    let second = trace.find("SecondVetoSlot").unwrap();
-    let allow = trace.find("AllowAll").unwrap();
-    assert!(
-        first < second && second < allow,
-        "veto-capable insertion should preserve registration order before allow-only policies:\n{trace}"
-    );
-}
-
-#[tokio::test]
 async fn projected_row_helpers_evaluate_and_filter_original_items() {
     let mut checker = PermissionChecker::new();
     checker.add_policy(grant_even_resources("EvenResource"));
@@ -1212,258 +680,10 @@ async fn lookup_page_accepts_exhausted_initial_page_and_rejects_stuck_cursor() {
     assert!(matches!(err, LookupAuthorizedError::LookupCursorStuck));
 }
 
-struct MixedGrantPolicy;
-
-#[async_trait]
-impl Policy<Domain> for MixedGrantPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.grant("granted")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("MixedGrantPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::AllowOrForbid
-    }
-}
-
-struct MixedNotApplicablePolicy;
-
-#[async_trait]
-impl Policy<Domain> for MixedNotApplicablePolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.not_applicable("n/a")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("MixedNotApplicablePolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::AllowOrForbid
-    }
-}
-
-#[tokio::test]
-async fn single_check_flushes_grant_after_veto_capable_prefix() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(MixedGrantPolicy);
-    checker.add_policy(MixedNotApplicablePolicy);
-
-    let session = EvaluationSession::empty();
-    let resource = Resource { id: 0 };
-
-    let single = check_resource(&checker, &session, &resource).await;
-    single.assert_granted_by("MixedGrantPolicy");
-
-    let filtered = filter_resources(&checker, &session, vec![resource]).await;
-    assert_eq!(filtered.len(), 1);
-}
-
-#[tokio::test]
-async fn batch_forbid_overrides_grants_regardless_of_registration_order() {
-    // The forbid policy is registered *after* the allow policy; forbid-first
-    // scheduling must still veto before the allow phase grants.
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(allow_everything("AllowAll"));
-    checker.add_policy(forbid_odd_resources("OddBlock"));
-
-    let session = EvaluationSession::empty();
-    let items = (0..4).map(|id| Resource { id }).collect::<Vec<_>>();
-    let results = evaluate_resources(&checker, &session, items).await;
-
-    let decisions = results
-        .iter()
-        .map(|(resource, evaluation)| {
-            (
-                resource.id,
-                evaluation.is_granted(),
-                evaluation.forbidden_by().map(str::to_owned),
-            )
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(
-        decisions,
-        vec![
-            (0, true, None),
-            (1, false, Some("OddBlock".to_string())),
-            (2, true, None),
-            (3, false, Some("OddBlock".to_string())),
-        ]
-    );
-
-    // The filter convenience (and therefore the lookup pipeline built on
-    // it) honors the forbid identically.
-    let visible = filter_resources(
-        &checker,
-        &session,
-        (0..4).map(|id| Resource { id }).collect::<Vec<_>>(),
-    )
-    .await;
-    assert_eq!(
-        visible
-            .iter()
-            .map(|resource| resource.id)
-            .collect::<Vec<_>>(),
-        vec![0, 2]
-    );
-}
-
-#[tokio::test]
-async fn single_and_batch_forbid_decisions_agree() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(allow_everything("AllowAll"));
-    checker.add_policy(forbid_odd_resources("OddBlock"));
-
-    let session = EvaluationSession::empty();
-    for id in 0..4 {
-        let single = check_resource(&checker, &session, &Resource { id }).await;
-        let batch = evaluate_resources(&checker, &session, vec![Resource { id }])
-            .await
-            .remove(0)
-            .1;
-        assert_eq!(single.is_granted(), batch.is_granted(), "id {id}");
-        assert_eq!(single.forbidden_by(), batch.forbidden_by(), "id {id}");
-    }
-}
-
-/// Forbids propagate through combinators so a fluent wrapper cannot silently
-/// drop a veto.
-#[tokio::test]
-async fn forbid_inside_combinators_vetoes_access() {
-    let session = EvaluationSession::empty();
-    let blocked = Resource { id: 1 };
-
-    // OR: the nested forbid overrides the allow arm.
-    let or_gate = OrPolicy::try_new(vec![
-        Arc::from(allow_everything("AllowAll")),
-        Arc::from(forbid_odd_resources("OddBlock")),
-    ])
-    .unwrap();
-    let mut or_checker = PermissionChecker::new();
-    or_checker.add_policy(or_gate);
-    let or_result = check_resource(&or_checker, &session, &blocked).await;
-    or_result.assert_forbidden_by("OddBlock");
-
-    // AND: the conjunction fails because the child actively vetoes.
-    let and_gate = AndPolicy::try_new(vec![
-        Arc::from(allow_everything("AllowAll")),
-        Arc::from(forbid_odd_resources("OddBlock")),
-    ])
-    .unwrap();
-    let mut and_checker = PermissionChecker::new();
-    and_checker.add_policy(and_gate);
-    let and_result = check_resource(&and_checker, &session, &blocked).await;
-    and_result.assert_forbidden_by("OddBlock");
-
-    // NOT still grants for a non-matching forbid child, but an active forbid
-    // is not inverted into a grant.
-    let mut not_checker = PermissionChecker::new();
-    not_checker.add_policy(NotPolicy::new(forbid_odd_resources("OddBlock")));
-    let not_result = check_resource(&not_checker, &session, &Resource { id: 0 }).await;
-    assert!(
-        not_result.is_granted(),
-        "NOT(non-matching deny) is granted, as for any non-granting child"
-    );
-    let not_blocked = check_resource(&not_checker, &session, &blocked).await;
-    not_blocked.assert_forbidden_by("OddBlock");
-}
-
-#[tokio::test]
-async fn combinator_effects_preserve_nested_forbid_capability_for_checker_scheduling() {
-    let allow_only_or = OrPolicy::try_new(vec![
-        Arc::from(allow_everything("AllowA")),
-        Arc::from(allow_everything("AllowB")),
-    ])
-    .unwrap();
-    assert_eq!(allow_only_or.effect(), Effect::Allow);
-
-    let allow_or_forbid = OrPolicy::try_new(vec![
-        Arc::from(allow_everything("NestedAllow")),
-        Arc::from(forbid_odd_resources("NestedBlock")),
-    ])
-    .unwrap();
-    assert_eq!(allow_or_forbid.effect(), Effect::AllowOrForbid);
-
-    let forbid_only_and = AndPolicy::try_new(vec![
-        Arc::from(allow_everything("RequiredAllow")),
-        Arc::from(forbid_odd_resources("RequiredBlock")),
-    ])
-    .unwrap();
-    assert_eq!(forbid_only_and.effect(), Effect::Forbid);
-
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(allow_everything("ParentAllow"));
-    checker.add_policy(allow_or_forbid);
-
-    let session = EvaluationSession::empty();
-    let blocked = check_resource(&checker, &session, &Resource { id: 1 }).await;
-    blocked.assert_forbidden_by("NestedBlock");
-}
-
-#[tokio::test]
-async fn and_policy_requires_each_child_to_grant_across_veto_boundary() {
-    let session = EvaluationSession::empty();
-
-    let grant_then_required_non_grant = AndPolicy::try_new(vec![
-        Arc::new(MixedGrantPolicy) as Arc<dyn Policy<Domain>>,
-        Arc::new(NamedNoopPolicy {
-            name: "RequiredAllow",
-        }) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(grant_then_required_non_grant);
-    let denied = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    assert!(!denied.is_granted());
-    assert!(denied.trace().format().contains("RequiredAllow"));
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-    assert!(!batch[0].1.is_granted());
-
-    let forbid_only_non_match_then_grant = AndPolicy::try_new(vec![
-        Arc::from(forbid_odd_resources("OddBlock")),
-        Arc::from(allow_everything("AllowAll")),
-    ])
-    .unwrap();
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(forbid_only_non_match_then_grant);
-    let denied = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    assert!(
-        !denied.is_granted(),
-        "a forbid-only child that does not match still does not satisfy AND"
-    );
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-    assert!(!batch[0].1.is_granted());
-}
-
-#[tokio::test]
-async fn or_policy_grants_from_first_allow_only_child_after_veto_boundary() {
-    let session = EvaluationSession::empty();
-    let or_gate = OrPolicy::try_new(vec![
-        Arc::new(MixedNotApplicablePolicy) as Arc<dyn Policy<Domain>>,
-        Arc::from(allow_everything("AllowAll")),
-    ])
-    .unwrap();
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(or_gate);
-
-    let granted = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    granted.assert_granted_by("OrPolicy");
-    assert!(granted.trace().format().contains("AllowAll"));
-
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-    assert!(batch[0].1.is_granted());
-    assert!(batch[0].1.trace().format().contains("AllowAll"));
-}
-
-/// Identity-mapped delegating policy whose child checker grants everything
-/// except odd resource ids, which it forbids.
 fn delegating_forbid_policy() -> DelegatingPolicy<Domain, Domain> {
     let mut child: PermissionChecker<Domain> = PermissionChecker::new();
     child.add_policy(allow_everything("ChildAllow"));
-    child.add_policy(forbid_odd_resources("ChildBlock"));
+    child.add_veto(forbid_odd_resources("ChildBlock"));
     DelegatingPolicy::new(
         "DelegatedDecision",
         child,
@@ -1485,11 +705,11 @@ async fn delegated_child_forbid_propagates_to_parent_checker() {
     for delegate_registered_first in [true, false] {
         let mut parent = PermissionChecker::new();
         if delegate_registered_first {
-            parent.add_policy(delegating_forbid_policy());
+            parent.add_delegate(delegating_forbid_policy());
             parent.add_policy(allow_everything("ParentAllow"));
         } else {
             parent.add_policy(allow_everything("ParentAllow"));
-            parent.add_policy(delegating_forbid_policy());
+            parent.add_delegate(delegating_forbid_policy());
         }
 
         let result = check_resource(&parent, &session, &Resource { id: 1 }).await;
@@ -1500,205 +720,18 @@ async fn delegated_child_forbid_propagates_to_parent_checker() {
     // Without the parent grant, the delegated veto is still reported as the
     // cause of denial.
     let mut parent_without_allow = PermissionChecker::new();
-    parent_without_allow.add_policy(delegating_forbid_policy());
+    parent_without_allow.add_delegate(delegating_forbid_policy());
     let denied = check_resource(&parent_without_allow, &session, &Resource { id: 1 }).await;
     denied.assert_forbidden_by("ChildBlock");
 }
 
 /// A hand-written policy that declares `Effect::Forbid` and forbids via
 /// `ctx.forbid` is honored on both evaluation paths.
-struct SuspendedSubjectPolicy;
-
-#[async_trait]
-impl Policy<Domain> for SuspendedSubjectPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        if ctx.resource.id == 1 {
-            ctx.forbid("resource 1 is frozen")
-        } else {
-            ctx.not_applicable("not applicable")
-        }
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("SuspendedSubjectPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
-}
-
-#[tokio::test]
-async fn custom_policy_forbid_via_ctx_forbid_is_honored() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(allow_everything("AllowAll"));
-    checker.add_policy(SuspendedSubjectPolicy);
-
-    let session = EvaluationSession::empty();
-    let blocked = check_resource(&checker, &session, &Resource { id: 1 }).await;
-    blocked.assert_forbidden_by("SuspendedSubjectPolicy");
-
-    let granted = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    granted.assert_granted_by("AllowAll");
-
-    // Default evaluate_batch forwards to evaluate, so the batch path
-    // observes the same forbids.
-    let results = evaluate_resources(
-        &checker,
-        &session,
-        vec![Resource { id: 0 }, Resource { id: 1 }],
-    )
-    .await;
-    assert!(results[0].1.is_granted());
-    assert_eq!(results[1].1.forbidden_by(), Some("SuspendedSubjectPolicy"));
-}
-
-/// Contract violation: a policy declaring `Effect::Forbid` must not grant.
-/// The checker fails closed, treating the grant as not applicable.
-struct MisbehavingForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for MisbehavingForbidPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.grant("grant from a forbid-effect policy")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("MisbehavingForbidPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
-}
-
-#[tokio::test]
-async fn grant_from_forbid_declared_policy_is_treated_as_not_applicable() {
-    // Alone in a checker, the misbehaving grant must not grant access.
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(MisbehavingForbidPolicy);
-    let session = EvaluationSession::empty();
-    let alone = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    assert!(!alone.is_granted());
-    assert_eq!(alone.forbidden_by(), None);
-
-    // Alongside a real allow policy, the sibling grant still decides.
-    checker.add_policy(allow_everything("AllowAll"));
-    let with_allow = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    with_allow.assert_granted_by("AllowAll");
-
-    // Same fail-closed handling on the batch path.
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-    assert!(batch[0].1.is_granted());
-}
-
-/// An *undeclared* forbid (default `Effect::Allow`) is honored when the
-/// checker observes it, but a sibling grant evaluated earlier can
-/// short-circuit before it is reached — declaring `Effect::Forbid` is what
-/// makes a veto order-independent.
-struct UndeclaredForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for UndeclaredForbidPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.forbid("forbid without declaring Effect::Forbid")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("UndeclaredForbidPolicy")
-    }
-}
-
-#[tokio::test]
-async fn undeclared_forbid_is_honored_when_observed_but_not_scheduled_first() {
-    let session = EvaluationSession::empty();
-
-    // Observed before any grant: honored.
-    let mut forbid_first = PermissionChecker::new();
-    forbid_first.add_policy(UndeclaredForbidPolicy);
-    forbid_first.add_policy(allow_everything("AllowAll"));
-    let blocked = check_resource(&forbid_first, &session, &Resource { id: 0 }).await;
-    blocked.assert_forbidden_by("UndeclaredForbidPolicy");
-
-    // Grant short-circuits first: the undeclared forbid is never reached.
-    // This pins the documented contract that forbidding policies must
-    // declare Effect::Forbid to veto deterministically.
-    let mut grant_first = PermissionChecker::new();
-    grant_first.add_policy(allow_everything("AllowAll"));
-    grant_first.add_policy(UndeclaredForbidPolicy);
-    let granted = check_resource(&grant_first, &session, &Resource { id: 0 }).await;
-    granted.assert_granted_by("AllowAll");
-}
-
-/// A forbid-effect policy whose batch override returns the wrong number of
-/// results fails closed: affected items are denied, not granted by the
-/// allow phase.
-struct WrongLengthForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for WrongLengthForbidPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.not_applicable("not applicable")
-    }
-
-    async fn evaluate_batch<'item>(
-        &self,
-        _ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
-        Vec::new()
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("WrongLengthForbidPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
-}
-
-#[tokio::test]
-async fn wrong_length_batch_from_forbid_policy_fails_closed() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(allow_everything("AllowAll"));
-    checker.add_policy(WrongLengthForbidPolicy);
-
-    let session = EvaluationSession::empty();
-    let results = evaluate_resources(
-        &checker,
-        &session,
-        vec![Resource { id: 0 }, Resource { id: 1 }],
-    )
-    .await;
-
-    for (_item, evaluation) in &results {
-        assert!(
-            !evaluation.is_granted(),
-            "items touched by a broken forbid policy must fail closed"
-        );
-        assert!(
-            evaluation.is_indeterminate(),
-            "a broken batch contract means the items could not be evaluated"
-        );
-    }
-}
-
-// ---- indeterminate semantics ---------------------------------------
-
-/// A policy that always reports it could not be evaluated (e.g. its fact
-/// backend is down), with a configurable declared effect.
-struct IndeterminatePolicy {
-    name: &'static str,
-    effect: Effect,
-}
-
-/// Models the explicit-provenance escape hatch: the leaf remains
-/// `NotApplicable`, but its provenance says a required fact load failed.
 struct ErrorBearingNotApplicablePolicy;
 
 #[async_trait]
 impl Policy<Domain> for ErrorBearingNotApplicablePolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         ctx.not_applicable_with_facts(
             "fact was unavailable",
             vec![FactProvenance::new(
@@ -1721,7 +754,7 @@ impl Policy<Domain> for ErrorBearingNotApplicablePolicy {
 #[tokio::test]
 async fn not_policy_fail_closes_error_bearing_not_applicable() {
     let mut checker = PermissionChecker::new();
-    checker.add_policy(NotPolicy::new(ErrorBearingNotApplicablePolicy));
+    checker.add_policy(ErrorBearingNotApplicablePolicy.not());
     let session = EvaluationSession::empty();
 
     let single = check_resource(&checker, &session, &Resource { id: 0 }).await;
@@ -1738,323 +771,7 @@ async fn not_policy_fail_closes_error_bearing_not_applicable() {
     assert_eq!(batch.fact_load_errors().len(), 1);
 }
 
-#[async_trait]
-impl Policy<Domain> for IndeterminatePolicy {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        PolicyEvalResult::indeterminate(self.name, "backing store unreachable")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(self.name)
-    }
-
-    fn effect(&self) -> Effect {
-        self.effect
-    }
-}
-
-/// An indeterminate veto-capable policy blocks a sibling grant on every
-/// path: its unresolved potential veto must not let the grant through, and
-/// the outcome is `Indeterminate`, not `Denied`.
-#[tokio::test]
-async fn veto_indeterminate_blocks_grant_and_yields_indeterminate() {
-    let session = EvaluationSession::empty();
-    for indeterminate_registered_first in [true, false] {
-        let mut checker = PermissionChecker::new();
-        if indeterminate_registered_first {
-            checker.add_policy(IndeterminatePolicy {
-                name: "BrokenVeto",
-                effect: Effect::AllowOrForbid,
-            });
-            checker.add_policy(allow_everything("AllowAll"));
-        } else {
-            checker.add_policy(allow_everything("AllowAll"));
-            checker.add_policy(IndeterminatePolicy {
-                name: "BrokenVeto",
-                effect: Effect::AllowOrForbid,
-            });
-        }
-
-        let single = check_resource(&checker, &session, &Resource { id: 0 }).await;
-        single.assert_indeterminate();
-        assert!(!single.is_granted());
-        assert_eq!(single.forbidden_by(), None);
-        let reason = single.indeterminate_reason().unwrap();
-        assert!(reason.contains("BrokenVeto"), "reason: {reason}");
-        assert!(
-            reason.contains("backing store unreachable"),
-            "reason: {reason}"
-        );
-
-        let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }])
-            .await
-            .remove(0)
-            .1;
-        batch.assert_indeterminate();
-        assert_eq!(
-            batch.indeterminate_reason(),
-            single.indeterminate_reason(),
-            "single and batch paths must agree"
-        );
-
-        // The filter pipeline fails closed on indeterminate items.
-        let visible = filter_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-        assert!(visible.is_empty());
-    }
-}
-
-/// A definite forbid observed later in the veto prefix downgrades an
-/// earlier indeterminate to an ordinary veto denial: deny overrides
-/// indeterminate. Distinguishes mutants that return `Indeterminate` before
-/// the veto prefix has fully run.
-#[tokio::test]
-async fn veto_indeterminate_then_real_forbid_is_denied() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(IndeterminatePolicy {
-        name: "BrokenVeto",
-        effect: Effect::AllowOrForbid,
-    });
-    checker.add_policy(forbid_odd_resources("OddBlock"));
-    checker.add_policy(allow_everything("AllowAll"));
-
-    let session = EvaluationSession::empty();
-
-    let single = check_resource(&checker, &session, &Resource { id: 1 }).await;
-    single.assert_forbidden_by("OddBlock");
-
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 1 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_forbidden_by("OddBlock");
-
-    // On even resources the forbid does not match, so the indeterminate
-    // veto policy is decisive again.
-    let even = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    even.assert_indeterminate();
-}
-
-/// An indeterminate *allow-only* policy cannot block a sibling grant: it
-/// could only have granted, so "first grant wins" is preserved.
-#[tokio::test]
-async fn allow_only_indeterminate_does_not_block_grant() {
-    let session = EvaluationSession::empty();
-    for indeterminate_registered_first in [true, false] {
-        let mut checker = PermissionChecker::new();
-        if indeterminate_registered_first {
-            checker.add_policy(IndeterminatePolicy {
-                name: "BrokenAllow",
-                effect: Effect::Allow,
-            });
-            checker.add_policy(allow_everything("AllowAll"));
-        } else {
-            checker.add_policy(allow_everything("AllowAll"));
-            checker.add_policy(IndeterminatePolicy {
-                name: "BrokenAllow",
-                effect: Effect::Allow,
-            });
-        }
-
-        let single = check_resource(&checker, &session, &Resource { id: 0 }).await;
-        single.assert_granted_by("AllowAll");
-
-        let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }])
-            .await
-            .remove(0)
-            .1;
-        batch.assert_granted_by("AllowAll");
-    }
-}
-
-/// With no grant on the table, an indeterminate allow-only policy makes the
-/// evaluation indeterminate rather than "All policies denied access": the
-/// failed policy might have granted.
-#[tokio::test]
-async fn allow_only_indeterminate_without_grant_is_indeterminate() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(NamedNoopPolicy { name: "NoOpinion" });
-    checker.add_policy(IndeterminatePolicy {
-        name: "BrokenAllow",
-        effect: Effect::Allow,
-    });
-
-    let session = EvaluationSession::empty();
-
-    let single = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    single.assert_indeterminate();
-    assert!(single
-        .indeterminate_reason()
-        .unwrap()
-        .contains("BrokenAllow"));
-    assert!(single.to_result(|reason| reason.to_string()).is_err());
-
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_indeterminate();
-    assert_eq!(batch.indeterminate_reason(), single.indeterminate_reason());
-}
-
-/// A custom combinator that reports a granting decision while keeping a
-/// `Forbidden` leaf in its children is still treated as forbidding: the
-/// whole-tree scan in `is_forbidden` is the fail-closed backstop.
-struct LyingGrantCombinator;
-
-#[async_trait]
-impl Policy<Domain> for LyingGrantCombinator {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        PolicyEvalResult::Combined {
-            policy_type: std::borrow::Cow::Borrowed("LyingGrantCombinator"),
-            operation: gatehouse::CombineOp::And,
-            children: vec![PolicyEvalResult::forbidden("HiddenVeto", "buried veto")],
-            decision: Decision::Grant,
-        }
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("LyingGrantCombinator")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::AllowOrForbid
-    }
-}
-
-/// A custom node that carries `Decision::Forbid` without any `Forbidden`
-/// leaf still vetoes: the decision half of `is_forbidden` is honored too.
-struct DecisionOnlyForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for DecisionOnlyForbidPolicy {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        PolicyEvalResult::Combined {
-            policy_type: std::borrow::Cow::Borrowed("DecisionOnlyForbid"),
-            operation: gatehouse::CombineOp::And,
-            children: Vec::new(),
-            decision: Decision::Forbid,
-        }
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("DecisionOnlyForbid")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
-}
-
-struct DecisionOnlyIndeterminatePolicy;
-
-#[async_trait]
-impl Policy<Domain> for DecisionOnlyIndeterminatePolicy {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        PolicyEvalResult::Combined {
-            policy_type: std::borrow::Cow::Borrowed("DecisionOnlyIndeterminate"),
-            operation: gatehouse::CombineOp::And,
-            children: Vec::new(),
-            decision: Decision::Indeterminate,
-        }
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("DecisionOnlyIndeterminate")
-    }
-}
-
-#[tokio::test]
-async fn decision_only_indeterminate_has_a_nonempty_fallback_reason() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(DecisionOnlyIndeterminatePolicy);
-    let session = EvaluationSession::empty();
-
-    let single = check_resource(&checker, &session, &Resource { id: 0 }).await;
-    single.assert_indeterminate();
-    assert_eq!(
-        single.indeterminate_reason(),
-        Some(
-            "Could not evaluate DecisionOnlyIndeterminate: indeterminate result did not contain an indeterminate leaf"
-        )
-    );
-
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 0 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_indeterminate();
-    assert_eq!(batch.indeterminate_reason(), single.indeterminate_reason());
-}
-
-#[tokio::test]
-async fn inconsistent_custom_combinator_nodes_still_fail_closed() {
-    let session = EvaluationSession::empty();
-
-    // Forbidden leaf under a lying `Grant` decision: the leaf scan wins.
-    let mut lying = PermissionChecker::new();
-    lying.add_policy(allow_everything("AllowAll"));
-    lying.add_policy(LyingGrantCombinator);
-    let evaluation = check_resource(&lying, &session, &Resource { id: 0 }).await;
-    evaluation.assert_forbidden_by("HiddenVeto");
-    let batch = evaluate_resources(&lying, &session, vec![Resource { id: 0 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_forbidden_by("HiddenVeto");
-
-    // `Decision::Forbid` with no Forbidden leaf: the decision wins.
-    let mut decision_only = PermissionChecker::new();
-    decision_only.add_policy(allow_everything("AllowAll"));
-    decision_only.add_policy(DecisionOnlyForbidPolicy);
-    let evaluation = check_resource(&decision_only, &session, &Resource { id: 0 }).await;
-    evaluation.assert_denied();
-    evaluation.assert_denied_with_reason_containing("Forbidden by");
-    let batch = evaluate_resources(&decision_only, &session, vec![Resource { id: 0 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_denied();
-}
-
-/// An indeterminate child checker propagates through `DelegatingPolicy`:
-/// the parent evaluation is indeterminate, and a veto-capable delegate
-/// blocks parent grants.
-#[tokio::test]
-async fn delegated_child_indeterminate_propagates_to_parent_checker() {
-    let session = EvaluationSession::empty();
-
-    let mut child: PermissionChecker<Domain> = PermissionChecker::new();
-    child.add_policy(IndeterminatePolicy {
-        name: "ChildBroken",
-        effect: Effect::AllowOrForbid,
-    });
-    let delegate = DelegatingPolicy::new(
-        "DelegatedDecision",
-        child,
-        |_subject: &Subject| Subject,
-        |_action: &Action| Action,
-        |_subject: &Subject, _action: &Action, resource: &Resource, _ctx: &Ctx| Resource {
-            id: resource.id,
-        },
-        |_subject: &Subject, _action: &Action, _ctx: &Ctx| Ctx,
-    );
-
-    let mut parent = PermissionChecker::new();
-    parent.add_policy(allow_everything("ParentAllow"));
-    parent.add_policy(delegate);
-
-    let evaluation = check_resource(&parent, &session, &Resource { id: 0 }).await;
-    evaluation.assert_indeterminate();
-    assert!(evaluation
-        .indeterminate_reason()
-        .unwrap()
-        .contains("ChildBroken"));
-}
-
-// ---- recording contexts (EvalCtx::fact / BatchEvalCtx::facts_by) ----
-
-/// Per-resource yes/no fact used to exercise provenance recording.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct OddFlag(u8);
 
 impl gatehouse::FactKey for OddFlag {
@@ -2102,26 +819,23 @@ fn odd_flag_session(fail_ids: impl IntoIterator<Item = u8>) -> EvaluationSession
 struct HandBuiltOddPolicy;
 
 impl HandBuiltOddPolicy {
-    fn result_for(fact: FactLoadResult<bool>) -> PolicyEvalResult {
+    fn result_for(fact: FactLoadResult<bool>) -> GrantResult {
         match fact {
             FactLoadResult::Found(true) => {
-                PolicyEvalResult::granted("HandBuiltOddPolicy", Some("odd resource".into()))
+                GrantResult::granted("HandBuiltOddPolicy", Some("odd resource".into()))
             }
-            _ => PolicyEvalResult::not_applicable("HandBuiltOddPolicy", "not odd"),
+            _ => GrantResult::not_applicable("HandBuiltOddPolicy", "not odd"),
         }
     }
 }
 
 #[async_trait]
 impl Policy<Domain> for HandBuiltOddPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         Self::result_for(ctx.fact(OddFlag(ctx.resource.id)).await)
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
         ctx.facts_by(|resource| OddFlag(resource.id))
             .await
             .into_iter()
@@ -2141,14 +855,9 @@ struct HandBuiltCombinedOddPolicy;
 
 #[async_trait]
 impl Policy<Domain> for HandBuiltCombinedOddPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         let _ = ctx.fact(OddFlag(ctx.resource.id)).await;
-        PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
-            operation: gatehouse::CombineOp::And,
-            children: Vec::new(),
-            decision: Decision::NotApplicable,
-        }
+        GrantResult::all(self.policy_type(), Vec::new())
     }
 
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
@@ -2278,7 +987,11 @@ async fn combinators_merge_recorded_facts_for_hand_built_children() {
     or_checker.add_policy(
         OrPolicy::try_new(vec![
             Arc::new(HandBuiltOddPolicy),
-            Arc::new(NamedNoopPolicy { name: "NoOpinion" }) as Arc<dyn Policy<Domain>>,
+            Arc::new(
+                PolicyBuilder::<Domain>::new("NoOpinion")
+                    .when(|_, _, _, _| false)
+                    .build(),
+            ) as Arc<dyn Policy<Domain>>,
         ])
         .unwrap(),
     );
@@ -2291,7 +1004,7 @@ async fn combinators_merge_recorded_facts_for_hand_built_children() {
     // NOT: without the merge the failed child would look like an ordinary
     // non-grant and NOT would invert it into a grant.
     let mut not_checker = PermissionChecker::new();
-    not_checker.add_policy(NotPolicy::new(HandBuiltOddPolicy));
+    not_checker.add_policy(HandBuiltOddPolicy.not());
     let session = odd_flag_session([3]);
     let single = check_resource(&not_checker, &session, &failing).await;
     single.assert_indeterminate();
@@ -2302,83 +1015,26 @@ async fn combinators_merge_recorded_facts_for_hand_built_children() {
 
 /// A `Forbid`-effect policy that (in violation of its contract) grants,
 /// after consulting a fact through the recording context.
-struct MisbehavingFactBackedForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for MisbehavingFactBackedForbidPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        let _ = ctx.fact(OddFlag(ctx.resource.id)).await;
-        ctx.grant("grants despite declaring Effect::Forbid")
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("MisbehavingFactBackedForbidPolicy")
-    }
-
-    fn effect(&self) -> Effect {
-        Effect::Forbid
-    }
-}
-
-/// Normalizing a forbid-effect policy's contract-violating grant to
-/// `NotApplicable` keeps the facts the policy consulted in the trace, on
-/// both evaluation paths.
-#[tokio::test]
-async fn forbid_effect_grant_normalization_preserves_provenance() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(MisbehavingFactBackedForbidPolicy);
-    let session = odd_flag_session([]);
-
-    let single = check_resource(&checker, &session, &Resource { id: 1 }).await;
-    single.assert_denied();
-    let rendered = single.trace().format();
-    assert!(
-        rendered.contains("treated as not applicable"),
-        "trace should show the normalized contract violation:\n{rendered}"
-    );
-    assert!(
-        rendered.contains("fact odd_flag [found]"),
-        "normalization must not drop the consulted facts:\n{rendered}"
-    );
-
-    let batch = evaluate_resources(&checker, &session, vec![Resource { id: 1 }])
-        .await
-        .remove(0)
-        .1;
-    batch.assert_denied();
-    let rendered = batch.trace().format();
-    assert!(rendered.contains("treated as not applicable"));
-    assert!(
-        rendered.contains("fact odd_flag [found]"),
-        "batch normalization must not drop the consulted facts:\n{rendered}"
-    );
-}
-
-/// A batch-shared fact loaded through `BatchEvalCtx::fact` records
-/// provenance against every item in the batch.
 struct SharedFactPolicy;
 
 #[async_trait]
 impl Policy<Domain> for SharedFactPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         match ctx.fact(OddFlag(0)).await {
             FactLoadResult::Found(true) => ctx.grant("shared flag set"),
             _ => ctx.not_applicable("shared flag not set"),
         }
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
         let fact = ctx.fact(OddFlag(0)).await;
         ctx.items
             .iter()
             .map(|_| match &fact {
                 FactLoadResult::Found(true) => {
-                    PolicyEvalResult::granted("SharedFactPolicy", Some("shared flag set".into()))
+                    GrantResult::granted("SharedFactPolicy", Some("shared flag set".into()))
                 }
-                _ => PolicyEvalResult::not_applicable("SharedFactPolicy", "shared flag not set"),
+                _ => GrantResult::not_applicable("SharedFactPolicy", "shared flag not set"),
             })
             .collect()
     }
@@ -2426,351 +1082,953 @@ async fn batch_shared_fact_records_against_every_item() {
 /// the veto-prefix rules (indeterminate outranks a definite non-grant when
 /// the child might have forbidden) from the allow-only rules (a definite
 /// answer outranks the indeterminate when it settles the aggregate).
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Truth {
+    Yes,
+    No,
+    Unknown,
+}
+
+fn any_truth(values: impl IntoIterator<Item = Truth>) -> Truth {
+    let mut unknown = false;
+    for value in values {
+        match value {
+            Truth::Yes => return Truth::Yes,
+            Truth::Unknown => unknown = true,
+            Truth::No => {}
+        }
+    }
+    if unknown {
+        Truth::Unknown
+    } else {
+        Truth::No
+    }
+}
+fn all_truth(values: impl IntoIterator<Item = Truth>) -> Truth {
+    let mut unknown = false;
+    for value in values {
+        match value {
+            Truth::No => return Truth::No,
+            Truth::Unknown => unknown = true,
+            Truth::Yes => {}
+        }
+    }
+    if unknown {
+        Truth::Unknown
+    } else {
+        Truth::Yes
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Expression {
+    Leaf([Truth; 3]),
+    All(Box<Expression>, Box<Expression>),
+    Any(Box<Expression>, Box<Expression>),
+    Not(Box<Expression>),
+}
+impl Expression {
+    fn interpret(&self, resource: u8) -> Truth {
+        match self {
+            Self::Leaf(values) => values[usize::from(resource % 3)],
+            Self::All(left, right) => {
+                all_truth([left.interpret(resource), right.interpret(resource)])
+            }
+            Self::Any(left, right) => {
+                any_truth([left.interpret(resource), right.interpret(resource)])
+            }
+            Self::Not(child) => match child.interpret(resource) {
+                Truth::Yes => Truth::No,
+                Truth::No => Truth::Yes,
+                Truth::Unknown => Truth::Unknown,
+            },
+        }
+    }
+    fn grant(&self) -> Box<dyn Policy<Domain>> {
+        match self {
+            Self::Leaf(values) => Box::new(GrantLeaf(*values)),
+            Self::All(left, right) => Box::new(left.grant().and(right.grant())),
+            Self::Any(left, right) => Box::new(left.grant().or(right.grant())),
+            Self::Not(child) => Box::new(child.grant().not()),
+        }
+    }
+    fn veto(&self) -> Box<dyn VetoPolicy<Domain>> {
+        match self {
+            Self::Leaf(values) => Box::new(VetoLeaf(*values)),
+            Self::All(left, right) => Box::new(left.veto().all_of(right.veto())),
+            Self::Any(left, right) => Box::new(left.veto().any_of(right.veto())),
+            Self::Not(_) => unreachable!("veto strategy has no negation"),
+        }
+    }
+}
+struct GrantLeaf([Truth; 3]);
+#[async_trait]
+impl Policy<Domain> for GrantLeaf {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+        match self.0[usize::from(ctx.resource.id % 3)] {
+            Truth::Yes => ctx.grant("grant"),
+            Truth::No => ctx.not_applicable("abstain"),
+            Truth::Unknown => ctx.indeterminate("grant unavailable"),
+        }
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "GrantLeaf".into()
+    }
+}
+struct VetoLeaf([Truth; 3]);
+#[async_trait]
+impl VetoPolicy<Domain> for VetoLeaf {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+        match self.0[usize::from(ctx.resource.id % 3)] {
+            Truth::Yes => ctx.forbid("veto"),
+            Truth::No => ctx.pass("pass"),
+            Truth::Unknown => ctx.veto_indeterminate("veto unavailable"),
+        }
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "VetoLeaf".into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CheckerSpec {
+    grants: Vec<Expression>,
+    vetoes: Vec<Expression>,
+    delegates: Vec<CheckerSpec>,
+}
+impl CheckerSpec {
+    fn grant_truth(&self, resource: u8) -> Truth {
+        any_truth(
+            self.grants
+                .iter()
+                .map(|node| node.interpret(resource))
+                .chain(
+                    self.delegates
+                        .iter()
+                        .map(|child| child.grant_truth(resource)),
+                ),
+        )
+    }
+    fn veto_truth(&self, resource: u8) -> Truth {
+        any_truth(
+            self.vetoes
+                .iter()
+                .map(|node| node.interpret(resource))
+                .chain(
+                    self.delegates
+                        .iter()
+                        .map(|child| child.veto_truth(resource)),
+                ),
+        )
+    }
+    fn decision(&self, resource: u8) -> Decision {
+        match self.veto_truth(resource) {
+            Truth::Yes => Decision::Forbid,
+            Truth::Unknown => Decision::Indeterminate,
+            Truth::No => match self.grant_truth(resource) {
+                Truth::Yes => Decision::Grant,
+                Truth::No => Decision::NotApplicable,
+                Truth::Unknown => Decision::Indeterminate,
+            },
+        }
+    }
+    fn checker(&self, reverse: bool, batch_size: usize) -> PermissionChecker<Domain> {
+        let mut checker =
+            PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(batch_size).unwrap());
+        if reverse {
+            for veto in self.vetoes.iter().rev() {
+                checker.add_veto(veto.veto());
+            }
+            for grant in self.grants.iter().rev() {
+                checker.add_policy(grant.grant());
+            }
+        } else {
+            for grant in &self.grants {
+                checker.add_policy(grant.grant());
+            }
+            for veto in &self.vetoes {
+                checker.add_veto(veto.veto());
+            }
+        }
+        for child in &self.delegates {
+            checker.add_delegate(identity_delegate(child.checker(reverse, batch_size)));
+        }
+        checker
+    }
+}
+fn identity_delegate(checker: PermissionChecker<Domain>) -> DelegatingPolicy<Domain, Domain> {
+    DelegatingPolicy::new(
+        "Delegate",
+        checker,
+        |_: &Subject| Subject,
+        |_: &Action| Action,
+        |_: &Subject, _: &Action, resource: &Resource, _: &Ctx| resource.clone(),
+        |_: &Subject, _: &Action, _: &Ctx| Ctx,
+    )
+}
+fn truth_strategy() -> impl Strategy<Value = Truth> {
+    prop_oneof![Just(Truth::Yes), Just(Truth::No), Just(Truth::Unknown)]
+}
+fn expression_strategy(grant: bool) -> BoxedStrategy<Expression> {
+    prop::array::uniform3(truth_strategy())
+        .prop_map(Expression::Leaf)
+        .prop_recursive(3, 24, 2, move |inner| {
+            let binary = prop_oneof![
+                (inner.clone(), inner.clone())
+                    .prop_map(|(left, right)| Expression::All(Box::new(left), Box::new(right))),
+                (inner.clone(), inner.clone())
+                    .prop_map(|(left, right)| Expression::Any(Box::new(left), Box::new(right))),
+            ];
+            if grant {
+                prop_oneof![
+                    binary.boxed(),
+                    inner
+                        .prop_map(|child| Expression::Not(Box::new(child)))
+                        .boxed()
+                ]
+                .boxed()
+            } else {
+                binary.boxed()
+            }
+        })
+        .boxed()
+}
+fn checker_strategy() -> impl Strategy<Value = CheckerSpec> {
+    let local = (
+        prop::collection::vec(expression_strategy(true), 0..4),
+        prop::collection::vec(expression_strategy(false), 0..4),
+    );
+    local
+        .clone()
+        .prop_map(|(grants, vetoes)| CheckerSpec {
+            grants,
+            vetoes,
+            delegates: Vec::new(),
+        })
+        .prop_recursive(2, 12, 2, move |inner| {
+            (local.clone(), prop::collection::vec(inner, 1..3)).prop_map(
+                |((grants, vetoes), delegates)| CheckerSpec {
+                    grants,
+                    vetoes,
+                    delegates,
+                },
+            )
+        })
+}
+fn access_decision(evaluation: &AccessEvaluation) -> Decision {
+    evaluation
+        .trace()
+        .root()
+        .expect("evaluation audit root")
+        .decision()
+}
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+    #[test]
+    fn recursive_composition_and_delegation_match_independent_oracle(spec in checker_strategy(), resources in prop::collection::vec(0u8..24,0..16), reverse in any::<bool>(), batch_size in 1usize..6) {
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(async {
+            let checker = spec.checker(reverse,batch_size);
+            let session = EvaluationSession::empty();
+            let batch = bind(&checker,&session).evaluate(resources.iter().map(|&id| Resource { id })).await;
+            prop_assert_eq!(batch.len(),resources.len());
+            for ((resource,batch),id) in batch.iter().zip(resources) {
+                let expected = spec.decision(id);
+                let single = bind(&checker,&session).check(resource).await;
+                prop_assert_eq!(access_decision(batch),expected,"spec: {:?}, resource: {}",spec,id);
+                prop_assert_eq!(access_decision(&single),expected);
+                prop_assert_eq!(batch.trace().format(),single.trace().format());
+                if expected == Decision::Forbid { prop_assert!(batch.forbidden_by().is_some()); }
+                if expected == Decision::Indeterminate { prop_assert!(batch.indeterminate_reason().is_some_and(|reason| !reason.is_empty())); }
+            }
+            Ok(())
+        })?;
+    }
+}
+
 #[tokio::test]
-async fn combinator_indeterminate_decision_tables() {
+async fn grant_and_veto_combinators_exhaustive_truth_tables() {
+    let values = [Truth::Yes, Truth::No, Truth::Unknown];
     let session = EvaluationSession::empty();
     let resource = Resource { id: 0 };
+    for left in values {
+        for right in values {
+            for conjunction in [true, false] {
+                let expression = if conjunction {
+                    Expression::All(
+                        Box::new(Expression::Leaf([left; 3])),
+                        Box::new(Expression::Leaf([right; 3])),
+                    )
+                } else {
+                    Expression::Any(
+                        Box::new(Expression::Leaf([left; 3])),
+                        Box::new(Expression::Leaf([right; 3])),
+                    )
+                };
+                let grant = expression.grant();
+                let veto = expression.veto();
+                let ctx = EvalCtx::new(&session, &Subject, &Action, &resource, &Ctx, "test");
+                let items = [PolicyBatchItem {
+                    resource: &resource,
+                }];
+                let batch_ctx =
+                    BatchEvalCtx::new(&session, &Subject, &Action, &Ctx, &items, "test");
+                let expected = expression.interpret(0);
+                let grant_expected = match expected {
+                    Truth::Yes => Decision::Grant,
+                    Truth::No => Decision::NotApplicable,
+                    Truth::Unknown => Decision::Indeterminate,
+                };
+                let veto_expected = match expected {
+                    Truth::Yes => Decision::Forbid,
+                    Truth::No => Decision::NotApplicable,
+                    Truth::Unknown => Decision::Indeterminate,
+                };
+                assert_eq!(grant.evaluate(&ctx).await.decision(), grant_expected);
+                assert_eq!(
+                    grant.evaluate_batch(&batch_ctx).await[0].decision(),
+                    grant_expected
+                );
+                assert_eq!(veto.evaluate(&ctx).await.decision(), veto_expected);
+                assert_eq!(
+                    veto.evaluate_batch(&batch_ctx).await[0].decision(),
+                    veto_expected
+                );
+            }
+        }
+    }
+}
 
-    async fn decide(
-        policy: &dyn Policy<Domain>,
-        session: &EvaluationSession,
-        resource: &Resource,
-    ) -> Decision {
-        let single = policy
-            .evaluate(&EvalCtx::new(
-                session,
-                &Subject,
-                &Action,
-                resource,
-                &Ctx,
-                policy.policy_type(),
-            ))
-            .await;
-        let items = [PolicyBatchItem { resource }];
-        let batch = policy
-            .evaluate_batch(&BatchEvalCtx::new(
-                session,
-                &Subject,
-                &Action,
-                &Ctx,
-                &items,
-                policy.policy_type(),
-            ))
-            .await;
-        assert_eq!(batch.len(), 1);
+#[tokio::test]
+async fn delegated_grant_outage_does_not_block_parent_grant_but_veto_outage_does() {
+    for veto in [Truth::No, Truth::Unknown, Truth::Yes] {
+        let mut child = PermissionChecker::new();
+        child.add_veto(VetoLeaf([veto; 3]));
+        child.add_policy(GrantLeaf([Truth::Unknown; 3]));
+        let mut parent = PermissionChecker::new();
+        parent.add_delegate(identity_delegate(child));
+        parent.add_policy(GrantLeaf([Truth::Yes; 3]));
+        let expected = match veto {
+            Truth::No => Decision::Grant,
+            Truth::Unknown => Decision::Indeterminate,
+            Truth::Yes => Decision::Forbid,
+        };
+        let session = EvaluationSession::empty();
         assert_eq!(
-            single.decision(),
-            batch[0].decision(),
-            "single and batch combinator decisions must agree"
+            access_decision(&bind(&parent, &session).check(&Resource { id: 0 }).await),
+            expected
         );
-        single.decision()
-    }
-
-    let veto_indet = || IndeterminatePolicy {
-        name: "BrokenVeto",
-        effect: Effect::AllowOrForbid,
-    };
-    let allow_indet = || IndeterminatePolicy {
-        name: "BrokenAllow",
-        effect: Effect::Allow,
-    };
-
-    // A veto-capable child that definitely grants must not be mistaken for a
-    // failed veto-prefix child on the batch path. This distinguishes the
-    // `!is_granted && !is_indeterminate` conjunction from `||`.
-    let and = AndPolicy::try_new(vec![Arc::new(MixedGrantPolicy)]).unwrap();
-    assert_eq!(decide(&and, &session, &resource).await, Decision::Grant);
-    let or = OrPolicy::try_new(vec![Arc::new(MixedGrantPolicy)]).unwrap();
-    assert_eq!(decide(&or, &session, &resource).await, Decision::Grant);
-
-    // AND: a veto-prefix indeterminate outranks both grants and definite
-    // non-grants from the prefix.
-    let and = AndPolicy::try_new(vec![Arc::new(veto_indet()), Arc::new(MixedGrantPolicy)]).unwrap();
-    assert_eq!(
-        decide(&and, &session, &resource).await,
-        Decision::Indeterminate
-    );
-    let and = AndPolicy::try_new(vec![
-        Arc::new(veto_indet()),
-        Arc::new(MixedNotApplicablePolicy),
-    ])
-    .unwrap();
-    assert_eq!(
-        decide(&and, &session, &resource).await,
-        Decision::Indeterminate
-    );
-
-    // AND: an allow-only indeterminate is outranked by a definite
-    // non-grant (the conjunction is definitely not satisfied…)
-    let and = AndPolicy::try_new(vec![
-        Arc::new(allow_indet()),
-        Arc::new(NamedNoopPolicy { name: "NoOpinion" }),
-    ])
-    .unwrap();
-    assert_eq!(
-        decide(&and, &session, &resource).await,
-        Decision::NotApplicable
-    );
-    // …but taints an otherwise-granting conjunction.
-    let and = AndPolicy::try_new(vec![
-        Arc::new(allow_indet()),
-        Arc::new(allow_everything("AllowAll")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
-    assert_eq!(
-        decide(&and, &session, &resource).await,
-        Decision::Indeterminate
-    );
-
-    // OR: a veto-prefix indeterminate blocks even a sibling grant from the
-    // prefix (the unresolved child might have forbidden the request)…
-    let or = OrPolicy::try_new(vec![Arc::new(veto_indet()), Arc::new(MixedGrantPolicy)]).unwrap();
-    assert_eq!(
-        decide(&or, &session, &resource).await,
-        Decision::Indeterminate
-    );
-    // …but an allow-only indeterminate cannot block a definite grant…
-    let or = OrPolicy::try_new(vec![
-        Arc::new(allow_indet()),
-        Arc::new(allow_everything("AllowAll")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
-    assert_eq!(decide(&or, &session, &resource).await, Decision::Grant);
-    // …and with nothing granting, the disjunction is indeterminate.
-    let or = OrPolicy::try_new(vec![
-        Arc::new(allow_indet()),
-        Arc::new(NamedNoopPolicy { name: "NoOpinion" }),
-    ])
-    .unwrap();
-    assert_eq!(
-        decide(&or, &session, &resource).await,
-        Decision::Indeterminate
-    );
-
-    // NOT: inversion never manufactures certainty or neutralizes a veto.
-    let not = NotPolicy::new(allow_indet());
-    assert_eq!(
-        decide(&not, &session, &resource).await,
-        Decision::Indeterminate
-    );
-    let not = NotPolicy::new(forbid_odd_resources("OddBlock"));
-    assert_eq!(
-        decide(&not, &session, &Resource { id: 1 }).await,
-        Decision::Forbid
-    );
-    let not = NotPolicy::new(NamedNoopPolicy { name: "NoOpinion" });
-    assert_eq!(decide(&not, &session, &resource).await, Decision::Grant);
-    let not = NotPolicy::new(allow_everything("AllowAll"));
-    assert_eq!(
-        decide(&not, &session, &resource).await,
-        Decision::NotApplicable
-    );
-}
-
-// ---- wrong-length batches feed the normal combination rules ----------
-
-/// A policy whose batch override breaks the one-result-per-item contract,
-/// with a configurable declared effect. Its single-item path is an
-/// ordinary non-grant, so only batch evaluation observes the violation.
-struct WrongLengthBatchPolicy {
-    name: &'static str,
-    effect: Effect,
-}
-
-#[async_trait]
-impl Policy<Domain> for WrongLengthBatchPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.not_applicable("not applicable")
-    }
-
-    async fn evaluate_batch<'item>(
-        &self,
-        _ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
-        Vec::new()
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(self.name)
-    }
-
-    fn effect(&self) -> Effect {
-        self.effect
-    }
-}
-
-fn wrong_length_allow() -> WrongLengthBatchPolicy {
-    WrongLengthBatchPolicy {
-        name: "BrokenAllowBatch",
-        effect: Effect::Allow,
-    }
-}
-
-fn wrong_length_veto() -> WrongLengthBatchPolicy {
-    WrongLengthBatchPolicy {
-        name: "BrokenVetoBatch",
-        effect: Effect::AllowOrForbid,
-    }
-}
-
-/// A malformed allow-only batch is an indeterminate that cannot block a
-/// later grant: the checker keeps evaluating instead of sealing the item.
-/// With nothing granting, it is what makes the item indeterminate.
-#[tokio::test]
-async fn wrong_length_allow_only_batch_does_not_suppress_later_grant() {
-    let session = EvaluationSession::empty();
-
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(wrong_length_allow());
-    checker.add_policy(allow_everything("AllowAll"));
-    let results = evaluate_resources(
-        &checker,
-        &session,
-        vec![Resource { id: 0 }, Resource { id: 1 }],
-    )
-    .await;
-    assert_eq!(results.len(), 2);
-    for (_item, evaluation) in &results {
-        evaluation.assert_granted_by("AllowAll");
-        evaluation.assert_trace_contains("BrokenAllowBatch INDETERMINATE");
-    }
-
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(wrong_length_allow());
-    checker.add_policy(NamedNoopPolicy { name: "NoOpinion" });
-    let results = evaluate_resources(&checker, &session, vec![Resource { id: 0 }]).await;
-    results[0].1.assert_indeterminate();
-    assert!(
-        results[0]
-            .1
-            .indeterminate_reason()
-            .is_some_and(|reason| reason.contains("BrokenAllowBatch")),
-        "unexpected reason: {:?}",
-        results[0].1.indeterminate_reason()
-    );
-}
-
-/// A malformed veto-capable batch is an unresolved veto: it blocks a later
-/// grant, but a later definite forbid in the prefix still wins and stays
-/// attributable through `forbidden_by`.
-#[tokio::test]
-async fn wrong_length_veto_batch_yields_to_later_forbid_but_blocks_grant() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(wrong_length_veto());
-    checker.add_policy(forbid_odd_resources("OddBlock"));
-    checker.add_policy(allow_everything("AllowAll"));
-    let session = EvaluationSession::empty();
-
-    let results = evaluate_resources(
-        &checker,
-        &session,
-        vec![Resource { id: 1 }, Resource { id: 2 }],
-    )
-    .await;
-    assert_eq!(results.len(), 2);
-    // Odd: the definite forbid later in the veto prefix overrides the
-    // indeterminate from the malformed batch.
-    results[0].1.assert_forbidden_by("OddBlock");
-    // Even: no forbid observed, so the unresolved veto blocks the grant.
-    results[1].1.assert_indeterminate();
-    assert!(
-        results[1]
-            .1
-            .indeterminate_reason()
-            .is_some_and(|reason| reason.contains("BrokenVetoBatch")),
-        "unexpected reason: {:?}",
-        results[1].1.indeterminate_reason()
-    );
-}
-
-/// Malformed child batches inside combinators are indeterminate children,
-/// not terminal: the remaining children still apply the combination rules.
-#[tokio::test]
-async fn wrong_length_child_batches_keep_combinator_items_pending() {
-    let session = EvaluationSession::empty();
-    let resource = Resource { id: 1 };
-
-    async fn decide_batch(
-        policy: &dyn Policy<Domain>,
-        session: &EvaluationSession,
-        resource: &Resource,
-    ) -> Decision {
-        let items = [PolicyBatchItem { resource }];
-        let results = policy
-            .evaluate_batch(&BatchEvalCtx::new(
-                session,
-                &Subject,
-                &Action,
-                &Ctx,
-                &items,
-                policy.policy_type(),
-            ))
+        let batch = bind(&parent, &session)
+            .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
             .await;
-        assert_eq!(results.len(), 1);
-        results[0].decision()
+        assert!(batch
+            .iter()
+            .all(|(_, result)| access_decision(result) == expected));
     }
+}
 
-    // AND: allow-only malformed child, then a definite non-grant settles
-    // the conjunction as NotApplicable...
-    let and = AndPolicy::try_new(vec![
-        Arc::new(wrong_length_allow()),
-        Arc::new(NamedNoopPolicy { name: "NoOpinion" }),
-    ])
-    .unwrap();
+struct CountingVeto {
+    calls: Arc<AtomicUsize>,
+}
+#[async_trait]
+impl VetoPolicy<Domain> for CountingVeto {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ctx.pass("pass")
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "CountingVeto".into()
+    }
+}
+#[tokio::test]
+async fn atomic_delegation_evaluates_each_capability_once_per_resource() {
+    let veto_calls = Arc::new(AtomicUsize::new(0));
+    let grant_calls = Arc::new(AtomicUsize::new(0));
+    let mut child = PermissionChecker::new();
+    child.add_veto(CountingVeto {
+        calls: veto_calls.clone(),
+    });
+    child.add_policy(BatchGrantPolicy {
+        name: "grant",
+        single_calls: grant_calls.clone(),
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: Arc::new(Mutex::new(Vec::new())),
+        grant: Arc::new(|_| true),
+    });
+    let mut parent = PermissionChecker::new();
+    parent.add_delegate(identity_delegate(child));
+    let session = EvaluationSession::empty();
+    assert!(bind(&parent, &session)
+        .check(&Resource { id: 0 })
+        .await
+        .is_granted());
+    assert_eq!(veto_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(grant_calls.load(Ordering::SeqCst), 1);
+    let results = bind(&parent, &session)
+        .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+        .await;
+    assert!(results.iter().all(|(_, result)| result.is_granted()));
+    assert_eq!(veto_calls.load(Ordering::SeqCst), 3);
+    assert_eq!(grant_calls.load(Ordering::SeqCst), 1);
+}
+
+struct WrongGrant(usize);
+#[async_trait]
+impl Policy<Domain> for WrongGrant {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+        ctx.indeterminate("unavailable")
+    }
+    async fn evaluate_batch<'item>(&self, _ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
+        vec![GrantResult::granted("WrongGrant", None); self.0]
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "WrongGrant".into()
+    }
+}
+struct WrongVeto(usize);
+#[async_trait]
+impl VetoPolicy<Domain> for WrongVeto {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+        ctx.veto_indeterminate("unavailable")
+    }
+    async fn evaluate_batch<'item>(&self, _ctx: &BatchEvalCtx<'item, Domain>) -> Vec<VetoResult> {
+        vec![VetoResult::pass("WrongVeto", "pass"); self.0]
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "WrongVeto".into()
+    }
+}
+#[tokio::test]
+async fn malformed_batches_preserve_capability_specific_uncertainty() {
+    for count in [0, 3] {
+        let session = EvaluationSession::empty();
+        let mut grants = PermissionChecker::new();
+        grants.add_policy(WrongGrant(count));
+        grants.add_policy(GrantLeaf([Truth::Yes; 3]));
+        assert!(bind(&grants, &session)
+            .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+            .await
+            .iter()
+            .all(|(_, result)| result.is_granted()));
+        for later in [Truth::No, Truth::Yes] {
+            let mut vetoes = PermissionChecker::new();
+            vetoes.add_veto(WrongVeto(count));
+            vetoes.add_veto(VetoLeaf([later; 3]));
+            vetoes.add_policy(GrantLeaf([Truth::Yes; 3]));
+            let expected = if later == Truth::Yes {
+                Decision::Forbid
+            } else {
+                Decision::Indeterminate
+            };
+            assert!(bind(&vetoes, &session)
+                .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+                .await
+                .iter()
+                .all(|(_, result)| access_decision(result) == expected));
+        }
+    }
+}
+
+#[tokio::test]
+async fn malformed_combinator_batches_do_not_claim_definite_outcomes() {
+    let session = EvaluationSession::empty();
+    for count in [0, 3] {
+        for (policy, expected) in [
+            (
+                WrongGrant(count).or(GrantLeaf([Truth::Yes; 3])).boxed(),
+                Decision::Grant,
+            ),
+            (
+                WrongGrant(count).and(GrantLeaf([Truth::Yes; 3])).boxed(),
+                Decision::Indeterminate,
+            ),
+            (
+                WrongGrant(count).and(GrantLeaf([Truth::No; 3])).boxed(),
+                Decision::NotApplicable,
+            ),
+            (WrongGrant(count).not().boxed(), Decision::Indeterminate),
+        ] {
+            let mut checker = PermissionChecker::new();
+            checker.add_policy(policy);
+            assert!(bind(&checker, &session)
+                .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+                .await
+                .iter()
+                .all(|(_, result)| access_decision(result) == expected));
+        }
+        for (veto, expected) in [
+            (
+                WrongVeto(count).any_of(VetoLeaf([Truth::Yes; 3])).boxed(),
+                Decision::Forbid,
+            ),
+            (
+                WrongVeto(count).all_of(VetoLeaf([Truth::No; 3])).boxed(),
+                Decision::Grant,
+            ),
+            (
+                WrongVeto(count).all_of(VetoLeaf([Truth::Yes; 3])).boxed(),
+                Decision::Indeterminate,
+            ),
+        ] {
+            let mut checker = PermissionChecker::new();
+            checker.add_veto(veto);
+            checker.add_policy(GrantLeaf([Truth::Yes; 3]));
+            assert!(bind(&checker, &session)
+                .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+                .await
+                .iter()
+                .all(|(_, result)| access_decision(result) == expected));
+        }
+    }
+}
+
+#[tokio::test]
+async fn dormant_veto_descendant_does_not_override_all_of_pass_or_steal_attribution() {
+    let session = EvaluationSession::empty();
+    let mut checker = PermissionChecker::new();
+    checker.add_veto(VetoLeaf([Truth::Yes; 3]).all_of(VetoLeaf([Truth::No; 3])));
+    checker.add_policy(GrantLeaf([Truth::Yes; 3]));
+    let result = bind(&checker, &session).check(&Resource { id: 0 }).await;
+    assert!(result.is_granted());
+    assert_eq!(result.forbidden_by(), None);
+    checker.add_veto(PolicyBuilder::<Domain>::new("ActiveVeto").build_veto());
+    let denied = bind(&checker, &session).check(&Resource { id: 0 }).await;
+    denied.assert_forbidden_by("ActiveVeto");
     assert_eq!(
-        decide_batch(&and, &session, &resource).await,
+        denied.denied_reason(),
+        Some("Forbidden by ActiveVeto: Policy forbids access")
+    );
+}
+
+#[tokio::test]
+async fn vetoes_run_in_registration_order_before_grants_and_stop_after_definite_veto() {
+    struct NamedVeto {
+        name: &'static str,
+        truth: Truth,
+    }
+    #[async_trait]
+    impl VetoPolicy<Domain> for NamedVeto {
+        async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+            match self.truth {
+                Truth::Yes => ctx.forbid("blocked"),
+                Truth::No => ctx.pass("passed"),
+                Truth::Unknown => ctx.veto_indeterminate("unavailable"),
+            }
+        }
+        fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+            self.name.into()
+        }
+    }
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(allow_everything("GrantAfterVetoes"));
+    checker.add_veto(NamedVeto {
+        name: "FirstVeto",
+        truth: Truth::No,
+    });
+    checker.add_veto(NamedVeto {
+        name: "SecondVeto",
+        truth: Truth::No,
+    });
+    let session = EvaluationSession::empty();
+    let result = bind(&checker, &session).check(&Resource { id: 0 }).await;
+    let trace = result.trace().format();
+    assert!(trace.find("FirstVeto").unwrap() < trace.find("SecondVeto").unwrap());
+    assert!(trace.find("SecondVeto").unwrap() < trace.find("GrantAfterVetoes").unwrap());
+    checker.add_veto(NamedVeto {
+        name: "UnresolvedVeto",
+        truth: Truth::Unknown,
+    });
+    checker.add_veto(NamedVeto {
+        name: "DefiniteVeto",
+        truth: Truth::Yes,
+    });
+    checker.add_veto(NamedVeto {
+        name: "SkippedVeto",
+        truth: Truth::Yes,
+    });
+    let result = bind(&checker, &session).check(&Resource { id: 0 }).await;
+    result.assert_forbidden_by("DefiniteVeto");
+    assert!(!result.trace().format().contains("SkippedVeto"));
+    assert!(!result.trace().format().contains("GrantAfterVetoes"));
+    for (_, result) in bind(&checker, &session)
+        .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+        .await
+    {
+        result.assert_forbidden_by("DefiniteVeto");
+        assert!(!result.trace().format().contains("SkippedVeto"));
+        assert!(!result.trace().format().contains("GrantAfterVetoes"));
+    }
+}
+
+#[tokio::test]
+async fn not_preserves_uncertainty_and_inverts_only_definite_results() {
+    let session = EvaluationSession::empty();
+    for (input, expected) in [
+        (Truth::Yes, Decision::NotApplicable),
+        (Truth::No, Decision::Grant),
+        (Truth::Unknown, Decision::Indeterminate),
+    ] {
+        let policy = GrantLeaf([input; 3]).not();
+        let resource = Resource { id: 0 };
+        let ctx = EvalCtx::new(&session, &Subject, &Action, &resource, &Ctx, "Not");
+        let items = [PolicyBatchItem {
+            resource: &resource,
+        }];
+        let batch = BatchEvalCtx::new(&session, &Subject, &Action, &Ctx, &items, "Not");
+        assert_eq!(policy.evaluate(&ctx).await.decision(), expected);
+        assert_eq!(policy.evaluate_batch(&batch).await[0].decision(), expected);
+    }
+}
+
+#[tokio::test]
+async fn checker_clone_preserves_vetoes_delegates_and_batch_limit() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let mut child = PermissionChecker::new();
+    child.add_veto(VetoLeaf([Truth::No, Truth::Yes, Truth::No]));
+    child.add_policy(BatchGrantPolicy {
+        name: "Batched",
+        batch_calls: Arc::new(AtomicUsize::new(0)),
+        single_calls: Arc::new(AtomicUsize::new(0)),
+        seen_batches: seen.clone(),
+        grant: Arc::new(|_| true),
+    });
+    let mut checker =
+        PermissionChecker::named("Cloned").with_max_batch_size(NonZeroUsize::new(2).unwrap());
+    checker.add_delegate(identity_delegate(child));
+    let cloned = checker.clone();
+    let session = EvaluationSession::empty();
+    let results = bind(&cloned, &session)
+        .evaluate((0..8).map(|id| Resource { id }))
+        .await;
+    assert_eq!(
+        results
+            .iter()
+            .map(|(_, result)| result.is_granted())
+            .collect::<Vec<_>>(),
+        vec![true, false, true, true, false, true, true, false]
+    );
+    assert!(seen.lock().unwrap().iter().all(|batch| batch.len() <= 2));
+    assert_eq!(
+        seen.lock()
+            .unwrap()
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![0, 2, 3, 5, 6]
+    );
+    assert_eq!(cloned.name(), Some("Cloned"));
+}
+
+#[tokio::test]
+async fn veto_recording_upgrades_failed_pass_and_preserves_definite_forbid() {
+    struct FactVeto(bool);
+    #[async_trait]
+    impl VetoPolicy<Domain> for FactVeto {
+        async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+            let _ = ctx.fact(OddFlag(ctx.resource.id)).await;
+            if self.0 {
+                VetoResult::forbid("FactVeto", "blocked")
+            } else {
+                VetoResult::pass("FactVeto", "pass")
+            }
+        }
+        async fn evaluate_batch<'item>(
+            &self,
+            ctx: &BatchEvalCtx<'item, Domain>,
+        ) -> Vec<VetoResult> {
+            let _ = ctx.facts_by(|resource| OddFlag(resource.id)).await;
+            ctx.items
+                .iter()
+                .map(|_| {
+                    if self.0 {
+                        VetoResult::forbid("FactVeto", "blocked")
+                    } else {
+                        VetoResult::pass("FactVeto", "pass")
+                    }
+                })
+                .collect()
+        }
+        fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+            "FactVeto".into()
+        }
+    }
+    for forbid in [false, true] {
+        let mut checker = PermissionChecker::new();
+        checker.add_veto(FactVeto(forbid));
+        checker.add_policy(allow_everything("Allow"));
+        let session = odd_flag_session([3]);
+        let expected = if forbid {
+            Decision::Forbid
+        } else {
+            Decision::Indeterminate
+        };
+        let result = bind(&checker, &session).check(&Resource { id: 3 }).await;
+        assert_eq!(access_decision(&result), expected);
+        assert_eq!(result.fact_load_errors().len(), 1);
+        let result = bind(&checker, &session)
+            .evaluate(vec![Resource { id: 3 }])
+            .await
+            .remove(0)
+            .1;
+        assert_eq!(access_decision(&result), expected);
+        assert_eq!(result.fact_load_errors().len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn veto_trait_objects_forward_batch_overrides_and_empty_inputs_are_not_evaluated() {
+    struct BatchOnlyVeto;
+    #[async_trait]
+    impl VetoPolicy<Domain> for BatchOnlyVeto {
+        async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+            panic!("batch override must be forwarded")
+        }
+        async fn evaluate_batch<'item>(
+            &self,
+            ctx: &BatchEvalCtx<'item, Domain>,
+        ) -> Vec<VetoResult> {
+            assert!(!ctx.items.is_empty());
+            ctx.items
+                .iter()
+                .map(|_| VetoResult::pass("BatchOnlyVeto", "pass"))
+                .collect()
+        }
+        fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+            "BatchOnlyVeto".into()
+        }
+    }
+    let boxed: Box<dyn VetoPolicy<Domain>> = Box::new(BatchOnlyVeto);
+    let shared: Arc<dyn VetoPolicy<Domain>> = Arc::new(boxed);
+    let mut checker = PermissionChecker::new();
+    checker.add_veto(shared);
+    checker.add_policy(allow_everything("Allow"));
+    let session = EvaluationSession::empty();
+    assert!(bind(&checker, &session)
+        .evaluate(Vec::<Resource>::new())
+        .await
+        .is_empty());
+    assert!(bind(&checker, &session)
+        .evaluate(vec![Resource { id: 0 }])
+        .await
+        .remove(0)
+        .1
+        .is_granted());
+}
+
+#[test]
+fn empty_policy_combinators_are_rejected_and_empty_result_aggregates_abstain() {
+    let error = AndPolicy::<Domain>::try_new(Vec::new())
+        .err()
+        .expect("empty conjunction must fail");
+    assert_eq!(error.to_string(), "AndPolicy requires at least one policy");
+    assert!(OrPolicy::<Domain>::try_new(Vec::new()).is_err());
+    assert!(gatehouse::AllOfVeto::<Domain>::try_new(Vec::new()).is_err());
+    assert!(gatehouse::AnyOfVeto::<Domain>::try_new(Vec::new()).is_err());
+    assert_eq!(
+        GrantResult::all("Empty", Vec::new()).decision(),
         Decision::NotApplicable
     );
-    // ...while a later grant leaves it tainted.
-    let and = AndPolicy::try_new(vec![
-        Arc::new(wrong_length_allow()),
-        Arc::new(allow_everything("AllowAll")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
     assert_eq!(
-        decide_batch(&and, &session, &resource).await,
-        Decision::Indeterminate
+        GrantResult::any("Empty", Vec::new()).decision(),
+        Decision::NotApplicable
     );
-    // AND: veto-capable malformed child, then a definite forbid in the
-    // prefix still wins.
-    let and = AndPolicy::try_new(vec![
-        Arc::new(wrong_length_veto()),
-        Arc::new(forbid_odd_resources("OddBlock")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
-    assert_eq!(
-        decide_batch(&and, &session, &resource).await,
-        Decision::Forbid
-    );
+}
 
-    // OR: allow-only malformed child, then a grant resolves the disjunction.
-    let or = OrPolicy::try_new(vec![
-        Arc::new(wrong_length_allow()),
-        Arc::new(allow_everything("AllowAll")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
-    assert_eq!(
-        decide_batch(&or, &session, &resource).await,
-        Decision::Grant
+struct MappedValue(usize);
+struct MappedDomain;
+impl PolicyDomain for MappedDomain {
+    type Subject = MappedValue;
+    type Action = MappedValue;
+    type Resource = MappedValue;
+    type Context = MappedValue;
+}
+type MappedObservation = (char, usize, usize, usize, usize);
+struct ObserveMapped {
+    observed: Arc<Mutex<Vec<MappedObservation>>>,
+    grants: bool,
+}
+#[async_trait]
+impl Policy<MappedDomain> for ObserveMapped {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, MappedDomain>) -> GrantResult {
+        self.observed.lock().unwrap().push((
+            'G',
+            ctx.subject.0,
+            ctx.action.0,
+            ctx.resource.0,
+            ctx.context.0,
+        ));
+        if self.grants {
+            ctx.grant("observed")
+        } else {
+            ctx.not_applicable("observed")
+        }
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "ObserveGrant".into()
+    }
+}
+#[async_trait]
+impl VetoPolicy<MappedDomain> for ObserveMapped {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, MappedDomain>) -> VetoResult {
+        self.observed.lock().unwrap().push((
+            'V',
+            ctx.subject.0,
+            ctx.action.0,
+            ctx.resource.0,
+            ctx.context.0,
+        ));
+        ctx.pass("observed")
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "ObserveVeto".into()
+    }
+}
+
+#[tokio::test]
+async fn delegation_maps_once_across_capability_phases_and_batch_chunks() {
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let mut child = PermissionChecker::new();
+    child.add_veto(ObserveMapped {
+        observed: observed.clone(),
+        grants: true,
+    });
+    child.add_policy(ObserveMapped {
+        observed: observed.clone(),
+        grants: true,
+    });
+    let counts: [Arc<AtomicUsize>; 4] = std::array::from_fn(|_| Arc::new(AtomicUsize::new(0)));
+    let [subject_calls, action_calls, resource_calls, context_calls] = counts.clone();
+    let delegate = DelegatingPolicy::new(
+        "MappedOnce",
+        child,
+        move |_: &Subject| MappedValue(subject_calls.fetch_add(1, Ordering::SeqCst)),
+        move |_: &Action| MappedValue(action_calls.fetch_add(1, Ordering::SeqCst)),
+        move |_: &Subject, _: &Action, _: &Resource, _: &Ctx| {
+            MappedValue(resource_calls.fetch_add(1, Ordering::SeqCst))
+        },
+        move |_: &Subject, _: &Action, _: &Ctx| {
+            MappedValue(context_calls.fetch_add(1, Ordering::SeqCst))
+        },
     );
-    // OR: allow-only malformed child with nothing granting is indeterminate.
-    let or = OrPolicy::try_new(vec![
-        Arc::new(wrong_length_allow()),
-        Arc::new(NamedNoopPolicy { name: "NoOpinion" }),
-    ])
-    .unwrap();
+    let mut checker = PermissionChecker::new().with_max_batch_size(NonZeroUsize::new(1).unwrap());
+    checker.add_delegate(delegate);
+    let session = EvaluationSession::empty();
+    let results = bind(&checker, &session)
+        .evaluate(vec![
+            Resource { id: 0 },
+            Resource { id: 0 },
+            Resource { id: 1 },
+        ])
+        .await;
+    assert!(results.iter().all(|(_, result)| result.is_granted()));
     assert_eq!(
-        decide_batch(&or, &session, &resource).await,
-        Decision::Indeterminate
+        counts.each_ref().map(|count| count.load(Ordering::SeqCst)),
+        [1, 1, 3, 1]
     );
-    // OR: veto-capable malformed child, then a definite forbid still wins.
-    let or = OrPolicy::try_new(vec![
-        Arc::new(wrong_length_veto()),
-        Arc::new(forbid_odd_resources("OddBlock")) as Arc<dyn Policy<Domain>>,
-    ])
-    .unwrap();
     assert_eq!(
-        decide_batch(&or, &session, &resource).await,
-        Decision::Forbid
+        *observed.lock().unwrap(),
+        vec![
+            ('V', 0, 0, 0, 0),
+            ('V', 0, 0, 1, 0),
+            ('V', 0, 0, 2, 0),
+            ('G', 0, 0, 0, 0),
+            ('G', 0, 0, 1, 0),
+            ('G', 0, 0, 2, 0)
+        ]
     );
+    observed.lock().unwrap().clear();
+    assert!(bind(&checker, &session)
+        .check(&Resource { id: 0 })
+        .await
+        .is_granted());
+    assert_eq!(
+        counts.each_ref().map(|count| count.load(Ordering::SeqCst)),
+        [2, 2, 4, 2]
+    );
+    assert_eq!(
+        *observed.lock().unwrap(),
+        vec![('V', 1, 1, 3, 1), ('G', 1, 1, 3, 1)]
+    );
+}
+
+#[tokio::test]
+async fn reused_child_checkers_keep_independent_nested_mapping_state() {
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let mut leaf = PermissionChecker::new();
+    leaf.add_veto(ObserveMapped {
+        observed: observed.clone(),
+        grants: false,
+    });
+    leaf.add_policy(ObserveMapped {
+        observed: observed.clone(),
+        grants: false,
+    });
+    let mut middle = PermissionChecker::<MappedDomain>::new();
+    middle.add_delegate(DelegatingPolicy::new(
+        "Inner",
+        leaf,
+        |value: &MappedValue| MappedValue(value.0),
+        |value: &MappedValue| MappedValue(value.0),
+        |_: &MappedValue, _: &MappedValue, value: &MappedValue, _: &MappedValue| {
+            MappedValue(value.0)
+        },
+        |_: &MappedValue, _: &MappedValue, value: &MappedValue| MappedValue(value.0),
+    ));
+    let mut parent = PermissionChecker::new();
+    for offset in [10, 20] {
+        parent.add_delegate(DelegatingPolicy::new(
+            "Outer",
+            middle.clone(),
+            move |_: &Subject| MappedValue(offset),
+            |_: &Action| MappedValue(0),
+            move |_: &Subject, _: &Action, resource: &Resource, _: &Ctx| {
+                MappedValue(offset + usize::from(resource.id))
+            },
+            |_: &Subject, _: &Action, _: &Ctx| MappedValue(0),
+        ));
+    }
+    let session = EvaluationSession::empty();
+    assert!(!bind(&parent, &session)
+        .check(&Resource { id: 1 })
+        .await
+        .is_granted());
+    assert_eq!(
+        *observed.lock().unwrap(),
+        vec![
+            ('V', 10, 0, 11, 0),
+            ('V', 20, 0, 21, 0),
+            ('G', 10, 0, 11, 0),
+            ('G', 20, 0, 21, 0)
+        ]
+    );
+}
+
+#[tokio::test]
+async fn negation_preserves_failed_facts_nested_inside_custom_grant_aggregates() {
+    struct AggregateWithFailedFact;
+    #[async_trait]
+    impl Policy<Domain> for AggregateWithFailedFact {
+        async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+            let leaf = ErrorBearingNotApplicablePolicy.evaluate(ctx).await;
+            GrantResult::all("Outer", vec![GrantResult::any("Inner", vec![leaf])])
+        }
+        fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+            "AggregateWithFailedFact".into()
+        }
+    }
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(AggregateWithFailedFact.not());
+    let session = EvaluationSession::empty();
+    let single = bind(&checker, &session).check(&Resource { id: 0 }).await;
+    single.assert_indeterminate();
+    assert_eq!(single.fact_load_errors().len(), 1);
+    for (_, result) in bind(&checker, &session)
+        .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+        .await
+    {
+        result.assert_indeterminate();
+        assert_eq!(result.fact_load_errors().len(), 1);
+    }
 }

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -725,8 +725,9 @@ async fn delegated_child_forbid_propagates_to_parent_checker() {
     denied.assert_forbidden_by("ChildBlock");
 }
 
-/// A hand-written policy that declares `Effect::Forbid` and forbids via
-/// `ctx.forbid` is honored on both evaluation paths.
+/// A grant policy that reports a failed fact load as explicit provenance on
+/// an abstention. The constructor upgrades the result to `Indeterminate`, so
+/// negation can never turn the failed load into a grant.
 struct ErrorBearingNotApplicablePolicy;
 
 #[async_trait]
@@ -1077,10 +1078,11 @@ async fn batch_shared_fact_records_against_every_item() {
     }
 }
 
-/// Combinator decision tables for indeterminate children. Distinguishes
-/// the veto-prefix rules (indeterminate outranks a definite non-grant when
-/// the child might have forbidden) from the allow-only rules (a definite
-/// answer outranks the indeterminate when it settles the aggregate).
+/// Three-valued model for grant and veto composition. `Unknown` is an
+/// indeterminate child; `all_truth` / `any_truth` encode that a definite
+/// abstention (or pass) settles a conjunction and a definite grant (or veto)
+/// settles a disjunction, while anything else involving `Unknown` stays
+/// `Unknown`.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Truth {

--- a/tests/checker_contract.rs
+++ b/tests/checker_contract.rs
@@ -749,8 +749,7 @@ impl Policy<Domain> for ErrorBearingNotApplicablePolicy {
 }
 
 /// Negation must never manufacture a grant from a leaf that reports a failed
-/// fact load, even when the policy deliberately used the explicit-provenance
-/// escape hatch to keep the leaf itself `NotApplicable`.
+/// fact load through explicit provenance.
 #[tokio::test]
 async fn not_policy_fail_closes_error_bearing_not_applicable() {
     let mut checker = PermissionChecker::new();
@@ -1124,6 +1123,7 @@ fn all_truth(values: impl IntoIterator<Item = Truth>) -> Truth {
 #[derive(Clone, Debug)]
 enum Expression {
     Leaf([Truth; 3]),
+    RecordedLeaf([Truth; 3]),
     All(Box<Expression>, Box<Expression>),
     Any(Box<Expression>, Box<Expression>),
     Not(Box<Expression>),
@@ -1131,7 +1131,7 @@ enum Expression {
 impl Expression {
     fn interpret(&self, resource: u8) -> Truth {
         match self {
-            Self::Leaf(values) => values[usize::from(resource % 3)],
+            Self::Leaf(values) | Self::RecordedLeaf(values) => values[usize::from(resource % 3)],
             Self::All(left, right) => {
                 all_truth([left.interpret(resource), right.interpret(resource)])
             }
@@ -1148,6 +1148,7 @@ impl Expression {
     fn grant(&self) -> Box<dyn Policy<Domain>> {
         match self {
             Self::Leaf(values) => Box::new(GrantLeaf(*values)),
+            Self::RecordedLeaf(values) => Box::new(RecordedGrantLeaf(*values)),
             Self::All(left, right) => Box::new(left.grant().and(right.grant())),
             Self::Any(left, right) => Box::new(left.grant().or(right.grant())),
             Self::Not(child) => Box::new(child.grant().not()),
@@ -1156,6 +1157,7 @@ impl Expression {
     fn veto(&self) -> Box<dyn VetoPolicy<Domain>> {
         match self {
             Self::Leaf(values) => Box::new(VetoLeaf(*values)),
+            Self::RecordedLeaf(values) => Box::new(RecordedVetoLeaf(*values)),
             Self::All(left, right) => Box::new(left.veto().all_of(right.veto())),
             Self::Any(left, right) => Box::new(left.veto().any_of(right.veto())),
             Self::Not(_) => unreachable!("veto strategy has no negation"),
@@ -1271,8 +1273,14 @@ fn truth_strategy() -> impl Strategy<Value = Truth> {
     prop_oneof![Just(Truth::Yes), Just(Truth::No), Just(Truth::Unknown)]
 }
 fn expression_strategy(grant: bool) -> BoxedStrategy<Expression> {
-    prop::array::uniform3(truth_strategy())
-        .prop_map(Expression::Leaf)
+    (prop::array::uniform3(truth_strategy()), any::<bool>())
+        .prop_map(|(values, recorded)| {
+            if recorded {
+                Expression::RecordedLeaf(values)
+            } else {
+                Expression::Leaf(values)
+            }
+        })
         .prop_recursive(3, 24, 2, move |inner| {
             let binary = prop_oneof![
                 (inner.clone(), inner.clone())
@@ -2030,5 +2038,131 @@ async fn negation_preserves_failed_facts_nested_inside_custom_grant_aggregates()
     {
         result.assert_indeterminate();
         assert_eq!(result.fact_load_errors().len(), 1);
+    }
+}
+
+fn failed_fact() -> FactProvenance {
+    FactProvenance::from_load_result(
+        "membership",
+        "subject",
+        &FactLoadResult::<bool>::Error(gatehouse::FactLoadError::backend_message(
+            "backend unavailable",
+        )),
+    )
+}
+struct RecordedGrantLeaf([Truth; 3]);
+#[async_trait]
+impl Policy<Domain> for RecordedGrantLeaf {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+        if self.0[usize::from(ctx.resource.id % 3)] == Truth::Unknown {
+            ctx.record(failed_fact());
+        }
+        GrantLeaf(self.0).evaluate(ctx).await
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "RecordedGrantLeaf".into()
+    }
+}
+struct RecordedVetoLeaf([Truth; 3]);
+#[async_trait]
+impl VetoPolicy<Domain> for RecordedVetoLeaf {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+        if self.0[usize::from(ctx.resource.id % 3)] == Truth::Unknown {
+            ctx.record(failed_fact());
+        }
+        VetoLeaf(self.0).evaluate(ctx).await
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "RecordedVetoLeaf".into()
+    }
+}
+
+#[tokio::test]
+async fn negation_respects_settled_aggregates_with_failed_descendants() {
+    let session = EvaluationSession::empty();
+    for failed in [
+        RecordedGrantLeaf([Truth::Unknown; 3]).boxed(),
+        ErrorBearingNotApplicablePolicy.boxed(),
+    ] {
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(failed.and(GrantLeaf([Truth::No; 3])).not());
+        let bound = bind(&checker, &session);
+        let single = bound.check(&Resource { id: 0 }).await;
+        assert!(single.is_granted(), "{single}");
+        assert_eq!(single.fact_load_errors().len(), 1);
+        for (_, result) in bound
+            .evaluate(vec![Resource { id: 0 }, Resource { id: 1 }])
+            .await
+        {
+            assert!(result.is_granted(), "{result}");
+            assert_eq!(result.fact_load_errors().len(), 1);
+        }
+        assert_eq!(
+            bound
+                .try_filter(vec![Resource { id: 0 }, Resource { id: 1 }])
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        let page = bound
+            .try_lookup_page(
+                &StaticLookup {
+                    ids: vec![0, 1],
+                    next_cursor: None,
+                },
+                &ResourceHydrator,
+                None,
+                NonZeroUsize::new(2).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.resources.len(), 2);
+    }
+}
+
+#[test]
+fn explicit_failed_facts_normalize_abstentions_and_passes() {
+    for outcome in [FactOutcome::Error, FactOutcome::Found, FactOutcome::Missing] {
+        let facts = vec![FactProvenance::new(
+            "membership",
+            "subject",
+            outcome.clone(),
+            None,
+        )];
+        let expected = if outcome == FactOutcome::Error {
+            Decision::Indeterminate
+        } else {
+            Decision::NotApplicable
+        };
+        let grant = GrantResult::not_applicable_with_facts("Grant", "reason", facts.clone());
+        let veto = VetoResult::pass_with_facts("Veto", "reason", facts.clone());
+        assert_eq!(grant.decision(), expected);
+        assert_eq!(veto.decision(), expected);
+        assert_eq!(grant.provenance(), facts);
+        assert_eq!(veto.provenance(), facts);
+        assert_eq!(grant.trace().reason_str(), Some("reason"));
+        assert_eq!(veto.trace().reason_str(), Some("reason"));
+        assert!(GrantResult::granted_with_facts("Grant", None, facts.clone()).is_granted());
+        assert!(VetoResult::forbid_with_facts("Veto", "reason", facts).is_forbidden());
+    }
+}
+
+#[tokio::test]
+async fn negated_malformed_batch_attributes_the_child() {
+    let session = EvaluationSession::empty();
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(WrongGrant(0).not());
+    for (_, result) in bind(&checker, &session)
+        .evaluate(vec![Resource { id: 0 }])
+        .await
+    {
+        assert!(
+            result
+                .indeterminate_reason()
+                .unwrap()
+                .contains("WrongGrant"),
+            "{result}"
+        );
     }
 }

--- a/tests/lookup_contract.rs
+++ b/tests/lookup_contract.rs
@@ -8,8 +8,8 @@
 
 use async_trait::async_trait;
 use gatehouse::{
-    EvalCtx, EvaluationSession, Hydrator, LookupAuthorizedError, LookupPage, LookupSource,
-    PermissionChecker, Policy, PolicyDomain, PolicyEvalResult,
+    EvalCtx, EvaluationSession, GrantResult, Hydrator, LookupAuthorizedError, LookupPage,
+    LookupSource, PermissionChecker, Policy, PolicyDomain,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -62,13 +62,13 @@ struct OwnerPolicy {
 
 #[async_trait]
 impl Policy<AuthDomain> for OwnerPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, AuthDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, AuthDomain>) -> GrantResult {
         match self.owns.get(&ctx.resource.id) {
-            Some(owner) if *owner == ctx.subject.id => PolicyEvalResult::granted(
+            Some(owner) if *owner == ctx.subject.id => GrantResult::granted(
                 self.policy_type().to_string(),
                 Some(format!("user {} owns doc {}", owner, ctx.resource.id)),
             ),
-            _ => PolicyEvalResult::not_applicable(
+            _ => GrantResult::not_applicable(
                 self.policy_type().to_string(),
                 format!(
                     "user {} does not own doc {}",
@@ -89,11 +89,11 @@ struct PublicDocPolicy;
 
 #[async_trait]
 impl Policy<AuthDomain> for PublicDocPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, AuthDomain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, AuthDomain>) -> GrantResult {
         if ctx.resource.public {
-            PolicyEvalResult::granted(self.policy_type().to_string(), Some("public doc".into()))
+            GrantResult::granted(self.policy_type().to_string(), Some("public doc".into()))
         } else {
-            PolicyEvalResult::not_applicable(self.policy_type().to_string(), "doc is not public")
+            GrantResult::not_applicable(self.policy_type().to_string(), "doc is not public")
         }
     }
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {

--- a/tests/outcome_contract.rs
+++ b/tests/outcome_contract.rs
@@ -1,0 +1,672 @@
+use async_trait::async_trait;
+use gatehouse::{
+    AccessEvaluation, BatchEvalCtx, Decision, EvalCtx, EvaluationSession, FactLoadResult,
+    FactOutcome, FactProvenance, FactSource, GrantResult, Hydrator, LookupAuthorizedError,
+    LookupPage, LookupSource, PermissionChecker, Policy, PolicyBuilder, PolicyDomain, PolicyResult,
+};
+use std::{collections::HashSet, convert::Infallible, num::NonZeroUsize};
+#[derive(Debug, Clone)]
+struct Subject;
+
+#[derive(Debug, Clone)]
+struct Action;
+
+#[derive(Debug, Clone)]
+struct Ctx;
+
+#[derive(Debug, Clone)]
+struct Resource {
+    id: u8,
+}
+
+struct Domain;
+
+impl PolicyDomain for Domain {
+    type Subject = Subject;
+    type Action = Action;
+    type Resource = Resource;
+    type Context = Ctx;
+}
+
+fn bind<'a>(
+    checker: &'a PermissionChecker<Domain>,
+    session: &'a EvaluationSession,
+) -> gatehouse::BoundEvaluator<'a, Domain> {
+    checker.bind(session, &Subject, &Action, &Ctx)
+}
+async fn check_resource(
+    checker: &PermissionChecker<Domain>,
+    session: &EvaluationSession,
+    resource: &Resource,
+) -> AccessEvaluation {
+    bind(checker, session).check(resource).await
+}
+async fn evaluate_resources(
+    checker: &PermissionChecker<Domain>,
+    session: &EvaluationSession,
+    resources: Vec<Resource>,
+) -> Vec<(Resource, AccessEvaluation)> {
+    bind(checker, session).evaluate(resources).await
+}
+struct StaticLookup {
+    ids: Vec<u8>,
+    next_cursor: Option<Vec<u8>>,
+}
+
+#[async_trait]
+impl LookupSource<Domain> for StaticLookup {
+    type Id = u8;
+    type Error = Infallible;
+
+    async fn lookup_page(
+        &self,
+        _subject: &Subject,
+        _action: &Action,
+        _context: &Ctx,
+        _cursor: Option<&[u8]>,
+        _limit: NonZeroUsize,
+    ) -> Result<LookupPage<Self::Id>, Self::Error> {
+        Ok(LookupPage {
+            ids: self.ids.clone(),
+            next_cursor: self.next_cursor.clone(),
+        })
+    }
+}
+
+struct ResourceHydrator;
+
+#[async_trait]
+impl Hydrator<u8> for ResourceHydrator {
+    type Resource = Resource;
+    type Error = Infallible;
+
+    async fn hydrate(&self, ids: &[u8]) -> Result<Vec<Option<Self::Resource>>, Self::Error> {
+        Ok(ids.iter().map(|id| Some(Resource { id: *id })).collect())
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct OddFlag(u8);
+
+impl gatehouse::FactKey for OddFlag {
+    const NAME: &'static str = "odd_flag";
+    type Value = bool;
+}
+
+/// Answers `Found(id is odd)` and fails to load configured ids.
+struct OddFlagSource {
+    fail_ids: HashSet<u8>,
+}
+
+#[async_trait]
+impl FactSource<OddFlag> for OddFlagSource {
+    async fn load_many(&self, keys: &[OddFlag]) -> Vec<FactLoadResult<bool>> {
+        keys.iter()
+            .map(|OddFlag(id)| {
+                if self.fail_ids.contains(id) {
+                    FactLoadResult::Error(gatehouse::FactLoadError::backend_message(
+                        "flag store unreachable",
+                    ))
+                } else {
+                    FactLoadResult::Found(id % 2 == 1)
+                }
+            })
+            .collect()
+    }
+}
+
+fn odd_flag_session(fail_ids: impl IntoIterator<Item = u8>) -> EvaluationSession {
+    gatehouse::FactRegistry::builder()
+        .with::<OddFlag, _>(OddFlagSource {
+            fail_ids: fail_ids.into_iter().collect(),
+        })
+        .build()
+        .session()
+}
+
+/// A fact-backed policy that loads through the recording context but builds
+/// its results **by hand** with the plain constructors — the #58 case 3
+/// "forgetful" shape. Provenance (and the NotApplicable → Indeterminate
+/// upgrade after a failed load) must therefore come from the caller-side
+/// `EvalCtx::finish` / `BatchEvalCtx::finish` merge in the checker and
+/// combinators; removing any of those calls breaks these tests.
+struct HandBuiltOddPolicy;
+
+impl HandBuiltOddPolicy {
+    fn result_for(fact: FactLoadResult<bool>) -> GrantResult {
+        match fact {
+            FactLoadResult::Found(true) => {
+                GrantResult::granted("HandBuiltOddPolicy", Some("odd resource".into()))
+            }
+            _ => GrantResult::not_applicable("HandBuiltOddPolicy", "not odd"),
+        }
+    }
+}
+
+#[async_trait]
+impl Policy<Domain> for HandBuiltOddPolicy {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+        Self::result_for(ctx.fact(OddFlag(ctx.resource.id)).await)
+    }
+
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
+        ctx.facts_by(|resource| OddFlag(resource.id))
+            .await
+            .into_iter()
+            .map(Self::result_for)
+            .collect()
+    }
+
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("HandBuiltOddPolicy")
+    }
+}
+
+#[tokio::test]
+async fn typed_access_error_distinguishes_denial_from_outage() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    let session = odd_flag_session([3]);
+    assert!(check_resource(&checker, &session, &Resource { id: 1 })
+        .await
+        .into_result()
+        .is_ok());
+    assert!(matches!(
+        check_resource(&checker, &session, &Resource { id: 2 })
+            .await
+            .into_result(),
+        Err(gatehouse::AccessError::Denied { .. })
+    ));
+    let error = check_resource(&checker, &session, &Resource { id: 3 })
+        .await
+        .into_result()
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        gatehouse::AccessError::Indeterminate { .. }
+    ));
+    assert_eq!(error.fact_load_errors().len(), 1);
+    assert_eq!(
+        error.fact_load_errors()[0].error_kind,
+        Some(gatehouse::FactLoadErrorKind::Backend)
+    );
+    assert!(error.to_string().contains("authorization indeterminate"));
+}
+
+#[tokio::test]
+async fn strict_filters_keep_all_original_items_and_decisions_on_failure() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    let session = odd_flag_session([3]);
+    let error = bind(&checker, &session)
+        .try_filter(vec![
+            Resource { id: 1 },
+            Resource { id: 2 },
+            Resource { id: 3 },
+        ])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error
+            .evaluations
+            .iter()
+            .map(|(item, _)| item.id)
+            .collect::<Vec<_>>(),
+        [1, 2, 3]
+    );
+    assert!(error.evaluations[0].1.is_granted());
+    error.evaluations[1].1.assert_denied();
+    error.evaluations[2].1.assert_indeterminate();
+    assert_eq!(error.evaluations[2].1.fact_load_errors().len(), 1);
+    assert_eq!(
+        error
+            .indeterminate()
+            .map(|(item, _)| item.id)
+            .collect::<Vec<_>>(),
+        [3]
+    );
+
+    let items = vec![
+        ("one".to_string(), Resource { id: 1 }),
+        ("three".to_string(), Resource { id: 3 }),
+    ];
+    let error = bind(&checker, &session)
+        .try_filter_by(items, |item| &item.1)
+        .await
+        .unwrap_err();
+    assert_eq!(error.evaluations[0].0 .0, "one");
+    assert_eq!(error.evaluations[1].0 .0, "three");
+
+    let allowed = bind(&checker, &session)
+        .try_filter(vec![Resource { id: 1 }, Resource { id: 2 }])
+        .await
+        .unwrap();
+    assert_eq!(allowed.iter().map(|item| item.id).collect::<Vec<_>>(), [1]);
+    let allowed = bind(&checker, &session)
+        .try_filter_by(
+            vec![(1, Resource { id: 1 }), (2, Resource { id: 2 })],
+            |item| &item.1,
+        )
+        .await
+        .unwrap();
+    assert_eq!(allowed.iter().map(|item| item.0).collect::<Vec<_>>(), [1]);
+    assert!(bind(&checker, &session)
+        .try_filter(Vec::<Resource>::new())
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn strict_filter_accepts_grant_after_irrelevant_allow_failure() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    checker.add_policy(
+        PolicyBuilder::<Domain>::new("Override")
+            .when(|_, _, _, _| true)
+            .build(),
+    );
+    let session = odd_flag_session([3]);
+    let allowed = bind(&checker, &session)
+        .try_filter(vec![Resource { id: 3 }])
+        .await
+        .unwrap();
+    assert_eq!(allowed[0].id, 3);
+    assert!(check_resource(&checker, &session, &Resource { id: 3 })
+        .await
+        .into_result()
+        .is_ok());
+}
+
+#[tokio::test]
+async fn strict_lookup_fails_without_advancing_past_unresolved_page() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    let lookup = StaticLookup {
+        ids: vec![1, 2, 3],
+        next_cursor: Some(b"next".to_vec()),
+    };
+    let session = odd_flag_session([1, 3]);
+    let error = bind(&checker, &session)
+        .try_lookup_page(
+            &lookup,
+            &ResourceHydrator,
+            Some(b"current"),
+            NonZeroUsize::new(3).unwrap(),
+        )
+        .await
+        .unwrap_err();
+    let LookupAuthorizedError::Evaluation(error) = error else {
+        panic!("expected authorization failure");
+    };
+    assert_eq!(
+        error
+            .evaluations
+            .iter()
+            .map(|(resource, _)| resource.id)
+            .collect::<Vec<_>>(),
+        [1, 2, 3]
+    );
+    assert_eq!(
+        error
+            .evaluations
+            .iter()
+            .filter(|(_, evaluation)| evaluation.is_indeterminate())
+            .count(),
+        2
+    );
+    let recovered_session = odd_flag_session([]);
+    let page = bind(&checker, &recovered_session)
+        .try_lookup_page(
+            &lookup,
+            &ResourceHydrator,
+            Some(b"current"),
+            NonZeroUsize::new(3).unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        page.resources
+            .iter()
+            .map(|resource| resource.id)
+            .collect::<Vec<_>>(),
+        [1, 3]
+    );
+    assert_eq!(page.next_cursor.as_deref(), Some(b"next".as_slice()));
+}
+
+struct RecordedAggregate {
+    decision: Decision,
+}
+
+#[async_trait]
+impl Policy<Domain> for RecordedAggregate {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
+        ctx.fact(OddFlag(ctx.resource.id)).await;
+        ctx.record(FactProvenance::new(
+            "optional",
+            "missing",
+            FactOutcome::Missing,
+            None,
+        ));
+        let child = if self.decision == Decision::Grant {
+            GrantResult::granted("IndependentGrant", None)
+        } else {
+            GrantResult::not_applicable("IndependentAbstention", "does not apply")
+        };
+        GrantResult::all(self.policy_type(), vec![child]).attach_recorded(vec![
+            FactProvenance::new("explicit", "last", FactOutcome::Found, None),
+        ])
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "RecordedAggregate".into()
+    }
+}
+
+#[tokio::test]
+async fn aggregate_provenance_is_lossless_and_decisive_grants_remain_decisive() {
+    for decision in [Decision::Grant, Decision::NotApplicable] {
+        let mut checker = PermissionChecker::new();
+        checker.add_policy(RecordedAggregate { decision });
+        let session = odd_flag_session([3]);
+        for resource_id in [1, 3] {
+            let single = check_resource(&checker, &session, &Resource { id: resource_id }).await;
+            let batch = evaluate_resources(&checker, &session, vec![Resource { id: resource_id }])
+                .await
+                .remove(0)
+                .1;
+            for evaluation in [single, batch] {
+                assert_eq!(evaluation.is_granted(), decision == Decision::Grant);
+                assert_eq!(
+                    evaluation.is_indeterminate(),
+                    decision == Decision::NotApplicable && resource_id == 3
+                );
+                assert_eq!(
+                    evaluation.fact_load_errors().len(),
+                    usize::from(resource_id == 3)
+                );
+                let rendered = evaluation.trace().format();
+                assert!(rendered.contains("fact odd_flag"));
+                assert!(rendered.contains("fact optional [missing]"));
+                assert!(rendered.contains("fact explicit [found]"));
+                assert!(
+                    rendered.find("fact odd_flag").unwrap()
+                        < rendered.find("fact optional").unwrap()
+                );
+                assert!(
+                    rendered.find("fact optional").unwrap()
+                        < rendered.find("fact explicit").unwrap()
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn explicit_veto_is_a_typed_denial_and_is_excluded_from_strict_lists() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(PolicyBuilder::<Domain>::new("Allow").build());
+    checker.add_veto(
+        PolicyBuilder::<Domain>::new("Block")
+            .resources(|resource| resource.id == 2)
+            .build_veto(),
+    );
+    let session = EvaluationSession::empty();
+    let error = bind(&checker, &session)
+        .check(&Resource { id: 2 })
+        .await
+        .into_result()
+        .unwrap_err();
+    assert!(matches!(error, gatehouse::AccessError::Denied { .. }));
+    assert!(error.trace().format().contains("Block"));
+    let allowed = bind(&checker, &session)
+        .try_filter([Resource { id: 1 }, Resource { id: 2 }])
+        .await
+        .unwrap();
+    assert_eq!(
+        allowed
+            .iter()
+            .map(|resource| resource.id)
+            .collect::<Vec<_>>(),
+        [1]
+    );
+}
+
+struct FailingLookup;
+
+#[async_trait]
+impl LookupSource<Domain> for FailingLookup {
+    type Id = u8;
+    type Error = std::io::Error;
+    async fn lookup_page(
+        &self,
+        _: &Subject,
+        _: &Action,
+        _: &Ctx,
+        _: Option<&[u8]>,
+        _: NonZeroUsize,
+    ) -> Result<LookupPage<u8>, Self::Error> {
+        Err(std::io::Error::other("candidate backend unavailable"))
+    }
+}
+
+#[tokio::test]
+async fn strict_lookup_preserves_pipeline_failures_and_all_indeterminate_pages() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    let session = odd_flag_session([1, 3]);
+    let bound = bind(&checker, &session);
+    let limit = NonZeroUsize::new(2).unwrap();
+    let error = bound
+        .try_lookup_page(&FailingLookup, &ResourceHydrator, None, limit)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, LookupAuthorizedError::Lookup(error) if error.to_string() == "candidate backend unavailable")
+    );
+
+    let lookup = StaticLookup {
+        ids: vec![1, 3],
+        next_cursor: Some(b"next".to_vec()),
+    };
+    let failing_hydrator = |_: &[u8]| async {
+        Err::<Vec<Option<Resource>>, _>(std::io::Error::other("resource backend unavailable"))
+    };
+    let error = bound
+        .try_lookup_page(&lookup, &failing_hydrator, None, limit)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, LookupAuthorizedError::Hydrate(error) if error.to_string() == "resource backend unavailable")
+    );
+
+    let short_hydrator = |_: &[u8]| async { Ok::<Vec<Option<Resource>>, Infallible>(vec![]) };
+    let error = bound
+        .try_lookup_page(&lookup, &short_hydrator, None, limit)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        LookupAuthorizedError::HydratorContractViolation {
+            expected: 2,
+            actual: 0
+        }
+    ));
+
+    let error = bound
+        .try_lookup_page(&lookup, &ResourceHydrator, Some(b"next"), limit)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, LookupAuthorizedError::LookupCursorStuck));
+
+    let error = bound
+        .try_lookup_page(&lookup, &ResourceHydrator, None, limit)
+        .await
+        .unwrap_err();
+    let LookupAuthorizedError::Evaluation(error) = error else {
+        panic!("expected evaluation failure");
+    };
+    assert_eq!(
+        error
+            .indeterminate()
+            .map(|(resource, _)| resource.id)
+            .collect::<Vec<_>>(),
+        [1, 3]
+    );
+}
+
+#[tokio::test]
+async fn strict_errors_support_borrowed_non_debug_rows() {
+    struct Row<'a> {
+        resource: Resource,
+        label: &'a str,
+    }
+    fn as_standard_error<'a>(
+        error: impl std::error::Error + 'a,
+    ) -> Box<dyn std::error::Error + 'a> {
+        Box::new(error)
+    }
+    let label = String::from("caller-owned data");
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(HandBuiltOddPolicy);
+    let session = odd_flag_session([3]);
+    let result = bind(&checker, &session)
+        .try_filter_by(
+            vec![Row {
+                resource: Resource { id: 3 },
+                label: &label,
+            }],
+            |row| &row.resource,
+        )
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("unavailable fact must fail the strict filter"),
+    };
+    assert_eq!(error.evaluations[0].0.label, label);
+    assert!(format!("{error:?}").contains("Indeterminate"));
+    let error = as_standard_error(error);
+    assert!(error
+        .to_string()
+        .contains("could not determine authorization"));
+
+    let error: LookupAuthorizedError<Infallible, Infallible, Row<'_>> =
+        LookupAuthorizedError::Evaluation(gatehouse::FilterError {
+            evaluations: vec![(
+                Row {
+                    resource: Resource { id: 3 },
+                    label: &label,
+                },
+                AccessEvaluation::Indeterminate {
+                    reason: "offline".into(),
+                    trace: gatehouse::EvalTrace::new(),
+                },
+            )],
+        });
+    assert!(!format!("{error:?}").contains(&label));
+    let error = as_standard_error(error);
+    assert!(error.source().is_none());
+}
+
+struct ExplicitFailure {
+    aggregate: bool,
+}
+
+#[async_trait]
+impl Policy<Domain> for ExplicitFailure {
+    async fn evaluate(&self, _: &EvalCtx<'_, Domain>) -> GrantResult {
+        let result = GrantResult::not_applicable_with_facts(
+            "ExplicitFailure",
+            "membership not established",
+            vec![FactProvenance::from_load_result(
+                "membership",
+                "subject",
+                &FactLoadResult::<bool>::Error(gatehouse::FactLoadError::backend_message(
+                    "private backend detail",
+                )),
+            )],
+        );
+        if self.aggregate {
+            GrantResult::all("EvidenceAggregate", vec![result])
+        } else {
+            result
+        }
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "ExplicitFailure".into()
+    }
+}
+
+#[tokio::test]
+async fn indeterminate_attribution_retains_aggregate_and_negated_fact_causes() {
+    use gatehouse::PolicyExt;
+    let mut aggregate = PermissionChecker::new();
+    aggregate.add_policy(RecordedAggregate {
+        decision: Decision::NotApplicable,
+    });
+    let mut negated = PermissionChecker::new();
+    negated.add_policy(ExplicitFailure { aggregate: false }.not().not());
+    let mut negated_aggregate = PermissionChecker::new();
+    negated_aggregate.add_policy(ExplicitFailure { aggregate: true }.not().not());
+    let session = odd_flag_session([3]);
+    for (checker, expected_policy) in [
+        (&aggregate, "RecordedAggregate"),
+        (&negated, "ExplicitFailure"),
+        (&negated_aggregate, "ExplicitFailure"),
+    ] {
+        let single = check_resource(checker, &session, &Resource { id: 3 }).await;
+        let batch = evaluate_resources(checker, &session, vec![Resource { id: 3 }])
+            .await
+            .remove(0)
+            .1;
+        for evaluation in [single, batch] {
+            evaluation.assert_indeterminate();
+            assert_eq!(evaluation.fact_load_errors().len(), 1);
+            assert_eq!(evaluation.indeterminate_reason(), Some(format!("Could not evaluate {expected_policy}: A consulted fact could not be loaded").as_str()));
+            assert!(!evaluation.to_string().contains("private backend detail"));
+        }
+    }
+}
+
+struct ResolvedThenUnknown;
+
+#[async_trait]
+impl Policy<Domain> for ResolvedThenUnknown {
+    async fn evaluate(&self, _: &EvalCtx<'_, Domain>) -> GrantResult {
+        GrantResult::any(
+            "Outer",
+            vec![
+                GrantResult::all(
+                    "Resolved",
+                    vec![
+                        GrantResult::not_applicable("DefiniteNonMatch", "not applicable"),
+                        GrantResult::indeterminate("InactiveFailure", "irrelevant failure"),
+                    ],
+                )
+                .attach_recorded(vec![FactProvenance::new(
+                    "optional",
+                    "key",
+                    FactOutcome::Found,
+                    None,
+                )]),
+                GrantResult::indeterminate("ActiveFailure", "required input unavailable"),
+            ],
+        )
+    }
+    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
+        "ResolvedThenUnknown".into()
+    }
+}
+
+#[tokio::test]
+async fn indeterminate_attribution_skips_resolved_subtrees() {
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(ResolvedThenUnknown);
+    let session = EvaluationSession::empty();
+    let evaluation = check_resource(&checker, &session, &Resource { id: 0 }).await;
+    evaluation.assert_indeterminate();
+    assert_eq!(
+        evaluation.indeterminate_reason(),
+        Some("Could not evaluate ActiveFailure: required input unavailable")
+    );
+}

--- a/tests/outcome_contract.rs
+++ b/tests/outcome_contract.rs
@@ -609,10 +609,18 @@ async fn indeterminate_attribution_retains_aggregate_and_negated_fact_causes() {
     let mut negated_aggregate = PermissionChecker::new();
     negated_aggregate.add_policy(ExplicitFailure { aggregate: true }.not().not());
     let session = odd_flag_session([3]);
-    for (checker, expected_policy) in [
-        (&aggregate, "RecordedAggregate"),
-        (&negated, "ExplicitFailure"),
-        (&negated_aggregate, "ExplicitFailure"),
+    for (checker, expected_policy, expected_reason) in [
+        (
+            &aggregate,
+            "RecordedAggregate",
+            "A consulted fact could not be loaded",
+        ),
+        (&negated, "ExplicitFailure", "membership not established"),
+        (
+            &negated_aggregate,
+            "ExplicitFailure",
+            "membership not established",
+        ),
     ] {
         let single = check_resource(checker, &session, &Resource { id: 3 }).await;
         let batch = evaluate_resources(checker, &session, vec![Resource { id: 3 }])
@@ -622,7 +630,10 @@ async fn indeterminate_attribution_retains_aggregate_and_negated_fact_causes() {
         for evaluation in [single, batch] {
             evaluation.assert_indeterminate();
             assert_eq!(evaluation.fact_load_errors().len(), 1);
-            assert_eq!(evaluation.indeterminate_reason(), Some(format!("Could not evaluate {expected_policy}: A consulted fact could not be loaded").as_str()));
+            assert_eq!(
+                evaluation.indeterminate_reason(),
+                Some(format!("Could not evaluate {expected_policy}: {expected_reason}").as_str())
+            );
             assert!(!evaluation.to_string().contains("private backend detail"));
         }
     }

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -1,7 +1,9 @@
+#![cfg(feature = "tracing")]
+
 use async_trait::async_trait;
 use gatehouse::{
-    BatchEvalCtx, CombineOp, Decision, EvalCtx, EvaluationSession, FactOutcome, FactProvenance,
-    PermissionChecker, Policy, PolicyBuilder, PolicyDomain, PolicyEvalResult,
+    BatchEvalCtx, EvalCtx, EvaluationSession, FactOutcome, FactProvenance, GrantResult,
+    PermissionChecker, Policy, PolicyBuilder, PolicyDomain, VetoPolicy, VetoResult,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -42,14 +44,11 @@ struct TracePolicy;
 
 #[async_trait]
 impl Policy<Domain> for TracePolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         result_for(ctx.resource.allowed)
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, ctx: &BatchEvalCtx<'item, Domain>) -> Vec<GrantResult> {
         ctx.items
             .iter()
             .map(|item| result_for(item.resource.allowed))
@@ -65,7 +64,7 @@ struct IndeterminateTracePolicy;
 
 #[async_trait]
 impl Policy<Domain> for IndeterminateTracePolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         ctx.indeterminate("fact backend unreachable")
     }
 
@@ -74,85 +73,20 @@ impl Policy<Domain> for IndeterminateTracePolicy {
     }
 }
 
-struct GrantingForbidPolicy;
-
-#[async_trait]
-impl Policy<Domain> for GrantingForbidPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.grant("misbehaving forbid grant")
-    }
-
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
-        ctx.items
-            .iter()
-            .map(|_| PolicyEvalResult::granted(self.policy_type(), Some("misbehaving".into())))
-            .collect()
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("GrantingForbidPolicy")
-    }
-
-    fn effect(&self) -> gatehouse::Effect {
-        gatehouse::Effect::Forbid
-    }
-}
-
-struct ForbiddingAllowPolicy;
-
-#[async_trait]
-impl Policy<Domain> for ForbiddingAllowPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.forbid("forbid without declaring an effect")
-    }
-
-    async fn evaluate_batch<'item>(
-        &self,
-        ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
-        ctx.items
-            .iter()
-            .map(|_| {
-                PolicyEvalResult::forbidden(
-                    self.policy_type(),
-                    "forbid without declaring an effect",
-                )
-            })
-            .collect()
-    }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("ForbiddingAllowPolicy")
-    }
-
-    // Intentionally no `effect()` override: defaults to `Effect::Allow`, so
-    // forbidding here is the contract violation the checker should warn about.
-}
-
 struct WrongLengthTracePolicy;
 
 #[async_trait]
-impl Policy<Domain> for WrongLengthTracePolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        ctx.not_applicable("not applicable")
+impl VetoPolicy<Domain> for WrongLengthTracePolicy {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> VetoResult {
+        ctx.pass("not applicable")
     }
 
-    async fn evaluate_batch<'item>(
-        &self,
-        _ctx: &BatchEvalCtx<'item, Domain>,
-    ) -> Vec<PolicyEvalResult> {
+    async fn evaluate_batch<'item>(&self, _ctx: &BatchEvalCtx<'item, Domain>) -> Vec<VetoResult> {
         Vec::new()
     }
 
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Borrowed("WrongLengthTracePolicy")
-    }
-
-    fn effect(&self) -> gatehouse::Effect {
-        gatehouse::Effect::Forbid
     }
 }
 
@@ -160,19 +94,14 @@ struct RecordedErrorCombinedPolicy;
 
 #[async_trait]
 impl Policy<Domain> for RecordedErrorCombinedPolicy {
-    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
+    async fn evaluate(&self, ctx: &EvalCtx<'_, Domain>) -> GrantResult {
         ctx.record(FactProvenance::new(
             "membership",
             "Membership(7)",
             FactOutcome::Error,
             Some("membership backend unavailable".to_string()),
         ));
-        PolicyEvalResult::Combined {
-            policy_type: self.policy_type(),
-            operation: CombineOp::And,
-            children: Vec::new(),
-            decision: Decision::NotApplicable,
-        }
+        GrantResult::all(self.policy_type(), Vec::new())
     }
 
     fn policy_type(&self) -> std::borrow::Cow<'static, str> {
@@ -180,11 +109,11 @@ impl Policy<Domain> for RecordedErrorCombinedPolicy {
     }
 }
 
-fn result_for(allowed: bool) -> PolicyEvalResult {
+fn result_for(allowed: bool) -> GrantResult {
     if allowed {
-        PolicyEvalResult::granted("TracePolicy", Some("allowed".to_string()))
+        GrantResult::granted("TracePolicy", Some("allowed".to_string()))
     } else {
-        PolicyEvalResult::not_applicable("TracePolicy", "denied")
+        GrantResult::not_applicable("TracePolicy", "denied")
     }
 }
 
@@ -650,11 +579,7 @@ fn tracing_fields_are_recorded_for_forbidden_decisions() {
     // An allow policy that would grant, vetoed by a forbid-effect policy.
     let mut checker = PermissionChecker::new();
     checker.add_policy(TracePolicy);
-    checker.add_policy(
-        PolicyBuilder::<Domain>::new("GlobalFreeze")
-            .forbid()
-            .build(),
-    );
+    checker.add_veto(PolicyBuilder::<Domain>::new("GlobalFreeze").build_veto());
 
     let session = EvaluationSession::empty();
     let (result, spans) = capture_async(|| async {
@@ -737,12 +662,12 @@ fn tracing_records_indeterminate_outcomes_and_batch_counts() {
 }
 
 #[test]
-fn tracing_warns_when_combined_result_preserves_recorded_errors() {
+fn tracing_records_combined_indeterminate_with_recorded_errors() {
     let mut checker = PermissionChecker::new();
     checker.add_policy(RecordedErrorCombinedPolicy);
     let session = EvaluationSession::empty();
 
-    let (result, _spans, events) = capture_async_with_events(|| async {
+    let (result, spans, events) = capture_async_with_events(|| async {
         checker
             .bind(&session, &Subject, &Action, &Ctx)
             .check(&Resource { allowed: false })
@@ -750,26 +675,30 @@ fn tracing_warns_when_combined_result_preserves_recorded_errors() {
     });
 
     result.assert_indeterminate();
+    assert_value(
+        span(&spans, "evaluate_one"),
+        "policy.type",
+        "RecordedErrorCombinedPolicy",
+    );
     assert_eq!(result.fact_load_errors().len(), 1);
 
-    let warning = events
+    let event = events
         .iter()
         .find(|event| {
-            event.level == "WARN"
-                && event.values.get("message").is_some_and(|message| {
-                    message.contains("preserving the failures on an Indeterminate child")
-                })
+            event
+                .values
+                .get("policy.type")
+                .is_some_and(|value| value == "RecordedErrorCombinedPolicy")
         })
-        .unwrap_or_else(|| panic!("missing combined-error warning; events: {events:#?}"));
-    assert_event_value(warning, "policy.type", "RecordedErrorCombinedPolicy");
-    assert_event_value(warning, "recorded_count", "1");
-    assert_event_value(warning, "error_count", "1");
+        .expect("aggregate security event");
+    assert_event_value(event, "event.outcome", "unknown");
+    assert!(!events.iter().any(|event| event.level == "WARN"));
 }
 
 #[test]
 fn tracing_records_wrong_length_batch_policy_denials() {
     let mut checker = PermissionChecker::new();
-    checker.add_policy(WrongLengthTracePolicy);
+    checker.add_veto(WrongLengthTracePolicy);
     let session = EvaluationSession::empty();
     let (_results, spans) = capture_async(|| async {
         checker
@@ -792,212 +721,140 @@ fn tracing_records_wrong_length_batch_policy_denials() {
     assert_value(policy, "policy.forbidden_count", "0");
 }
 
-/// A combinator node whose decision disagrees with a surviving `Forbidden`
-/// leaf is treated as forbidding, and the backstop names the inconsistent
-/// node in a `WARN` so the broken combinator is visible in logs.
-struct LyingGrantNodePolicy;
+#[test]
+fn wrong_length_veto_emits_contract_warning() {
+    let mut checker = PermissionChecker::new();
+    checker.add_veto(WrongLengthTracePolicy);
+    checker.add_policy(TracePolicy);
+    let session = EvaluationSession::empty();
+    let (results, spans, events) = capture_async_with_events(|| async {
+        checker
+            .bind(&session, &Subject, &Action, &Ctx)
+            .evaluate(vec![
+                Resource { allowed: true },
+                Resource { allowed: false },
+            ])
+            .await
+    });
+    assert!(results.iter().all(|(_, result)| result.is_indeterminate()));
+    let warning = events
+        .iter()
+        .find(|event| event.level == "WARN")
+        .expect("batch contract warning");
+    assert_event_value(warning, "policy.type", "WrongLengthTracePolicy");
+    assert_event_value(warning, "expected", "2");
+    assert_event_value(warning, "actual", "0");
+    assert!(!spans.iter().any(|span| span
+        .values
+        .get("policy.type")
+        .is_some_and(|name| name == "TracePolicy")));
+}
 
-#[async_trait]
-impl Policy<Domain> for LyingGrantNodePolicy {
-    async fn evaluate(&self, _ctx: &EvalCtx<'_, Domain>) -> PolicyEvalResult {
-        PolicyEvalResult::Combined {
-            policy_type: std::borrow::Cow::Borrowed("LyingGrantNodePolicy"),
-            operation: gatehouse::CombineOp::And,
-            children: vec![PolicyEvalResult::forbidden("HiddenVeto", "buried veto")],
-            decision: gatehouse::Decision::Grant,
+#[test]
+fn passing_veto_and_grant_report_separate_phase_events() {
+    let mut checker = PermissionChecker::new();
+    checker.add_veto(
+        PolicyBuilder::<Domain>::new("Freeze")
+            .when(|_, _, _, _| false)
+            .build_veto(),
+    );
+    checker.add_policy(TracePolicy);
+    let session = EvaluationSession::empty();
+    let (result, _, events) = capture_async_with_events(|| async {
+        checker
+            .bind(&session, &Subject, &Action, &Ctx)
+            .check(&Resource { allowed: true })
+            .await
+    });
+    assert!(result.is_granted());
+    assert!(!events.iter().any(|event| event.level == "WARN"));
+    let veto = events
+        .iter()
+        .find(|event| {
+            event
+                .values
+                .get("policy.type")
+                .is_some_and(|name| name == "Freeze")
+        })
+        .expect("veto event");
+    assert_event_value(veto, "policy.effect", "deny");
+    let grant = events
+        .iter()
+        .find(|event| {
+            event
+                .values
+                .get("policy.type")
+                .is_some_and(|name| name == "TracePolicy")
+        })
+        .expect("grant event");
+    assert_event_value(grant, "policy.effect", "allow");
+    assert_event_value(grant, "event.outcome", "success");
+}
+
+#[test]
+fn composed_and_delegated_rule_names_and_metadata_reach_security_events() {
+    use gatehouse::{DelegatingPolicy, PolicyExt, SecurityRuleMetadata};
+    let mut child = PermissionChecker::new();
+    child.add_policy(TracePolicy);
+    let delegate = DelegatingPolicy::new(
+        "NamedDelegate",
+        child,
+        |_: &Subject| Subject,
+        |_: &Action| Action,
+        |_: &Subject, _: &Action, resource: &Resource, _: &Ctx| resource.clone(),
+        |_: &Subject, _: &Action, _: &Ctx| Ctx,
+    )
+    .with_security_rule(
+        SecurityRuleMetadata::new()
+            .with_name("Delegated security rule")
+            .with_category("Document access")
+            .with_ruleset_name("Document rules")
+            .with_description("Delegated access check"),
+    );
+    let mut checker = PermissionChecker::new();
+    checker.add_policy(PolicyBuilder::<Domain>::new("AlwaysGrant").build().not());
+    checker.add_delegate(delegate);
+    let session = EvaluationSession::empty();
+    for batch in [false, true] {
+        let (results, _spans, events) = capture_async_with_events(|| async {
+            let bound = checker.bind(&session, &Subject, &Action, &Ctx);
+            if batch {
+                bound
+                    .evaluate(vec![Resource { allowed: true }])
+                    .await
+                    .into_iter()
+                    .map(|(_, result)| result)
+                    .collect::<Vec<_>>()
+            } else {
+                vec![bound.check(&Resource { allowed: true }).await]
+            }
+        });
+        assert!(results[0].is_granted());
+        let rule_events: Vec<_> = events
+            .iter()
+            .filter(|event| event.target == "gatehouse::security")
+            .collect();
+        let negation = rule_events
+            .iter()
+            .find(|event| event.values.get("policy.type").map(String::as_str) == Some("NotPolicy"))
+            .expect("negation emits its public rule name");
+        assert_event_value(negation, "security_rule.name", "NotPolicy");
+        let delegates: Vec<_> = rule_events
+            .iter()
+            .filter(|event| {
+                event.values.get("policy.type").map(String::as_str) == Some("NamedDelegate")
+            })
+            .collect();
+        assert_eq!(
+            delegates.len(),
+            2,
+            "each delegated capability emits metadata"
+        );
+        for event in delegates {
+            assert_event_value(event, "security_rule.name", "Delegated security rule");
+            assert_event_value(event, "security_rule.category", "Document access");
+            assert_event_value(event, "security_rule.ruleset.name", "Document rules");
+            assert_event_value(event, "security_rule.description", "Delegated access check");
         }
     }
-
-    fn policy_type(&self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("LyingGrantNodePolicy")
-    }
-
-    fn effect(&self) -> gatehouse::Effect {
-        gatehouse::Effect::AllowOrForbid
-    }
-}
-
-#[test]
-fn tracing_records_inconsistent_combined_node_warning() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(LyingGrantNodePolicy);
-    let session = EvaluationSession::empty();
-
-    let (result, _spans, events) = capture_async_with_events(|| async {
-        checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .check(&Resource { allowed: true })
-            .await
-    });
-    assert!(!result.is_granted(), "the buried veto must fail closed");
-
-    let warning = events
-        .iter()
-        .find(|event| {
-            event.level == "WARN"
-                && event
-                    .values
-                    .get("message")
-                    .is_some_and(|message| message.contains("non-forbid decision"))
-        })
-        .unwrap_or_else(|| panic!("missing inconsistent-node warning; events: {events:#?}"));
-    assert_event_value(warning, "node.policy_type", "LyingGrantNodePolicy");
-    assert_event_value(warning, "node.decision", "GRANT");
-    assert_event_value(warning, "forbidden_leaf.policy_type", "HiddenVeto");
-
-    // Consistent trees never trigger the backstop warning.
-    let mut clean_checker = PermissionChecker::new();
-    clean_checker.add_policy(PolicyBuilder::<Domain>::new("CleanForbid").forbid().build());
-    let (_result, _spans, clean_events) = capture_async_with_events(|| async {
-        clean_checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .check(&Resource { allowed: true })
-            .await
-    });
-    assert!(
-        clean_events.iter().all(|event| {
-            !event
-                .values
-                .get("message")
-                .is_some_and(|message| message.contains("non-forbid decision"))
-        }),
-        "consistent nodes must not emit the backstop warning: {clean_events:#?}"
-    );
-}
-
-#[test]
-fn tracing_records_forbid_effect_contract_violation_warning() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(GrantingForbidPolicy);
-    let session = EvaluationSession::empty();
-    let (_results, spans, events) = capture_async_with_events(|| async {
-        checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .evaluate(vec![Resource { allowed: true }])
-            .await
-    });
-
-    let policy = span(&spans, "gatehouse.batch_policy");
-    assert_value(policy, "policy.type", "GrantingForbidPolicy");
-    assert_value(policy, "policy.denied_count", "1");
-    assert_value(policy, "policy.granted_count", "0");
-
-    let warning = events
-        .iter()
-        .find(|event| {
-            event.level == "WARN"
-                && event.values.get("message").is_some_and(|message| {
-                    message.contains("Forbid-effect policy returned a grant")
-                })
-        })
-        .unwrap_or_else(|| panic!("missing contract-violation warning; events: {events:#?}"));
-    assert_event_value(warning, "policy.type", "GrantingForbidPolicy");
-    assert_event_value(warning, "item_count", "1");
-
-    let mut clean_checker = PermissionChecker::new();
-    clean_checker.add_policy(PolicyBuilder::<Domain>::new("CleanForbid").forbid().build());
-    let (_results, _spans, clean_events) = capture_async_with_events(|| async {
-        clean_checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .evaluate(vec![Resource { allowed: true }])
-            .await
-    });
-    assert!(
-        clean_events.iter().all(|event| {
-            !event
-                .values
-                .get("message")
-                .is_some_and(|message| message.contains("Forbid-effect policy returned a grant"))
-        }),
-        "well-behaved forbid policies must not emit contract-violation warnings: {clean_events:#?}"
-    );
-}
-
-#[test]
-fn tracing_records_allow_effect_contract_violation_warning() {
-    let mut checker = PermissionChecker::new();
-    checker.add_policy(ForbiddingAllowPolicy);
-    let session = EvaluationSession::empty();
-
-    // Batch path: the veto is still honored (fail-safe, not silently dropped)
-    // and a single warning records the contract violation with its count.
-    let (results, _spans, events) = capture_async_with_events(|| async {
-        checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .evaluate(vec![Resource { allowed: true }])
-            .await
-    });
-    assert!(!results[0].1.is_granted());
-
-    let warning = events
-        .iter()
-        .find(|event| {
-            event.level == "WARN"
-                && event.values.get("message").is_some_and(|message| {
-                    message.contains("Allow-effect policy returned a forbid")
-                })
-        })
-        .unwrap_or_else(|| panic!("missing contract-violation warning; events: {events:#?}"));
-    assert_event_value(warning, "policy.type", "ForbiddingAllowPolicy");
-    assert_event_value(warning, "item_count", "1");
-
-    // Single path: the same warning fires, and access is still denied.
-    let (single, _spans, single_events) = capture_async_with_events(|| async {
-        checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .check(&Resource { allowed: true })
-            .await
-    });
-    assert!(!single.is_granted());
-    assert!(
-        single_events.iter().any(|event| {
-            event.level == "WARN"
-                && event.values.get("message").is_some_and(|message| {
-                    message.contains("Allow-effect policy returned a forbid")
-                })
-        }),
-        "single-path evaluation must emit the contract-violation warning: {single_events:#?}"
-    );
-
-    // A policy that declares its forbid effect is well-behaved: no warning.
-    let mut clean_checker = PermissionChecker::new();
-    clean_checker.add_policy(PolicyBuilder::<Domain>::new("CleanForbid").forbid().build());
-    let (_results, _spans, clean_events) = capture_async_with_events(|| async {
-        clean_checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .evaluate(vec![Resource { allowed: true }])
-            .await
-    });
-    assert!(
-        clean_events.iter().all(|event| {
-            !event
-                .values
-                .get("message")
-                .is_some_and(|message| message.contains("Allow-effect policy returned a forbid"))
-        }),
-        "policies declaring their forbid effect must not emit contract-violation warnings: {clean_events:#?}"
-    );
-
-    // Single path, well-behaved: a plain `Effect::Allow` policy that does not
-    // forbid must emit no contract-violation warning. This pins that *both*
-    // operands matter — an `Allow` declaration alone (without a forbid result)
-    // is not enough to warn — so the guard cannot weaken from `&&` to `||`.
-    let mut allow_checker = PermissionChecker::new();
-    allow_checker.add_policy(TracePolicy);
-    let (granted, _spans, allow_events) = capture_async_with_events(|| async {
-        allow_checker
-            .bind(&session, &Subject, &Action, &Ctx)
-            .check(&Resource { allowed: true })
-            .await
-    });
-    assert!(granted.is_granted());
-    assert!(
-        allow_events.iter().all(|event| {
-            !event
-                .values
-                .get("message")
-                .is_some_and(|message| message.contains("Allow-effect policy returned a forbid"))
-        }),
-        "an allow policy that does not forbid must not emit the contract-violation warning: {allow_events:#?}"
-    );
 }

--- a/tests/tracing_contract.rs
+++ b/tests/tracing_contract.rs
@@ -576,7 +576,7 @@ fn named_checker_records_name_on_batch_span() {
 
 #[test]
 fn tracing_fields_are_recorded_for_forbidden_decisions() {
-    // An allow policy that would grant, vetoed by a forbid-effect policy.
+    // A grant policy that would grant, blocked by a registered veto.
     let mut checker = PermissionChecker::new();
     checker.add_policy(TracePolicy);
     checker.add_veto(PolicyBuilder::<Domain>::new("GlobalFreeze").build_veto());


### PR DESCRIPTION
Authorization policies can currently misdeclare their veto capability, and application helpers can hide indeterminate authorization as ordinary denial or an empty list. This candidate makes grant and veto authority separate Rust types and adds strict application-boundary APIs for the unreleased 0.6 line.

- Introduces typed grant/veto policies, independent composition, and atomic delegation with mapped inputs shared across both phases.
- Adds typed access errors and strict filtering/lookup that preserve original rows and distinguish backend uncertainty from definite denial.
- Preserves aggregate-local provenance and policy attribution. Negation uses settled decisions; explicit failed facts normalize abstentions/passes to indeterminate before composition.
- Makes tracing optional and default-enabled, with independent serde support.
- Updates examples, migration guidance, benchmarks, and feature/MSRV/doctest/mutation CI coverage. Release validation requires nonempty versioned changelog notes before publication.

This is a breaking API change from 0.5.1. The crate version is `0.6.0-alpha.1`; creating or merging this PR does not publish it. Publication requires separately approved release preparation, successful main CI on the exact release commit, and a matching tag.

Validation: all-feature tests and benchmark smoke checks; four feature configurations of Clippy, tests and doctests; Rust 1.82 library checks; 16 Loom models; dependency audit; and a verified publish dry run. The pre-migration downstream audit found 0 `effect()` overrides, 0 mixed grant/veto combinators, and 0 `DelegatingPolicy` uses across six consumers. The 0.6 migration therefore combines the authority boundary change with the existing breaking release. Integration details remain private. Mutation testing covers checker, combinators, typed capabilities, and delegation. The current revision passed all 167 mutations locally and in hosted CI (90 caught, 77 unviable), with no survivors or timeouts. One exact-equivalent metadata default mutation is narrowly excluded.

Closes #4.
Closes #63.

